### PR TITLE
fix: replace hardcoded rgba/hex in RecipeBook and HeroHome (#80)

### DIFF
--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -191,21 +191,21 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             label: 'Use Soon',
             detail: expiringCount > 0 ? `${expiringCount} item${expiringCount > 1 ? 's' : ''}` : 'All fresh!',
             href: '/pantry',
-            gradient: 'linear-gradient(135deg, #FFB7C5 0%, #FF8FAB 100%)',
+            gradient: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%)',
           },
           {
             emoji: '📷',
             label: 'Scan',
             detail: 'Receipt',
             href: '/pantry?add=scan',
-            gradient: 'linear-gradient(135deg, #B5D5F5 0%, #7EC8F0 100%)',
+            gradient: 'linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-dark) 100%)',
           },
           {
             emoji: '✨',
             label: 'Ask',
             detail: 'Bubbles',
             href: '/chat',
-            gradient: 'linear-gradient(135deg, #C9B5E8 0%, #9B7DD4 100%)',
+            gradient: 'linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-accent-dark) 100%)',
           },
         ].map((card, i) => (
           <FadeInView key={card.href} delay={0.35 + i * 0.08}>

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -222,7 +222,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
         className="relative rounded-2xl overflow-hidden border border-[var(--color-border)]"
         style={{
           background: 'var(--color-surface)',
-          boxShadow: '0 4px 24px rgba(255,183,197,0.15)',
+          boxShadow: '0 4px 24px color-mix(in srgb, var(--color-primary) 15%, transparent)',
           minHeight: '520px',
         }}
       >
@@ -425,9 +425,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
               <div
                 className="mx-4 mt-2 px-3 py-2 rounded-xl text-sm flex items-center justify-between"
                 style={{
-                  background: 'rgba(255,154,162,0.15)',
-                  border: '1px solid rgba(255,154,162,0.4)',
-                  color: '#4a4a4a',
+                  background: 'var(--color-bg)',
+                  border: '1px solid var(--color-border)',
+                  color: 'var(--color-text)',
                   fontFamily: 'Nunito, sans-serif',
                 }}
                 role="alert"
@@ -436,7 +436,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 <button
                   onClick={() => setErrorMessage(null)}
                   className="ml-2 hover:opacity-70 transition-opacity"
-                  style={{ color: '#ff9aa2' }}
+                  style={{ color: 'var(--color-primary-dark)' }}
                   aria-label="Dismiss error"
                 >
                   ✕


### PR DESCRIPTION
## Summary
**RecipeBook.tsx:**
- Card shadow: `rgba(255,183,197,0.15)` → `color-mix(in srgb, var(--color-primary) 15%, transparent)`
- Error banner: `rgba(255,154,162,0.15/0.4)` bg/border → `var(--color-bg)` / `var(--color-border)`
- Error dismiss button: `#ff9aa2` → `var(--color-primary-dark)`

**HeroHome.tsx:**
- 3 action card hardcoded gradients → `linear-gradient` using `--color-primary/accent/primary-dark/accent-dark` tokens so all 5 themes produce distinct gradient colors

## Test plan
- [ ] `cd nextjs && npx tsc --noEmit` exits 0
- [ ] Switch to Yuzu theme — home action cards show yellow/teal gradients (not sakura pink)
- [ ] Switch to Mint theme — home action cards show mint/peach gradients
- [ ] No hardcoded hex or rgba sakura values remain in either file

Closes #80