### PR TITLE
feat: wire PageTransition for route animations (#86)

### DIFF
--- a/nextjs/src/app/layout.tsx
+++ b/nextjs/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Nunito, Quicksand } from "next/font/google";
 import { Providers } from "@/components/Providers";
 import BottomNav from "@/components/layout/BottomNav";
+import PageTransition from "@/components/ui/PageTransition";
 import "./globals.css";
 
 const nunito = Nunito({
@@ -37,7 +38,7 @@ export default function RootLayout({
       </head>
       <body className="min-h-screen bg-[var(--color-bg)]" style={{ fontFamily: 'Nunito, sans-serif' }}>
         <Providers>
-          <main className="pb-20">{children}</main>
+          <main className="pb-20"><PageTransition>{children}</PageTransition></main>
           <BottomNav />
         </Providers>
       </body>

--- a/nextjs/src/components/ui/PageTransition.tsx
+++ b/nextjs/src/components/ui/PageTransition.tsx
@@ -1,21 +1,18 @@
 'use client'
-
+import { usePathname } from 'next/navigation'
 import { AnimatePresence, motion } from 'framer-motion'
 
-interface PageTransitionProps {
-  children: React.ReactNode
-  className?: string
-}
-
-export default function PageTransition({ children, className }: PageTransitionProps) {
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
   return (
     <AnimatePresence mode="wait">
       <motion.div
-        className={className}
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        exit={{ opacity: 0 }}
-        transition={{ duration: 0.3 }}
+        key={pathname}
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -4 }}
+        transition={{ duration: 0.2, ease: 'easeOut' }}
+        style={{ minHeight: '100%' }}
       >
         {children}
       </motion.div>


### PR DESCRIPTION
Wires the existing PageTransition component into the root layout. Uses key={pathname} on motion.div (not AnimatePresence) so exit animations fire correctly on route change. Closes #86.