### PR TITLE
feat: add source_url and source_platform to recipes (BubblyChef-3r5)

### DIFF
--- a/nextjs/src/__tests__/recipe-types.test.ts
+++ b/nextjs/src/__tests__/recipe-types.test.ts
@@ -1,0 +1,65 @@
+import type { GeneratedRecipe } from '@/types/recipes'
+
+describe('GeneratedRecipe type', () => {
+  it('accepts a recipe with no source fields (existing usage)', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+    }
+    expect(recipe.source_url).toBeUndefined()
+    expect(recipe.source_platform).toBeUndefined()
+  })
+
+  it('accepts source_url as a string', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+      source_url: 'https://www.allrecipes.com/recipe/12345/pasta/',
+    }
+    expect(recipe.source_url).toBe('https://www.allrecipes.com/recipe/12345/pasta/')
+  })
+
+  it('accepts source_url as null', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+      source_url: null,
+    }
+    expect(recipe.source_url).toBeNull()
+  })
+
+  it('accepts source_platform as a string', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+      source_platform: 'allrecipes',
+    }
+    expect(recipe.source_platform).toBe('allrecipes')
+  })
+
+  it('accepts source_platform as null', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+      source_platform: null,
+    }
+    expect(recipe.source_platform).toBeNull()
+  })
+
+  it('accepts both source_url and source_platform together', () => {
+    const recipe: GeneratedRecipe = {
+      title: 'Pasta',
+      ingredients: [],
+      instructions: [],
+      source_url: 'https://cooking.nytimes.com/recipes/1234-pasta',
+      source_platform: 'nytimes-cooking',
+    }
+    expect(recipe.source_url).toBe('https://cooking.nytimes.com/recipes/1234-pasta')
+    expect(recipe.source_platform).toBe('nytimes-cooking')
+  })
+})

--- a/nextjs/src/types/recipes.ts
+++ b/nextjs/src/types/recipes.ts
@@ -41,6 +41,8 @@ export interface GeneratedRecipe {
   dietary_tags?: string[]
   difficulty?: string | null
   tips?: string[]
+  source_url?: string | null
+  source_platform?: string | null
 }
 
 export interface GenerateRecipeResponse {

--- a/supabase/migrations/00005_add_recipe_source_columns.sql
+++ b/supabase/migrations/00005_add_recipe_source_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE recipes ADD COLUMN IF NOT EXISTS source_url TEXT;
+ALTER TABLE recipes ADD COLUMN IF NOT EXISTS source_platform TEXT;


### PR DESCRIPTION
## Issue
BubblyChef-3r5 — Add `source_url` and `source_platform` columns to the recipes table and update TypeScript types.

## Design
Both columns are nullable TEXT with no default. `source_url` already existed in the initial schema (00001) but was never tracked in `GeneratedRecipe`. Using `ADD COLUMN IF NOT EXISTS` in the migration makes it safe regardless of environment state. `source_platform` is new. This brings the DB schema in sync with `RecipeCard` in the AI service which already has `source_url: str | None`.

## Plan
1. Write `supabase/migrations/00005_add_recipe_source_columns.sql` — two `ALTER TABLE … ADD COLUMN IF NOT EXISTS` statements
2. Add `source_url?: string | null` and `source_platform?: string | null` to `GeneratedRecipe` in `nextjs/src/types/recipes.ts`
3. Write type assertion tests in `nextjs/src/__tests__/recipe-types.test.ts`

## Changes
- `supabase/migrations/00005_add_recipe_source_columns.sql` — new migration (2 lines)
- `nextjs/src/types/recipes.ts` — 2 optional fields added to `GeneratedRecipe`
- `nextjs/src/__tests__/recipe-types.test.ts` — 6 new type assertion tests

## Test coverage
- `cd nextjs && npx tsc --noEmit` — clean ✅
- `cd nextjs && npm test -- --ci` — 15 tests pass (6 new + 9 existing) ✅
- SQL reviewed against `00001_initial_schema.sql` — recipes table confirmed, `IF NOT EXISTS` handles the pre-existing `source_url` column safely ✅