### PR TITLE
fix(scan): increase body size limit to 10mb for receipt uploads

### DIFF
--- a/nextjs/next.config.ts
+++ b/nextjs/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverActions: {
+      bodySizeLimit: '10mb',
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Vercel's default serverless body limit is 4.5MB. Receipt images can exceed this, causing 413 errors. Sets `serverActions.bodySizeLimit` to 10mb in next.config.ts.