### PR TITLE
test: add Playwright e2e test harness

### DIFF
--- a/nextjs/.gitignore
+++ b/nextjs/.gitignore
@@ -42,3 +42,8 @@ next-env.d.ts
 
 # playwright-cli snapshots
 .playwright-cli/
+
+# Playwright
+e2e/.auth/user.json
+e2e/.results/
+e2e/.report/

--- a/nextjs/e2e/fixtures/auth.ts
+++ b/nextjs/e2e/fixtures/auth.ts
@@ -1,0 +1,7 @@
+import { test as base, expect } from '@playwright/test';
+import path from 'path';
+
+export const test = base.extend({});
+export { expect };
+
+test.use({ storageState: path.join(__dirname, '../.auth/user.json') });

--- a/nextjs/e2e/global-setup.ts
+++ b/nextjs/e2e/global-setup.ts
@@ -1,0 +1,81 @@
+import { chromium, FullConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import path from 'path';
+
+dotenv.config({ path: path.resolve(__dirname, '../.env.local') });
+
+const authFile = path.join(__dirname, '.auth/user.json');
+
+async function globalSetup(_config: FullConfig) {
+  const email = process.env.TEST_USERNAME;
+  const password = process.env.TEST_PASSWORD;
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!email || !password) {
+    throw new Error(
+      'Missing TEST_USERNAME or TEST_PASSWORD in nextjs/.env.local'
+    );
+  }
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error(
+      'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY in nextjs/.env.local'
+    );
+  }
+
+  // Authenticate via Supabase REST API
+  const res = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': supabaseKey,
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Supabase login failed (${res.status}): ${body}`);
+  }
+
+  const session = await res.json();
+
+  // @supabase/ssr stores session in a cookie named sb-<project-ref>-auth-token
+  // The value is the raw JSON string of the session
+  const projectRef = new URL(supabaseUrl).hostname.split('.')[0];
+  const cookieName = `sb-${projectRef}-auth-token`;
+  const cookieValue = JSON.stringify(session);
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+
+  // Set the auth cookie before navigating
+  await context.addCookies([
+    {
+      name: cookieName,
+      value: cookieValue,
+      domain: '127.0.0.1',
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+
+  // Verify we land on home (not redirected back to login)
+  const page = await context.newPage();
+  await page.goto('http://127.0.0.1:3000/');
+  await page.waitForLoadState('networkidle');
+
+  const finalUrl = page.url();
+  if (finalUrl.includes('/login')) {
+    throw new Error(
+      `Auth setup failed — redirected to login. Cookie "${cookieName}" was not recognized by middleware.`
+    );
+  }
+
+  await context.storageState({ path: authFile });
+  await browser.close();
+}
+
+export default globalSetup;

--- a/nextjs/e2e/smoke.spec.ts
+++ b/nextjs/e2e/smoke.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from './fixtures/auth';
+
+test.describe('smoke navigation', () => {
+  test('home → pantry → recipes', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByAltText(/Bubbles/)).toBeVisible();
+
+    await page.getByRole('link', { name: 'Pantry' }).click();
+    await expect(page).toHaveURL(/\/pantry/);
+
+    await page.getByRole('link', { name: 'Recipes' }).click();
+    await expect(page).toHaveURL(/\/recipes/);
+  });
+});

--- a/nextjs/jest.config.js
+++ b/nextjs/jest.config.js
@@ -2,6 +2,7 @@
 const config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testPathIgnorePatterns: ['/node_modules/', '/e2e/'],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -20,11 +20,13 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "dotenv": "^17.4.2",
         "eslint": "^9",
         "eslint-config-next": "16.2.2",
         "jest": "^30.3.0",
@@ -2218,6 +2220,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4642,6 +4660,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -9786,6 +9817,52 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -8,7 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "jest",
-    "test:watch": "jest --watch"
+    "test:watch": "jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@phosphor-icons/react": "^2.1.10",
@@ -23,11 +25,13 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "dotenv": "^17.4.2",
     "eslint": "^9",
     "eslint-config-next": "16.2.2",
     "jest": "^30.3.0",

--- a/nextjs/playwright.config.ts
+++ b/nextjs/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  outputDir: './e2e/.results',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['html', { outputFolder: './e2e/.report', open: 'never' }]],
+
+  globalSetup: './e2e/global-setup.ts',
+
+  use: {
+    baseURL: 'http://127.0.0.1:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium-mobile',
+      use: {
+        ...devices['Pixel 5'],
+        storageState: './e2e/.auth/user.json',
+      },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
## Summary

- Adds Playwright with a mobile-first smoke test (Pixel 5 viewport, Chromium only)
- Auth handled via Supabase REST API in global-setup (no UI login dependency)
- Jest config updated to exclude `e2e/` directory

## What to validate

1. `cd nextjs && npm run test:e2e` — smoke test passes (needs dev server on :3000 and valid `TEST_USERNAME`/`TEST_PASSWORD` in `.env.local`)
2. `cd nextjs && npm test` — Jest still passes (15 tests)
3. No application code was changed — only test infra

## Follow-up

- CI integration filed as #55

## Files added/modified

- `nextjs/playwright.config.ts` — config (mobile viewport, webServer, storageState)
- `nextjs/e2e/global-setup.ts` — Supabase API login → cookie injection
- `nextjs/e2e/fixtures/auth.ts` — reusable auth fixture
- `nextjs/e2e/smoke.spec.ts` — home → pantry → recipes navigation
- `nextjs/jest.config.js` — added `testPathIgnorePatterns: ['/e2e/']`
- `nextjs/.gitignore` — Playwright artifacts
- `nextjs/package.json` — `@playwright/test`, `dotenv`, two scripts