### PR TITLE
fix: replace hardcoded hex and opacity modifier violations in chat (#78)

### DIFF
--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -125,7 +125,7 @@ export default function ChatPage() {
               <button
                 type="button"
                 onClick={startNewChat}
-                className="text-xs font-semibold text-[var(--color-primary-dark)] bg-[var(--color-primary)]/10 px-3 py-1.5 rounded-full hover:bg-[var(--color-primary)]/20 transition-colors"
+                className="text-xs font-semibold text-[var(--color-primary-dark)] bg-[var(--color-surface)] px-3 py-1.5 rounded-full hover:bg-[var(--color-border)] transition-colors"
               >
                 New Chat
               </button>
@@ -137,9 +137,9 @@ export default function ChatPage() {
 
       {/* AI unavailable warning */}
       {!aiAvailable && (
-        <div className="mx-4 mt-3 px-4 py-2.5 bg-[#FFF3E4] border border-[#FFD4A3] rounded-xl flex items-center gap-2 text-sm">
+        <div className="mx-4 mt-3 px-4 py-2.5 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl flex items-center gap-2 text-sm">
           <span>⚠️</span>
-          <span className="text-[#8B5E2B]">
+          <span className="text-[var(--color-text)]">
             AI is unavailable. Check your Gemini API key or start Ollama.
           </span>
         </div>
@@ -191,7 +191,7 @@ export default function ChatPage() {
                   key={s}
                   type="button"
                   onClick={() => handleSuggestionClick(s)}
-                  className="bg-[var(--color-primary)]/10 text-[var(--color-text)] text-sm font-medium px-4 py-2 rounded-full border border-[var(--color-border)] hover:bg-[var(--color-primary)]/20 transition-colors"
+                  className="bg-[var(--color-surface)] text-[var(--color-text)] text-sm font-medium px-4 py-2 rounded-full border border-[var(--color-border)] hover:bg-[var(--color-border)] transition-colors"
                 >
                   {s}
                 </button>
@@ -211,7 +211,7 @@ export default function ChatPage() {
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             disabled={isStreaming}
-            className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] text-sm disabled:opacity-50"
+            className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] text-sm disabled:opacity-50"
           />
           <RotatingPlaceholder visible={!input && !isStreaming && !hasMessages} />
         </div>


### PR DESCRIPTION
## Summary
- AI-unavailable banner: 3 hardcoded hex values → semantic token references (`--color-surface`, `--color-border`, `--color-text`)
- Chat input: `bg-white` → `bg-[var(--color-surface)]`
- New Chat button: `bg-[var(--color-primary)]/10` → `bg-[var(--color-surface)] hover:bg-[var(--color-border)]`
- Suggestion chips: `/10`/`/20` opacity modifier violations → flat named token fills

## Test plan
- [ ] `cd nextjs && npx tsc --noEmit` exits 0
- [ ] Switch themes — chat page colors respond (banner, input, chips all change)
- [ ] No `#FFF3E4`, `#FFD4A3`, `#8B5E2B`, `bg-white`, or `/10`/`/20` opacity modifiers on CSS vars remain

Closes #78