### PR TITLE
feat: cook a recipe with pantry deduction (#40)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/recipes_ai.py
+++ b/ai-service/bubbly_chef/api/routes/recipes_ai.py
@@ -1,8 +1,10 @@
 """Recipe AI routes for the BubblyChef AI microservice.
 
 Exposes:
-- POST /v1/recipes/generate — generate a recipe from constraints + pantry
-- POST /v1/recipes/refine  — refine an existing recipe with a prompt
+- POST /v1/recipes/generate        — generate a recipe from constraints + pantry
+- POST /v1/recipes/refine          — refine an existing recipe with a prompt
+- POST /v1/recipes/cook            — build a CookProposal (match ingredients to pantry)
+- POST /v1/recipes/cook/confirm    — apply deductions + mark recipe as cooked
 """
 
 import logging
@@ -12,6 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
 from bubbly_chef.api.auth import get_current_user_id
+from bubbly_chef.models.cook import CookConfirmRequest, CookProposal
 from bubbly_chef.repository.supabase_repo import get_repository
 
 logger = logging.getLogger(__name__)
@@ -161,3 +164,113 @@ async def refine_recipe(
     except Exception as e:
         logger.error(f"Recipe refinement failed: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Recipe refinement failed: {str(e)}") from e
+
+
+# ---------------------------------------------------------------------------
+# Cook-a-recipe endpoints
+# ---------------------------------------------------------------------------
+
+
+class CookRequest(BaseModel):
+    """Request body for POST /v1/recipes/cook."""
+
+    recipe_id: str = Field(description="UUID of the recipe to cook")
+
+
+@router.post(
+    "/cook",
+    response_model=CookProposal,
+    summary="Match recipe ingredients against pantry",
+    responses={
+        200: {"description": "CookProposal with per-ingredient match results"},
+        401: {"description": "Missing or invalid JWT"},
+        404: {"description": "Recipe not found"},
+    },
+)
+async def cook_recipe(
+    request: CookRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> CookProposal:
+    """Fetch the recipe and the user's pantry, then return a CookProposal.
+
+    No writes are performed here — the user must call /cook/confirm to apply.
+    """
+    logger.info(f"Cook proposal: user={user_id}, recipe={request.recipe_id}")
+
+    try:
+        from bubbly_chef.services.cook_matcher import match_ingredients
+
+        repo = await get_repository()
+
+        # Fetch recipe (raw dict — get_recipe returns dict)
+        recipe_data = await repo.get_recipe(user_id, request.recipe_id)
+        if recipe_data is None:
+            raise HTTPException(status_code=404, detail="Recipe not found")
+
+        pantry_items = await repo.get_all_pantry_items(user_id)
+
+        # get_recipe returns a raw Supabase dict at runtime despite the RecipeCard type hint
+        recipe_dict: dict[str, Any] = recipe_data  # type: ignore[assignment]
+        ingredients: list[dict[str, Any]] = recipe_dict.get("ingredients", [])
+        title: str = recipe_dict.get("title", "")
+
+        proposal = match_ingredients(
+            recipe_id=request.recipe_id,
+            recipe_title=title,
+            recipe_ingredients=ingredients,
+            pantry_items=pantry_items,
+        )
+        return proposal
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Cook proposal failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Cook proposal failed: {str(e)}") from e
+
+
+@router.post(
+    "/cook/confirm",
+    summary="Apply pantry deductions and mark recipe as cooked",
+    responses={
+        200: {"description": "Deductions applied and recipe marked as cooked"},
+        401: {"description": "Missing or invalid JWT"},
+        404: {"description": "Recipe not found"},
+    },
+)
+async def cook_confirm(
+    request: CookConfirmRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> dict[str, Any]:
+    """Apply user-approved deductions and increment times_cooked on the recipe."""
+    logger.info(
+        f"Cook confirm: user={user_id}, recipe={request.recipe_id}, "
+        f"deductions={len(request.deductions)}"
+    )
+
+    try:
+        repo = await get_repository()
+
+        # Verify recipe exists and belongs to this user
+        recipe_data = await repo.get_recipe(user_id, str(request.recipe_id))
+        if recipe_data is None:
+            raise HTTPException(status_code=404, detail="Recipe not found")
+
+        # Apply each deduction
+        for deduction in request.deductions:
+            await repo.deduct_pantry_item(
+                user_id=user_id,
+                item_id=str(deduction.pantry_item_id),
+                deduct_qty=deduction.deduct_qty,
+            )
+
+        # Mark recipe as cooked
+        await repo.update_recipe_cooked(user_id=user_id, recipe_id=str(request.recipe_id))
+
+        return {"success": True, "deductions_applied": len(request.deductions)}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Cook confirm failed: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Cook confirm failed: {str(e)}") from e

--- a/ai-service/bubbly_chef/models/cook.py
+++ b/ai-service/bubbly_chef/models/cook.py
@@ -1,0 +1,67 @@
+"""Pydantic models for the cook-a-recipe / pantry-deduction workflow."""
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class IngredientMatch(BaseModel):
+    """Per-ingredient match result from the cook matcher."""
+
+    ingredient_name: str = Field(description="Ingredient name from the recipe")
+    ingredient_qty: float | None = Field(default=None, description="Quantity required by the recipe")
+    ingredient_unit: str | None = Field(default=None, description="Unit required by the recipe")
+
+    # Pantry side (None when status == "missing")
+    pantry_item_id: UUID | None = Field(default=None, description="Matched pantry item UUID")
+    pantry_item_name: str | None = Field(default=None, description="Matched pantry item name")
+    pantry_qty_available: float | None = Field(
+        default=None, description="Current quantity in pantry (base unit)"
+    )
+    deduct_qty: float | None = Field(
+        default=None, description="Amount to deduct (base unit)"
+    )
+    base_unit: str | None = Field(default=None, description="Base unit used for comparison")
+
+    status: Literal["ready", "shortfall", "unit_conflict", "missing"] = Field(
+        description="ready=have enough, shortfall=not enough, unit_conflict=can't compare, missing=not in pantry"
+    )
+    shortfall: float | None = Field(
+        default=None, description="How much is missing (base unit), only set when status==shortfall"
+    )
+
+
+class CookProposal(BaseModel):
+    """Proposal returned to the user before confirming a cook action."""
+
+    recipe_id: UUID = Field(description="ID of the recipe being cooked")
+    recipe_title: str = Field(description="Human-readable recipe title")
+    matches: list[IngredientMatch] = Field(
+        description="All matched ingredients (ready, shortfall, unit_conflict)"
+    )
+    missing: list[str] = Field(
+        default_factory=list,
+        description="Ingredient names that have no pantry match at all",
+    )
+    unit_conflicts: list[dict[str, str]] = Field(
+        default_factory=list,
+        description="Ingredient names where unit conversion is not possible",
+    )
+
+
+class DeductionItem(BaseModel):
+    """A single pantry deduction as confirmed by the user."""
+
+    pantry_item_id: UUID = Field(description="Pantry item to deduct from")
+    deduct_qty: float = Field(description="Amount to deduct (in base_unit)")
+    base_unit: str = Field(description="Unit of deduct_qty")
+
+
+class CookConfirmRequest(BaseModel):
+    """Request body for POST /v1/recipes/cook/confirm."""
+
+    recipe_id: UUID = Field(description="Recipe that was cooked")
+    deductions: list[DeductionItem] = Field(
+        description="Pantry deductions the user approved"
+    )

--- a/ai-service/bubbly_chef/repository/supabase_repo.py
+++ b/ai-service/bubbly_chef/repository/supabase_repo.py
@@ -305,6 +305,79 @@ class SupabaseRepository:
         # Return raw dict — caller can construct RecipeCard if needed
         return result.data  # type: ignore[return-value]
 
+    async def update_recipe_cooked(self, user_id: str, recipe_id: str) -> None:
+        """Increment times_cooked and set last_cooked_at to now."""
+        # Read current times_cooked first
+        result = (
+            self.client.table("recipes")
+            .select("times_cooked")
+            .eq("id", recipe_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        )
+        current = result.data or {}
+        times_cooked = int(current.get("times_cooked", 0)) + 1
+        (
+            self.client.table("recipes")
+            .update(
+                {
+                    "times_cooked": times_cooked,
+                    "last_cooked_at": datetime.now(UTC).isoformat(),
+                }
+            )
+            .eq("id", recipe_id)
+            .eq("user_id", user_id)
+            .execute()
+        )
+
+    async def deduct_pantry_item(
+        self, user_id: str, item_id: str, deduct_qty: float
+    ) -> None:
+        """Decrement pantry item quantity_base by deduct_qty, flooring at 0.
+
+        Also updates the display quantity proportionally when quantity_base
+        is available, so the frontend shows a sensible number.
+        """
+        result = (
+            self.client.table("pantry_items")
+            .select("quantity, quantity_base, unit_base")
+            .eq("id", item_id)
+            .eq("user_id", user_id)
+            .single()
+            .execute()
+        )
+        if not result.data:
+            logger.warning(f"deduct_pantry_item: item {item_id} not found for user {user_id}")
+            return
+
+        row = result.data
+        current_base = float(row["quantity_base"]) if row.get("quantity_base") is not None else None
+        current_qty = float(row["quantity"])
+
+        if current_base is not None:
+            new_base = max(0.0, current_base - deduct_qty)
+            # Proportionally scale display quantity
+            ratio = new_base / current_base if current_base > 0 else 0.0
+            new_qty = round(current_qty * ratio, 4)
+            (
+                self.client.table("pantry_items")
+                .update({"quantity": new_qty, "quantity_base": new_base})
+                .eq("id", item_id)
+                .eq("user_id", user_id)
+                .execute()
+            )
+        else:
+            # No base unit — deduct directly from display quantity
+            new_qty = max(0.0, current_qty - deduct_qty)
+            (
+                self.client.table("pantry_items")
+                .update({"quantity": new_qty})
+                .eq("id", item_id)
+                .eq("user_id", user_id)
+                .execute()
+            )
+
     # =========================================================================
     # Conversation history
     # =========================================================================

--- a/ai-service/bubbly_chef/services/cook_matcher.py
+++ b/ai-service/bubbly_chef/services/cook_matcher.py
@@ -1,0 +1,181 @@
+"""Cook matcher service.
+
+Given a list of recipe ingredients and a user's pantry items, produces a
+CookProposal that shows which ingredients can be deducted, which are
+insufficient, which have unit conflicts, and which are missing entirely.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from bubbly_chef.domain.catalog import lookup as catalog_lookup
+from bubbly_chef.domain.normalizer import normalize_food_name, normalize_to_base_unit
+from bubbly_chef.models.cook import CookProposal, IngredientMatch
+from bubbly_chef.models.pantry import PantryItem
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_ingredient_name(name: str) -> str:
+    """Normalize an ingredient name for matching against pantry items."""
+    # First try catalog lookup at 80-threshold (task spec)
+    entry = catalog_lookup(name, threshold=80)
+    if entry:
+        return entry.canonical.lower().strip()
+    # Fall back to synonym + regex normalizer
+    return normalize_food_name(name).lower().strip()
+
+
+def match_ingredients(
+    recipe_id: str,
+    recipe_title: str,
+    recipe_ingredients: list[dict[str, Any]],
+    pantry_items: list[PantryItem],
+) -> CookProposal:
+    """Match recipe ingredients against pantry items and produce a CookProposal.
+
+    Args:
+        recipe_id: UUID string of the recipe.
+        recipe_title: Human-readable title for the proposal.
+        recipe_ingredients: List of ingredient dicts with keys:
+            name (str), quantity (float|None), unit (str|None).
+        pantry_items: List of PantryItem objects for the current user.
+
+    Returns:
+        CookProposal with matches, missing, and unit_conflicts lists.
+    """
+    from uuid import UUID
+
+    # Build a lookup: normalized_name -> PantryItem
+    pantry_index: dict[str, PantryItem] = {}
+    for item in pantry_items:
+        key = _normalize_ingredient_name(item.name)
+        # Keep the item with the highest quantity if there are duplicates
+        if key not in pantry_index or item.quantity > pantry_index[key].quantity:
+            pantry_index[key] = item
+
+    matches: list[IngredientMatch] = []
+    missing: list[str] = []
+    unit_conflicts: list[dict[str, str]] = []
+
+    for ingredient in recipe_ingredients:
+        raw_name: str = ingredient.get("name", "")
+        if not raw_name:
+            continue
+
+        ing_qty: float | None = ingredient.get("quantity")
+        ing_unit: str | None = ingredient.get("unit")
+        norm_name = _normalize_ingredient_name(raw_name)
+
+        # --- Find pantry match ---
+        pantry_item = pantry_index.get(norm_name)
+
+        if pantry_item is None:
+            # No match at all
+            missing.append(raw_name)
+            continue
+
+        # --- No quantity on recipe ingredient → can't deduct, just note as ready ---
+        if ing_qty is None or ing_unit is None:
+            matches.append(
+                IngredientMatch(
+                    ingredient_name=raw_name,
+                    ingredient_qty=ing_qty,
+                    ingredient_unit=ing_unit,
+                    pantry_item_id=pantry_item.id,
+                    pantry_item_name=pantry_item.name,
+                    pantry_qty_available=pantry_item.quantity_base,
+                    deduct_qty=None,
+                    base_unit=pantry_item.unit_base,
+                    status="ready",
+                )
+            )
+            continue
+
+        # --- Convert recipe ingredient to base unit ---
+        req_base_qty, req_base_unit = normalize_to_base_unit(
+            name=raw_name,
+            quantity=ing_qty,
+            unit=ing_unit,
+        )
+
+        # Also ensure pantry item has a base unit
+        pantry_base_qty = pantry_item.quantity_base
+        pantry_base_unit = pantry_item.unit_base
+
+        # If pantry item lacks base values, try to derive them
+        if pantry_base_qty is None or pantry_base_unit is None:
+            pantry_base_qty, pantry_base_unit = normalize_to_base_unit(
+                name=pantry_item.name,
+                quantity=pantry_item.quantity,
+                unit=pantry_item.unit,
+            )
+
+        # --- Unit conflict: can't convert either side ---
+        if req_base_qty is None or pantry_base_qty is None or req_base_unit != pantry_base_unit:
+            conflict_info = {
+                "ingredient": raw_name,
+                "recipe_unit": ing_unit,
+                "pantry_unit": pantry_item.unit,
+            }
+            unit_conflicts.append(conflict_info)
+            matches.append(
+                IngredientMatch(
+                    ingredient_name=raw_name,
+                    ingredient_qty=ing_qty,
+                    ingredient_unit=ing_unit,
+                    pantry_item_id=pantry_item.id,
+                    pantry_item_name=pantry_item.name,
+                    pantry_qty_available=pantry_base_qty,
+                    deduct_qty=None,
+                    base_unit=pantry_base_unit or ing_unit,
+                    status="unit_conflict",
+                )
+            )
+            continue
+
+        # --- Quantity comparison ---
+        assert req_base_qty is not None
+        assert pantry_base_qty is not None
+        assert req_base_unit is not None
+
+        if pantry_base_qty >= req_base_qty:
+            matches.append(
+                IngredientMatch(
+                    ingredient_name=raw_name,
+                    ingredient_qty=ing_qty,
+                    ingredient_unit=ing_unit,
+                    pantry_item_id=pantry_item.id,
+                    pantry_item_name=pantry_item.name,
+                    pantry_qty_available=pantry_base_qty,
+                    deduct_qty=req_base_qty,
+                    base_unit=req_base_unit,
+                    status="ready",
+                )
+            )
+        else:
+            shortfall = req_base_qty - pantry_base_qty
+            matches.append(
+                IngredientMatch(
+                    ingredient_name=raw_name,
+                    ingredient_qty=ing_qty,
+                    ingredient_unit=ing_unit,
+                    pantry_item_id=pantry_item.id,
+                    pantry_item_name=pantry_item.name,
+                    pantry_qty_available=pantry_base_qty,
+                    deduct_qty=pantry_base_qty,  # deduct what we have
+                    base_unit=req_base_unit,
+                    status="shortfall",
+                    shortfall=round(shortfall, 4),
+                )
+            )
+
+    return CookProposal(
+        recipe_id=UUID(recipe_id),
+        recipe_title=recipe_title,
+        matches=matches,
+        missing=missing,
+        unit_conflicts=unit_conflicts,
+    )

--- a/ai-service/tests/test_cook_matcher.py
+++ b/ai-service/tests/test_cook_matcher.py
@@ -1,0 +1,153 @@
+"""Unit tests for the cook_matcher service."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+
+from bubbly_chef.models.pantry import FoodCategory, PantryItem, StorageLocation
+from bubbly_chef.services.cook_matcher import match_ingredients
+
+
+def _make_item(
+    name: str,
+    qty: float,
+    unit: str,
+    qty_base: float | None = None,
+    unit_base: str | None = None,
+) -> PantryItem:
+    return PantryItem(
+        id=uuid.uuid4(),
+        name=name,
+        category=FoodCategory.OTHER,
+        storage_location=StorageLocation.PANTRY,
+        quantity=qty,
+        unit=unit,
+        quantity_base=qty_base,
+        unit_base=unit_base,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+RECIPE_ID = str(uuid.uuid4())
+RECIPE_TITLE = "Test Recipe"
+
+
+class TestMatchIngredients:
+    """Happy-path and error-path tests for match_ingredients()."""
+
+    def test_ready_when_pantry_has_enough(self) -> None:
+        """Ingredient with sufficient base-unit quantity → status=ready."""
+        pantry = [_make_item("eggs", 12.0, "count", qty_base=12.0, unit_base="count")]
+        ingredients = [{"name": "eggs", "quantity": 2.0, "unit": "count"}]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        assert len(proposal.matches) == 1
+        assert proposal.matches[0].status == "ready"
+        assert proposal.matches[0].deduct_qty == pytest.approx(2.0)
+        assert proposal.missing == []
+
+    def test_shortfall_when_pantry_has_too_little(self) -> None:
+        """Ingredient with insufficient quantity → status=shortfall."""
+        pantry = [_make_item("milk", 1.0, "cup", qty_base=240.0, unit_base="ml")]
+        # Recipe needs 3 cups = 720 ml; pantry has 240 ml
+        ingredients = [{"name": "milk", "quantity": 3.0, "unit": "cup"}]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        assert len(proposal.matches) == 1
+        match = proposal.matches[0]
+        assert match.status == "shortfall"
+        assert match.shortfall == pytest.approx(480.0, abs=1.0)
+        assert match.deduct_qty == pytest.approx(240.0)  # deduct what we have
+
+    def test_missing_when_no_pantry_match(self) -> None:
+        """Ingredient with no pantry counterpart → appears in missing list."""
+        pantry: list[PantryItem] = []
+        ingredients = [{"name": "truffle oil", "quantity": 1.0, "unit": "tbsp"}]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        assert proposal.missing == ["truffle oil"]
+        assert proposal.matches == []
+
+    def test_unit_conflict_when_conversion_impossible(self) -> None:
+        """Ingredient where recipe unit can't be converted to pantry base unit → unit_conflict."""
+        # sugar in pantry is measured in count (items), recipe asks for grams
+        pantry = [_make_item("sugar", 1.0, "item", qty_base=1.0, unit_base="count")]
+        # 200g of sugar — can't compare grams to count
+        ingredients = [{"name": "sugar", "quantity": 200.0, "unit": "g"}]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        # Should be a unit_conflict, not missing
+        assert len(proposal.unit_conflicts) == 1
+        assert proposal.unit_conflicts[0]["ingredient"] == "sugar"
+        assert any(m.status == "unit_conflict" for m in proposal.matches)
+
+    def test_no_quantity_ingredient_is_ready(self) -> None:
+        """Ingredient with no quantity in recipe → status=ready (informational only)."""
+        pantry = [_make_item("salt", 500.0, "g", qty_base=500.0, unit_base="g")]
+        ingredients = [{"name": "salt", "quantity": None, "unit": None}]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        assert len(proposal.matches) == 1
+        assert proposal.matches[0].status == "ready"
+        assert proposal.matches[0].deduct_qty is None
+
+    def test_mixed_ingredients(self) -> None:
+        """Recipe with a mix of ready, shortfall, and missing ingredients."""
+        pantry = [
+            _make_item("eggs", 6.0, "count", qty_base=6.0, unit_base="count"),
+            _make_item("butter", 2.0, "oz", qty_base=56.7, unit_base="g"),
+        ]
+        ingredients = [
+            {"name": "eggs", "quantity": 3.0, "unit": "count"},       # ready
+            {"name": "butter", "quantity": 200.0, "unit": "g"},       # shortfall (only 56.7g)
+            {"name": "vanilla extract", "quantity": 1.0, "unit": "tsp"},  # missing
+        ]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        statuses = {m.ingredient_name: m.status for m in proposal.matches}
+        assert statuses["eggs"] == "ready"
+        assert statuses["butter"] == "shortfall"
+        assert "vanilla extract" in proposal.missing
+
+    def test_empty_pantry_all_missing(self) -> None:
+        """All ingredients go missing when pantry is empty."""
+        pantry: list[PantryItem] = []
+        ingredients = [
+            {"name": "chicken breast", "quantity": 2.0, "unit": "lb"},
+            {"name": "garlic", "quantity": 3.0, "unit": "count"},
+        ]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, ingredients, pantry)
+
+        assert len(proposal.missing) == 2
+        assert proposal.matches == []
+
+    def test_empty_ingredients_returns_empty_proposal(self) -> None:
+        """Recipe with no ingredients → empty proposal."""
+        pantry = [_make_item("eggs", 12.0, "count", qty_base=12.0, unit_base="count")]
+
+        proposal = match_ingredients(RECIPE_ID, RECIPE_TITLE, [], pantry)
+
+        assert proposal.matches == []
+        assert proposal.missing == []
+        assert proposal.unit_conflicts == []
+
+    def test_proposal_ids_and_title(self) -> None:
+        """Proposal carries recipe_id and recipe_title through."""
+        import uuid as _uuid
+
+        rid = str(_uuid.uuid4())
+        proposal = match_ingredients(rid, "My Recipe", [], [])
+
+        assert str(proposal.recipe_id) == rid
+        assert proposal.recipe_title == "My Recipe"

--- a/ai-service/tests/test_cook_routes.py
+++ b/ai-service/tests/test_cook_routes.py
@@ -1,0 +1,254 @@
+"""Integration tests for /v1/recipes/cook and /v1/recipes/cook/confirm routes.
+
+Mocks:
+- get_current_user_id dependency → fixed test user_id
+- SupabaseRepository.get_recipe, get_all_pantry_items, deduct_pantry_item,
+  update_recipe_cooked → AsyncMock stubs
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from bubbly_chef.api.auth import get_current_user_id
+from bubbly_chef.main import create_app
+from bubbly_chef.models.pantry import FoodCategory, PantryItem, StorageLocation
+
+TEST_USER_ID = "test-cook-user-123"
+RECIPE_ID = str(uuid.uuid4())
+PANTRY_ITEM_ID = str(uuid.uuid4())
+
+
+def _make_pantry_item(
+    item_id: str,
+    name: str,
+    qty: float,
+    unit: str,
+    qty_base: float | None,
+    unit_base: str | None,
+) -> PantryItem:
+    return PantryItem(
+        id=uuid.UUID(item_id),
+        name=name,
+        category=FoodCategory.OTHER,
+        storage_location=StorageLocation.PANTRY,
+        quantity=qty,
+        unit=unit,
+        quantity_base=qty_base,
+        unit_base=unit_base,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+@pytest.fixture
+def app():
+    """Create a FastAPI app with auth override and no-op lifespan."""
+    from contextlib import asynccontextmanager
+    from collections.abc import AsyncGenerator
+
+    @asynccontextmanager
+    async def _noop_lifespan(app: Any) -> AsyncGenerator[None, None]:
+        yield
+
+    _app = create_app()
+    _app.router.lifespan_context = _noop_lifespan
+
+    async def _fake_user() -> str:
+        return TEST_USER_ID
+
+    _app.dependency_overrides[get_current_user_id] = _fake_user
+    return _app
+
+
+@pytest_asyncio.fixture
+async def client(app: Any) -> AsyncClient:
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/recipes/cook
+# ---------------------------------------------------------------------------
+
+
+class TestCookRoute:
+    """Tests for the cook proposal endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_returns_proposal_for_valid_recipe(self, client: AsyncClient) -> None:
+        """Valid recipe with pantry items returns a CookProposal."""
+        pantry_item = _make_pantry_item(
+            PANTRY_ITEM_ID, "eggs", 12.0, "count", 12.0, "count"
+        )
+        recipe_dict: dict[str, Any] = {
+            "id": RECIPE_ID,
+            "title": "Scrambled Eggs",
+            "ingredients": [{"name": "eggs", "quantity": 3.0, "unit": "count"}],
+        }
+
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = recipe_dict
+        mock_repo.get_all_pantry_items.return_value = [pantry_item]
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post(
+                "/v1/recipes/cook", json={"recipe_id": RECIPE_ID}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recipe_id"] == RECIPE_ID
+        assert data["recipe_title"] == "Scrambled Eggs"
+        assert len(data["matches"]) == 1
+        assert data["matches"][0]["status"] == "ready"
+        assert data["missing"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_missing_recipe(self, client: AsyncClient) -> None:
+        """Recipe not found returns 404."""
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = None
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post(
+                "/v1/recipes/cook", json={"recipe_id": RECIPE_ID}
+            )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_missing_ingredient_appears_in_missing_list(
+        self, client: AsyncClient
+    ) -> None:
+        """Ingredient not in pantry appears in the missing list."""
+        recipe_dict: dict[str, Any] = {
+            "id": RECIPE_ID,
+            "title": "Pasta",
+            "ingredients": [{"name": "truffle oil", "quantity": 1.0, "unit": "tbsp"}],
+        }
+
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = recipe_dict
+        mock_repo.get_all_pantry_items.return_value = []
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post(
+                "/v1/recipes/cook", json={"recipe_id": RECIPE_ID}
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "truffle oil" in data["missing"]
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/recipes/cook/confirm
+# ---------------------------------------------------------------------------
+
+
+class TestCookConfirmRoute:
+    """Tests for the cook confirmation endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_applies_deductions_and_marks_cooked(
+        self, client: AsyncClient
+    ) -> None:
+        """Confirm call applies deductions and updates recipe."""
+        recipe_dict: dict[str, Any] = {"id": RECIPE_ID, "title": "Eggs"}
+
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = recipe_dict
+        mock_repo.deduct_pantry_item.return_value = None
+        mock_repo.update_recipe_cooked.return_value = None
+
+        payload = {
+            "recipe_id": RECIPE_ID,
+            "deductions": [
+                {
+                    "pantry_item_id": PANTRY_ITEM_ID,
+                    "deduct_qty": 3.0,
+                    "base_unit": "count",
+                }
+            ],
+        }
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post("/v1/recipes/cook/confirm", json=payload)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["success"] is True
+        assert data["deductions_applied"] == 1
+
+        mock_repo.deduct_pantry_item.assert_called_once_with(
+            user_id=TEST_USER_ID,
+            item_id=PANTRY_ITEM_ID,
+            deduct_qty=3.0,
+        )
+        mock_repo.update_recipe_cooked.assert_called_once_with(
+            user_id=TEST_USER_ID, recipe_id=RECIPE_ID
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_404_when_recipe_missing(self, client: AsyncClient) -> None:
+        """Confirm returns 404 if recipe doesn't exist."""
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = None
+
+        payload = {
+            "recipe_id": RECIPE_ID,
+            "deductions": [],
+        }
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post("/v1/recipes/cook/confirm", json=payload)
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_empty_deductions_still_marks_cooked(
+        self, client: AsyncClient
+    ) -> None:
+        """Confirm with no deductions still increments times_cooked."""
+        recipe_dict: dict[str, Any] = {"id": RECIPE_ID, "title": "Eggs"}
+
+        mock_repo = AsyncMock()
+        mock_repo.get_recipe.return_value = recipe_dict
+        mock_repo.update_recipe_cooked.return_value = None
+
+        payload = {"recipe_id": RECIPE_ID, "deductions": []}
+
+        with patch(
+            "bubbly_chef.api.routes.recipes_ai.get_repository",
+            return_value=mock_repo,
+        ):
+            response = await client.post("/v1/recipes/cook/confirm", json=payload)
+
+        assert response.status_code == 200
+        mock_repo.update_recipe_cooked.assert_called_once()
+        mock_repo.deduct_pantry_item.assert_not_called()

--- a/nextjs/src/app/api/ai/recipes/cook/confirm/route.ts
+++ b/nextjs/src/app/api/ai/recipes/cook/confirm/route.ts
@@ -1,0 +1,6 @@
+import { aiProxyJson } from '@/lib/api/ai-proxy'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  return aiProxyJson('/v1/recipes/cook/confirm', body)
+}

--- a/nextjs/src/app/api/ai/recipes/cook/route.ts
+++ b/nextjs/src/app/api/ai/recipes/cook/route.ts
@@ -1,0 +1,6 @@
+import { aiProxyJson } from '@/lib/api/ai-proxy'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+  return aiProxyJson('/v1/recipes/cook', body)
+}

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -1,0 +1,334 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { cookRecipe, confirmCook } from '@/lib/api/recipes'
+import type { CookProposal, IngredientMatch, DeductionItem } from '@/types/recipes'
+
+interface CookModalProps {
+  recipeId: string
+  recipeTitle: string
+  onClose: () => void
+  onCooked: () => void
+}
+
+type ModalState = 'loading' | 'review' | 'confirming' | 'success' | 'error'
+
+function statusColor(status: IngredientMatch['status']): string {
+  switch (status) {
+    case 'ready':
+      return '#b5ead7' // pastel-mint
+    case 'shortfall':
+      return '#ffdab3' // pastel-peach
+    case 'unit_conflict':
+      return '#ffdab3' // pastel-peach
+    case 'missing':
+      return '#e5e7eb' // grey
+    default:
+      return '#e5e7eb'
+  }
+}
+
+function statusLabel(status: IngredientMatch['status']): string {
+  switch (status) {
+    case 'ready':
+      return 'Ready'
+    case 'shortfall':
+      return 'Not enough'
+    case 'unit_conflict':
+      return 'Unit conflict'
+    case 'missing':
+      return 'Missing'
+    default:
+      return status
+  }
+}
+
+function formatQty(qty: number | null, unit: string | null): string {
+  if (qty == null) return '—'
+  const rounded = Math.round(qty * 100) / 100
+  return unit ? `${rounded} ${unit}` : String(rounded)
+}
+
+export default function CookModal({
+  recipeId,
+  recipeTitle,
+  onClose,
+  onCooked,
+}: CookModalProps) {
+  const [state, setState] = useState<ModalState>('loading')
+  const [proposal, setProposal] = useState<CookProposal | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string>('')
+  // Editable override quantities for unit_conflict rows (keyed by pantry_item_id)
+  const [overrides, setOverrides] = useState<Record<string, string>>({})
+
+  useEffect(() => {
+    let cancelled = false
+    cookRecipe(recipeId)
+      .then((p) => {
+        if (!cancelled) {
+          setProposal(p)
+          setState('review')
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setErrorMsg(err instanceof Error ? err.message : 'Failed to load cook proposal')
+          setState('error')
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [recipeId])
+
+  const handleConfirm = async () => {
+    if (!proposal) return
+    setState('confirming')
+
+    // Build deductions from matched items that have a deduct_qty
+    const deductions: DeductionItem[] = proposal.matches
+      .filter((m: IngredientMatch) => m.pantry_item_id != null && m.status !== 'missing')
+      .map((m: IngredientMatch) => {
+        // For unit_conflict rows, use the user's override qty (or 0 if not set)
+        const overrideKey = m.pantry_item_id!
+        let deductQty: number
+        if (m.status === 'unit_conflict') {
+          deductQty = parseFloat(overrides[overrideKey] ?? '0') || 0
+        } else {
+          deductQty = m.deduct_qty ?? 0
+        }
+        return {
+          pantry_item_id: m.pantry_item_id!,
+          deduct_qty: deductQty,
+          base_unit: m.base_unit ?? 'item',
+        }
+      })
+      .filter((d: DeductionItem) => d.deduct_qty > 0)
+
+    try {
+      await confirmCook(recipeId, deductions)
+      setState('success')
+      // Auto-close after a short delay so user sees the success state
+      setTimeout(() => {
+        onCooked()
+        onClose()
+      }, 1200)
+    } catch (err: unknown) {
+      setErrorMsg(err instanceof Error ? err.message : 'Failed to confirm cook')
+      setState('error')
+    }
+  }
+
+  return (
+    <AnimatePresence>
+      {/* Backdrop */}
+      <motion.div
+        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+        style={{ background: 'rgba(0,0,0,0.4)' }}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+          if (e.target === e.currentTarget) onClose()
+        }}
+      >
+        {/* Sheet */}
+        <motion.div
+          className="w-full max-w-md mx-2 mb-4 sm:mb-0 rounded-2xl overflow-hidden flex flex-col"
+          style={{
+            background: 'var(--color-surface)',
+            boxShadow: '0 8px 32px rgba(255,181,197,0.25)',
+            maxHeight: '85vh',
+          }}
+          initial={{ y: 60, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: 60, opacity: 0 }}
+          transition={{ type: 'spring', stiffness: 380, damping: 32 }}
+        >
+          {/* Header */}
+          <div
+            className="px-5 py-4 flex items-center justify-between flex-shrink-0 border-b border-[var(--color-border)]"
+            style={{ background: 'var(--color-bg)' }}
+          >
+            <div>
+              <h2
+                className="text-base font-extrabold text-[var(--color-text)]"
+                style={{ fontFamily: 'Nunito, sans-serif' }}
+              >
+                Cook it
+              </h2>
+              <p
+                className="text-xs text-[var(--color-muted)] mt-0.5 line-clamp-1"
+                style={{ fontFamily: 'Nunito, sans-serif' }}
+              >
+                {recipeTitle}
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              className="text-[var(--color-muted)] hover:text-[var(--color-text)] text-xl leading-none px-1"
+              aria-label="Close"
+            >
+              ✕
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {state === 'loading' && (
+              <div className="flex flex-col items-center gap-3 py-10">
+                <div
+                  className="w-8 h-8 rounded-full border-2 border-t-transparent animate-spin"
+                  style={{ borderColor: 'var(--color-primary)', borderTopColor: 'transparent' }}
+                />
+                <p
+                  className="text-sm text-[var(--color-muted)]"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  Checking your pantry...
+                </p>
+              </div>
+            )}
+
+            {state === 'error' && (
+              <div className="py-8 text-center">
+                <p className="text-sm font-semibold text-red-500" style={{ fontFamily: 'Nunito, sans-serif' }}>
+                  {errorMsg || 'Something went wrong. Please try again.'}
+                </p>
+              </div>
+            )}
+
+            {state === 'success' && (
+              <div className="py-8 text-center">
+                <p className="text-3xl mb-2">🍳</p>
+                <p
+                  className="text-sm font-extrabold text-[var(--color-text)]"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  Enjoy your meal!
+                </p>
+                <p
+                  className="text-xs text-[var(--color-muted)] mt-1"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  Pantry updated and recipe marked as cooked.
+                </p>
+              </div>
+            )}
+
+            {(state === 'review' || state === 'confirming') && proposal && (
+              <div className="flex flex-col gap-4">
+                {/* Ingredient table */}
+                {proposal.matches.length > 0 && (
+                  <table className="w-full text-xs" style={{ fontFamily: 'Nunito, sans-serif' }}>
+                    <thead>
+                      <tr className="text-[var(--color-muted)] text-left">
+                        <th className="pb-1 font-semibold">Ingredient</th>
+                        <th className="pb-1 font-semibold">Pantry match</th>
+                        <th className="pb-1 font-semibold text-right">Deduct</th>
+                        <th className="pb-1 font-semibold text-right">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {proposal.matches.map((m: IngredientMatch, i: number) => (
+                        <tr key={i} className="border-t border-[var(--color-border)]">
+                          <td className="py-1.5 pr-2 font-semibold text-[var(--color-text)]">
+                            {m.ingredient_name}
+                          </td>
+                          <td className="py-1.5 pr-2 text-[var(--color-muted)]">
+                            {m.pantry_item_name ?? '—'}
+                          </td>
+                          <td className="py-1.5 pr-2 text-right text-[var(--color-muted)]">
+                            {m.status === 'unit_conflict' ? (
+                              <input
+                                type="number"
+                                min="0"
+                                step="0.1"
+                                value={overrides[m.pantry_item_id!] ?? ''}
+                                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                                  setOverrides((prev: Record<string, string>) => ({
+                                    ...prev,
+                                    [m.pantry_item_id!]: e.target.value,
+                                  }))
+                                }
+                                className="w-16 text-right border border-[var(--color-border)] rounded px-1 py-0.5 text-xs"
+                                placeholder="qty"
+                                aria-label={`Deduct quantity for ${m.ingredient_name}`}
+                              />
+                            ) : (
+                              formatQty(m.deduct_qty, m.base_unit)
+                            )}
+                          </td>
+                          <td className="py-1.5 text-right">
+                            <span
+                              className="inline-block px-2 py-0.5 rounded-full text-[10px] font-bold"
+                              style={{
+                                background: statusColor(m.status),
+                                color: '#4a4a4a',
+                              }}
+                            >
+                              {statusLabel(m.status)}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+
+                {/* Missing items */}
+                {proposal.missing.length > 0 && (
+                  <div>
+                    <p
+                      className="text-xs font-bold text-[var(--color-muted)] mb-1"
+                      style={{ fontFamily: 'Nunito, sans-serif' }}
+                    >
+                      Not in pantry
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {proposal.missing.map((name: string) => (
+                        <span
+                          key={name}
+                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border border-[var(--color-border)] text-[var(--color-muted)]"
+                          style={{ fontFamily: 'Nunito, sans-serif' }}
+                        >
+                          ⚠️ {name}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* Footer actions */}
+          {(state === 'review' || state === 'confirming') && (
+            <div
+              className="px-5 py-4 flex gap-2 flex-shrink-0 border-t border-[var(--color-border)]"
+              style={{ background: 'var(--color-bg)' }}
+            >
+              <button
+                onClick={onClose}
+                disabled={state === 'confirming'}
+                className="flex-1 py-2 rounded-full text-sm font-bold border border-[var(--color-border)] text-[var(--color-muted)] active:scale-95 transition-transform disabled:opacity-50"
+                style={{ fontFamily: 'Nunito, sans-serif' }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleConfirm}
+                disabled={state === 'confirming'}
+                className="flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform disabled:opacity-50"
+                style={{ background: '#ffb5c5', fontFamily: 'Nunito, sans-serif' }}
+              >
+                {state === 'confirming' ? 'Saving...' : 'Confirm'}
+              </button>
+            </div>
+          )}
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>
+  )
+}

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -8,6 +8,7 @@ import BubblesMascot from '@/components/ui/BubblesMascot'
 import RecipeEditModal from './RecipeEditModal'
 import RecipeDeleteConfirm from './RecipeDeleteConfirm'
 import RecipeImportModal from './RecipeImportModal'
+import CookModal from './CookModal'
 
 interface RecipeBookProps {
   recipes: Recipe[]
@@ -44,6 +45,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
+  const [cookOpen, setCookOpen] = useState(false)
   const [importDraft, setImportDraft] = useState<Partial<Recipe> | null>(null)
   const [mutating, setMutating] = useState(false)
 
@@ -330,7 +332,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
               </div>
 
               {/* Action buttons */}
-              <div className="flex gap-2 mt-2">
+              <div className="flex items-center gap-2 mt-2">
                 <button
                   onClick={handleFavorite}
                   className="text-lg leading-none px-1 hover:scale-110 transition-transform"
@@ -354,6 +356,16 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   title="Delete recipe"
                 >
                   🗑️
+                </button>
+                {/* Cook it button */}
+                <button
+                  onClick={() => setCookOpen(true)}
+                  className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
+                  style={{ background: '#ffb5c5', fontFamily: 'Nunito, sans-serif' }}
+                  aria-label="Cook this recipe"
+                  title="Cook it — deduct ingredients from pantry"
+                >
+                  Cook it
                 </button>
               </div>
 
@@ -422,6 +434,18 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
           recipe={{ id: '', user_id: '', created_at: '', ...importDraft } as Recipe}
           onSave={handleImportSave}
           onClose={() => setImportDraft(null)}
+        />
+      )}
+
+      {/* Cook modal */}
+      {cookOpen && selectedRecipe && (
+        <CookModal
+          recipeId={selectedRecipe.id}
+          recipeTitle={selectedRecipe.title}
+          onClose={() => setCookOpen(false)}
+          onCooked={() => {
+            onMutate?.()
+          }}
         />
       )}
     </div>

--- a/nextjs/src/lib/api/recipes.ts
+++ b/nextjs/src/lib/api/recipes.ts
@@ -9,6 +9,8 @@ import type {
   RecipeConstraints,
   GenerateRecipeResponse,
   RefineRecipeRequest,
+  CookProposal,
+  DeductionItem,
 } from '@/types/recipes'
 
 /**
@@ -49,4 +51,42 @@ export async function refineRecipe(
   }
 
   return res.json()
+}
+
+/**
+ * Fetch a CookProposal for a recipe — matches ingredients against the user's pantry.
+ * No writes happen here; call confirmCook() to apply.
+ */
+export async function cookRecipe(recipeId: string): Promise<CookProposal> {
+  const res = await fetch('/api/ai/recipes/cook', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recipe_id: recipeId }),
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Cook proposal failed' }))
+    throw new Error(err.error ?? `Cook proposal failed: ${res.status}`)
+  }
+
+  return res.json()
+}
+
+/**
+ * Confirm cooking a recipe: apply pantry deductions and mark recipe as cooked.
+ */
+export async function confirmCook(
+  recipeId: string,
+  deductions: DeductionItem[],
+): Promise<void> {
+  const res = await fetch('/api/ai/recipes/cook/confirm', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ recipe_id: recipeId, deductions }),
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Cook confirmation failed' }))
+    throw new Error(err.error ?? `Cook confirmation failed: ${res.status}`)
+  }
 }

--- a/nextjs/src/types/recipes.ts
+++ b/nextjs/src/types/recipes.ts
@@ -58,3 +58,36 @@ export interface RefineRecipeRequest {
   recipe: Record<string, unknown>
   prompt: string
 }
+
+// ---------------------------------------------------------------------------
+// Cook-a-recipe / pantry deduction types
+// ---------------------------------------------------------------------------
+
+export type IngredientMatchStatus = 'ready' | 'shortfall' | 'unit_conflict' | 'missing'
+
+export interface IngredientMatch {
+  ingredient_name: string
+  ingredient_qty: number | null
+  ingredient_unit: string | null
+  pantry_item_id: string | null
+  pantry_item_name: string | null
+  pantry_qty_available: number | null
+  deduct_qty: number | null
+  base_unit: string | null
+  status: IngredientMatchStatus
+  shortfall: number | null
+}
+
+export interface CookProposal {
+  recipe_id: string
+  recipe_title: string
+  matches: IngredientMatch[]
+  missing: string[]
+  unit_conflicts: Array<{ ingredient: string; recipe_unit: string; pantry_unit: string }>
+}
+
+export interface DeductionItem {
+  pantry_item_id: string
+  deduct_qty: number
+  base_unit: string
+}

--- a/supabase/migrations/00006_add_recipe_cook_tracking.sql
+++ b/supabase/migrations/00006_add_recipe_cook_tracking.sql
@@ -1,0 +1,6 @@
+-- Migration: Add cook tracking columns to recipes table
+-- Tracks when a recipe was last cooked and how many times it has been cooked.
+
+ALTER TABLE recipes
+  ADD COLUMN IF NOT EXISTS last_cooked_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS times_cooked integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
Closes #40

## Summary

- **Migration** — adds `last_cooked_at` and `times_cooked` columns to the `recipes` table (`supabase/migrations/00006_add_recipe_cook_tracking.sql`)
- **Backend** — new `cook_matcher` service, Pydantic models, two AI-service routes, and two new repository methods; 15 tests (9 unit, 6 integration)
- **Frontend** — `CookModal` component, `Cook it` button in `RecipeBook`, TypeScript types, Next.js proxy routes

## Design

See the task spec for full architecture decisions. Key points:

- `POST /v1/recipes/cook` — read-only proposal: matches recipe ingredients to pantry using base-unit normalization, returns a `CookProposal` with per-ingredient status (`ready` / `shortfall` / `unit_conflict` / `missing`)
- `POST /v1/recipes/cook/confirm` — write path: applies user-approved deductions to `pantry_items`, then increments `times_cooked` and sets `last_cooked_at`
- Frontend: `CookModal` loads the proposal on mount, shows an ingredient table with colour-coded status, editable qty fields for `unit_conflict` rows, and a missing-items badge section. Nothing writes until user clicks Confirm.

## Key files changed

| File | Change |
|---|---|
| `supabase/migrations/00006_add_recipe_cook_tracking.sql` | New migration |
| `ai-service/bubbly_chef/models/cook.py` | New Pydantic models |
| `ai-service/bubbly_chef/services/cook_matcher.py` | New `match_ingredients()` service |
| `ai-service/bubbly_chef/repository/supabase_repo.py` | `update_recipe_cooked()`, `deduct_pantry_item()` |
| `ai-service/bubbly_chef/api/routes/recipes_ai.py` | `/cook` and `/cook/confirm` routes |
| `ai-service/tests/test_cook_matcher.py` | 9 unit tests |
| `ai-service/tests/test_cook_routes.py` | 6 integration tests |
| `nextjs/src/types/recipes.ts` | `CookProposal`, `IngredientMatch`, `DeductionItem` types |
| `nextjs/src/lib/api/recipes.ts` | `cookRecipe()`, `confirmCook()` client functions |
| `nextjs/src/app/api/ai/recipes/cook/` | Two Next.js proxy routes |
| `nextjs/src/components/recipes/CookModal.tsx` | New modal component |
| `nextjs/src/components/recipes/RecipeBook.tsx` | Cook it button + modal wiring |

## Test plan

- [ ] `cd ai-service && pytest tests/test_cook_matcher.py tests/test_cook_routes.py -v` — 15 tests pass
- [ ] `cd ai-service && ruff check bubbly_chef/` — no issues
- [ ] `cd ai-service && mypy bubbly_chef/models/cook.py bubbly_chef/services/cook_matcher.py --strict` — no issues
- [ ] Apply migration to Supabase: `supabase db push` or run SQL directly
- [ ] Open a saved recipe in the app, click "Cook it" — modal loads with ingredient table
- [ ] Confirm cook — pantry quantities are decremented, recipe shows updated `times_cooked`
- [ ] Confirm cook with missing items — missing items shown with badge, not deducted
- [ ] Unit conflict ingredient — editable qty field appears; entering 0 skips deduction