### PR TITLE
feat: recipe icon button containers and tags pill chips (#82, #83)

### DIFF
--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -359,6 +359,18 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   {selectedRecipe.description}
                 </p>
               )}
+              {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {selectedRecipe.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
               <div className="flex flex-wrap gap-1.5 mt-2">
                 {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
                 {totalTime && <MetaChip label={totalTime} />}
@@ -373,7 +385,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 <button
                   onClick={handleFavorite}
                   disabled={mutating}
-                  className="text-lg leading-none px-1 hover:scale-110 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
                   title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
                 >
@@ -382,7 +394,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 <button
                   onClick={() => setEditOpen(true)}
                   disabled={mutating}
-                  className="text-lg leading-none px-1 hover:scale-110 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Edit recipe"
                   title="Edit recipe"
                 >
@@ -391,7 +403,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 <button
                   onClick={() => setDeleteOpen(true)}
                   disabled={mutating}
-                  className="text-lg leading-none px-1 hover:scale-110 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                   aria-label="Delete recipe"
                   title="Delete recipe"
                 >


### PR DESCRIPTION
## Summary
**Issue #82 — Icon button containers:**
Wraps ✏️/🤍/🗑️ action buttons in 32px \`rounded-xl\` bordered containers with \`hover:border-[var(--color-primary)]\` state. Buttons were previously bare emoji text.

**Issue #83 — Tags pill chips:**
Renders \`recipe.tags\` as \`rounded-full\` pill chips in the recipe detail header. Tags were stored and indexed (used in search ranking) but never displayed in the UI. Note: buttons and tags are in \`RecipeBook.tsx\`, not \`RecipePage.tsx\` — the components are co-located there.

## Test plan
- [ ] \`cd nextjs && npx tsc --noEmit\` exits 0
- [ ] Recipe detail: edit/favorite/delete buttons have visible rounded bordered containers
- [ ] Hover over action buttons — border changes to primary color
- [ ] Recipe with tags: chips appear in the header area
- [ ] Recipe without tags: no empty row rendered

Closes #82
Closes #83