### PR TITLE
feat: render thumbnail_url on recipe cards and detail view (#90)

### DIFF
--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -303,6 +303,14 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                             }}
                           >
                             <span className="line-clamp-2">{r.title}</span>
+                            {r.thumbnail_url && (
+                              <img
+                                src={r.thumbnail_url}
+                                alt={r.title}
+                                className="w-full h-16 object-cover rounded-lg mt-1.5"
+                                onError={(e) => { e.currentTarget.style.display = 'none' }}
+                              />
+                            )}
                           </button>
                         </li>
                       )

--- a/nextjs/src/components/recipes/RecipePage.tsx
+++ b/nextjs/src/components/recipes/RecipePage.tsx
@@ -43,9 +43,23 @@ const FIRST_LINE_OFFSET = 4 // px — pad-top so first text line sits on first r
 
 export default function RecipeDetail({ recipe }: RecipeDetailProps) {
   return (
-    <div
-      className="px-5 py-4 text-sm text-[var(--color-text)]"
-      style={{
+    <>
+      {recipe.thumbnail_url && (
+        <div className="w-full h-36 rounded-2xl overflow-hidden mb-3 mx-5" style={{ width: 'calc(100% - 2.5rem)' }}>
+          <img
+            src={recipe.thumbnail_url}
+            alt={recipe.title}
+            className="w-full h-full object-cover"
+            onError={(e) => {
+              const parent = e.currentTarget.parentElement as HTMLDivElement | null
+              if (parent) parent.style.display = 'none'
+            }}
+          />
+        </div>
+      )}
+      <div
+        className="px-5 py-4 text-sm text-[var(--color-text)]"
+        style={{
         fontFamily: 'Nunito, sans-serif',
         backgroundImage:
           'repeating-linear-gradient(transparent, transparent 27px, var(--color-border) 27px, var(--color-border) 28px)',
@@ -150,5 +164,6 @@ export default function RecipeDetail({ recipe }: RecipeDetailProps) {
         </div>
       )}
     </div>
+    </>
   )
 }


### PR DESCRIPTION
Renders thumbnail_url in two places: the recipe sidebar card (below title, above meta chips) and the RecipePage detail header (full-width h-36 hero above ingredients). Both use plain img with onError fallback — thumbnail_url is user-provided/external so next/image is not used. Closes #90.