### PR TITLE
fix: replace hardcoded expiry badge colors and bg-white in pantry (#77)

### DIFF
--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -51,10 +51,10 @@ function daysUntilExpiry(date: string | null): number | null {
 
 function expiryBadge(days: number | null) {
   if (days === null) return null
-  if (days <= 0) return { label: 'Expired', color: 'bg-red-400 text-white' }
-  if (days <= 2) return { label: `${days}d left`, color: 'bg-red-300 text-white' }
-  if (days <= 5) return { label: `${days}d left`, color: 'bg-yellow-300 text-yellow-900' }
-  return { label: `${days}d left`, color: 'bg-green-200 text-green-800' }
+  if (days <= 0) return { label: 'Expired', color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
+  if (days <= 2) return { label: `${days}d left`, color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
+  if (days <= 5) return { label: `${days}d left`, color: 'bg-[var(--color-expiring)] text-[var(--color-expiring-text)]' }
+  return { label: `${days}d left`, color: 'bg-[var(--color-fresh)] text-[var(--color-fresh-text)]' }
 }
 
 function groupByCategory(items: PantryItem[]) {
@@ -179,7 +179,7 @@ function PantryPageInner() {
             className={`whitespace-nowrap px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
               locationFilter === loc.value
                 ? 'bg-[var(--color-primary)] text-white'
-                : 'bg-white text-[var(--color-text)] border border-[var(--color-border)]'
+                : 'bg-[var(--color-surface)] text-[var(--color-text)] border border-[var(--color-border)]'
             }`}
           >
             {loc.label}
@@ -228,7 +228,7 @@ function PantryPageInner() {
                         key={item.id}
                         type="button"
                         onClick={() => handleOpenEdit(item)}
-                        className="bg-white rounded-2xl p-3 border border-[var(--color-border)] text-left hover:border-[var(--color-primary)] transition-colors"
+                        className="bg-[var(--color-surface)] rounded-2xl p-3 border border-[var(--color-border)] text-left hover:border-[var(--color-primary)] transition-colors"
                         initial={{ opacity: 0, y: 8 }}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ delay: i * 0.04, duration: 0.25 }}


### PR DESCRIPTION
## Summary
- `getExpiryBadge()`: replaced `bg-red-400/bg-yellow-300/bg-green-200` with `bg-[var(--color-expired)]/bg-[var(--color-expiring)]/bg-[var(--color-fresh)]` semantic tokens
- Inactive filter chip: `bg-white` → `bg-[var(--color-surface)]`
- Item card container: `bg-white` → `bg-[var(--color-surface)]`

**Note:** Depends on #76 (semantic token definitions) being merged first.

## Test plan
- [ ] `cd nextjs && npx tsc --noEmit` exits 0
- [ ] Switch themes — pantry expiry badges change color with theme
- [ ] No `bg-white`, `bg-red-400`, `bg-yellow-300`, or `bg-green-200` remain in file

Closes #77