### PR TITLE
feat: rotateY card flip + dedicated category palette tokens (#89, #110)

### DIFF
--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -25,6 +25,13 @@
     --color-expiring-text: #7B5A00;
     --color-fresh: #DCFCE7;
     --color-fresh-text: #166534;
+    /* Category palette tokens — pantry card tinting */
+    --color-cat-produce: #d1fae5;
+    --color-cat-dairy: #fef3c7;
+    --color-cat-meat: #fce7f3;
+    --color-cat-frozen: #e0e7ff;
+    --color-cat-beverage: #e0f2fe;
+    --color-cat-snack: #fdf4ff;
   }
 
   /* Theme palettes — applied via data-theme attribute on <html> */
@@ -52,6 +59,12 @@
     --color-muted: #7A9B8A;
     --color-primary-dark: #6DC8A8;
     --color-accent-dark: #FF8C73;
+    --color-cat-produce: #bbf7d0;
+    --color-cat-dairy: #fef9c3;
+    --color-cat-meat: #fce7f3;
+    --color-cat-frozen: #e0e7ff;
+    --color-cat-beverage: #bae6fd;
+    --color-cat-snack: #f3e8ff;
   }
 
   /* Lavender: purple + butter yellow */
@@ -65,6 +78,12 @@
     --color-muted: #8A7A9B;
     --color-primary-dark: #9B7DD4;
     --color-accent-dark: #FFCA5A;
+    --color-cat-produce: #d1fae5;
+    --color-cat-dairy: #fef3c7;
+    --color-cat-meat: #fce7f3;
+    --color-cat-frozen: #ddd6fe;
+    --color-cat-beverage: #e0f2fe;
+    --color-cat-snack: #fdf4ff;
   }
 
   /* Yuzu: warm yellow + teal */

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -24,17 +24,17 @@ interface PantryItem {
 }
 
 const CATEGORY_BG: Record<string, string> = {
-  produce: 'var(--color-fresh)',
-  dairy: 'var(--color-expiring)',
-  frozen: 'var(--color-border)',
-  meat: 'var(--color-expired)',
-  seafood: 'var(--color-expired)',
-  beverages: 'var(--color-accent)',
+  produce: 'var(--color-cat-produce)',
+  dairy: 'var(--color-cat-dairy)',
+  frozen: 'var(--color-cat-frozen)',
+  meat: 'var(--color-cat-meat)',
+  seafood: 'var(--color-cat-meat)',
+  beverages: 'var(--color-cat-beverage)',
   condiments: 'var(--color-surface)',
   pantry: 'var(--color-surface)',
   dry_goods: 'var(--color-surface)',
   canned: 'var(--color-surface)',
-  snacks: 'var(--color-accent)',
+  snacks: 'var(--color-cat-snack)',
   other: 'var(--color-surface)',
 }
 

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -42,6 +42,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   const [selectedId, setSelectedId] = useState<string | null>(
     recipes.length > 0 ? recipes[0].id : null,
   )
+  const [flippedId, setFlippedId] = useState<string | null>(null)
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
@@ -285,28 +286,59 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                       {search ? `No results for "${search}"` : 'No recipes yet'}
                     </li>
                   ) : (
-                    filteredRecipes.map((r) => {
-                      const isActive = r.id === selectedId
-                      return (
+                    filteredRecipes.map((r) => (
                         <li key={r.id}>
-                          <button
-                            onClick={() => handleSelect(r.id)}
-                            className="w-full text-left px-4 py-3 text-sm transition-colors"
-                            style={{
-                              background: isActive ? 'var(--color-bg)' : 'transparent',
-                              borderLeft: `3px solid ${isActive ? 'var(--color-primary)' : 'transparent'}`,
-                              fontFamily: 'Nunito, sans-serif',
-                              fontWeight: isActive ? 700 : 400,
-                              color: isActive
-                                ? 'var(--color-text)'
-                                : 'var(--color-muted)',
-                            }}
-                          >
-                            <span className="line-clamp-2">{r.title}</span>
-                          </button>
+                          <div style={{ perspective: '1200px' }} className="cursor-pointer px-2 py-1.5">
+                            <motion.div
+                              style={{ transformStyle: 'preserve-3d', position: 'relative', willChange: 'transform', minHeight: '64px' }}
+                              animate={{ rotateY: flippedId === r.id ? 180 : 0 }}
+                              transition={{ type: 'spring', stiffness: 380, damping: 32 }}
+                              onClick={() => setFlippedId(flippedId === r.id ? null : r.id)}
+                            >
+                              {/* Front face */}
+                              <div
+                                style={{ backfaceVisibility: 'hidden' }}
+                                className="p-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)]"
+                              >
+                                <p className="text-sm font-semibold text-[var(--color-text)] line-clamp-2" style={{ fontFamily: 'Nunito, sans-serif' }}>{r.title}</p>
+                                <div className="flex gap-1 mt-1 flex-wrap">
+                                  {r.cuisine && <MetaChip label={r.cuisine} />}
+                                  {r.prep_time_minutes && <MetaChip label={`${r.prep_time_minutes}m`} />}
+                                </div>
+                              </div>
+                              {/* Back face */}
+                              <div
+                                style={{
+                                  backfaceVisibility: 'hidden',
+                                  transform: 'rotateY(180deg)',
+                                  position: 'absolute',
+                                  top: 0,
+                                  right: 0,
+                                  bottom: 0,
+                                  left: 0,
+                                }}
+                                className="p-2 rounded-xl border border-[var(--color-primary)] bg-[var(--color-bg)] overflow-hidden"
+                              >
+                                <p className="text-xs font-semibold text-[var(--color-primary-dark)] mb-1">Ingredients</p>
+                                <ul className="text-xs text-[var(--color-text)] space-y-0.5">
+                                  {r.ingredients?.slice(0, 4).map((ing, i) => (
+                                    <li key={i}>• {typeof ing === 'string' ? ing : (ing as { text?: string; name?: string }).text ?? (ing as { text?: string; name?: string }).name ?? ''}</li>
+                                  ))}
+                                  {(r.ingredients?.length ?? 0) > 4 && (
+                                    <li className="text-[var(--color-muted)]">+{r.ingredients!.length - 4} more</li>
+                                  )}
+                                </ul>
+                                <button
+                                  className="mt-1.5 text-xs text-[var(--color-primary-dark)] underline"
+                                  onClick={(e) => { e.stopPropagation(); handleSelect(r.id) }}
+                                >
+                                  Open recipe →
+                                </button>
+                              </div>
+                            </motion.div>
+                          </div>
                         </li>
-                      )
-                    })
+                      ))
                   )}
                 </ul>
 


### PR DESCRIPTION
## Changes

**rotateY spring flip (#89):** Adds a physical card flip to recipe sidebar list items. Clicking a card flips it (rotateY spring, stiffness 380 damping 32) to show a 4-ingredient preview and an 'Open recipe →' button. Clicking again flips back. Uses preserve-3d, backfaceVisibility: hidden, willChange: transform.

**Category palette tokens (#110):** Adds `--color-cat-*` tokens to globals.css (root + per-theme overrides) so pantry category tints no longer reuse expiry badge tokens. Produce/dairy/meat cards now have semantically correct pastel backgrounds that don't conflict with the expiry status visual language.

Closes #89. Closes #110.