### PR TITLE
feat: book page-turn swipe for recipe navigation (#89 fix)

### DIFF
--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect, useMemo } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence, type PanInfo } from 'framer-motion'
 import RecipeDetail, { type Recipe } from './RecipePage'
 import RecipeSearchBar from './RecipeSearchBar'
 import BubblesMascot from '@/components/ui/BubblesMascot'
@@ -36,12 +36,45 @@ function MetaChip({ label }: { label: string }) {
   )
 }
 
+// Page-turn animation variants — book-page-curl feel
+const pageVariants = {
+  enter: (dir: number) => ({
+    x: dir > 0 ? '60%' : '-60%',
+    rotateY: dir > 0 ? -15 : 15,
+    opacity: 0,
+    scale: 0.92,
+  }),
+  center: {
+    x: 0,
+    rotateY: 0,
+    opacity: 1,
+    scale: 1,
+  },
+  exit: (dir: number) => ({
+    x: dir > 0 ? '-60%' : '60%',
+    rotateY: dir > 0 ? 12 : -12,
+    opacity: 0,
+    scale: 0.92,
+  }),
+}
+
+const pageTransition = {
+  type: 'spring' as const,
+  stiffness: 260,
+  damping: 28,
+  mass: 0.8,
+}
+
+const SWIPE_THRESHOLD = 50
+const VELOCITY_THRESHOLD = 300
+
 export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   const [search, setSearch] = useState('')
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [selectedId, setSelectedId] = useState<string | null>(
     recipes.length > 0 ? recipes[0].id : null,
   )
+  const [direction, setDirection] = useState<1 | -1>(1)
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [importOpen, setImportOpen] = useState(false)
@@ -84,11 +117,42 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
 
   const selectedRecipe = recipesWithOverrides.find((r) => r.id === selectedId) ?? recipesWithOverrides[0] ?? null
 
+  const currentIndex = filteredRecipes.findIndex((r) => r.id === selectedId)
+
+  const goNext = useCallback(() => {
+    if (currentIndex < filteredRecipes.length - 1) {
+      setDirection(1)
+      setSelectedId(filteredRecipes[currentIndex + 1].id)
+      setSidebarOpen(false)
+    }
+  }, [currentIndex, filteredRecipes])
+
+  const goPrev = useCallback(() => {
+    if (currentIndex > 0) {
+      setDirection(-1)
+      setSelectedId(filteredRecipes[currentIndex - 1].id)
+      setSidebarOpen(false)
+    }
+  }, [currentIndex, filteredRecipes])
+
+  const handleDragEnd = useCallback(
+    (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+      if (info.offset.x < -SWIPE_THRESHOLD || info.velocity.x < -VELOCITY_THRESHOLD) {
+        goNext()
+      } else if (info.offset.x > SWIPE_THRESHOLD || info.velocity.x > VELOCITY_THRESHOLD) {
+        goPrev()
+      }
+    },
+    [goNext, goPrev],
+  )
+
   const handleSearch = useCallback((q: string) => {
     setSearch(q)
   }, [])
 
   const handleSelect = (id: string) => {
+    const newIndex = filteredRecipes.findIndex((r) => r.id === id)
+    setDirection(newIndex > currentIndex ? 1 : -1)
     setSelectedId(id)
     setSidebarOpen(false)
   }
@@ -297,20 +361,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                               borderLeft: `3px solid ${isActive ? 'var(--color-primary)' : 'transparent'}`,
                               fontFamily: 'Nunito, sans-serif',
                               fontWeight: isActive ? 700 : 400,
-                              color: isActive
-                                ? 'var(--color-text)'
-                                : 'var(--color-muted)',
+                              color: isActive ? 'var(--color-text)' : 'var(--color-muted)',
                             }}
                           >
                             <span className="line-clamp-2">{r.title}</span>
-                            {r.thumbnail_url && (
-                              <img
-                                src={r.thumbnail_url}
-                                alt={r.title}
-                                className="w-full h-16 object-cover rounded-lg mt-1.5"
-                                onError={(e) => { e.currentTarget.style.display = 'none' }}
-                              />
-                            )}
                           </button>
                         </li>
                       )
@@ -467,15 +521,54 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
             {/* Divider */}
             <div className="h-px flex-shrink-0" style={{ background: 'var(--color-border)' }} />
 
-            {/* Scrollable recipe body */}
-            <div className="flex-1 overflow-y-auto">
-              <AnimatePresence mode="wait">
+            {/* Page indicator + nav arrows */}
+            {filteredRecipes.length > 1 && (
+              <div className="flex items-center justify-between px-5 py-1.5 flex-shrink-0" style={{ borderBottom: '1px solid var(--color-border)' }}>
+                <button
+                  onClick={goPrev}
+                  disabled={currentIndex === 0}
+                  className="text-[var(--color-primary-dark)] text-lg px-1 disabled:opacity-30 active:scale-90 transition-transform"
+                  aria-label="Previous recipe"
+                >
+                  ‹
+                </button>
+                <span className="text-xs text-[var(--color-muted)]" style={{ fontFamily: 'Nunito, sans-serif' }}>
+                  {currentIndex + 1} / {filteredRecipes.length}
+                </span>
+                <button
+                  onClick={goNext}
+                  disabled={currentIndex === filteredRecipes.length - 1}
+                  className="text-[var(--color-primary-dark)] text-lg px-1 disabled:opacity-30 active:scale-90 transition-transform"
+                  aria-label="Next recipe"
+                >
+                  ›
+                </button>
+              </div>
+            )}
+
+            {/* Scrollable recipe body — book page-turn animation */}
+            <div className="flex-1 overflow-hidden relative" style={{ perspective: '1200px' }}>
+              <AnimatePresence mode="wait" custom={direction}>
                 <motion.div
                   key={selectedRecipe.id}
-                  initial={{ opacity: 0, y: 6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -6 }}
-                  transition={{ duration: 0.2 }}
+                  custom={direction}
+                  variants={pageVariants}
+                  initial="enter"
+                  animate="center"
+                  exit="exit"
+                  transition={pageTransition}
+                  drag="x"
+                  dragConstraints={{ left: 0, right: 0 }}
+                  dragElastic={0.1}
+                  onDragEnd={handleDragEnd}
+                  style={{
+                    height: '100%',
+                    overflowY: 'auto',
+                    transformOrigin: direction > 0 ? 'left center' : 'right center',
+                    cursor: 'grab',
+                    willChange: 'transform',
+                  }}
+                  whileDrag={{ cursor: 'grabbing' }}
                 >
                   <RecipeDetail recipe={selectedRecipe} />
                 </motion.div>

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -303,6 +303,14 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                             }}
                           >
                             <span className="line-clamp-2">{r.title}</span>
+                            {r.thumbnail_url && (
+                              <img
+                                src={r.thumbnail_url}
+                                alt={r.title}
+                                className="w-full h-16 object-cover rounded-lg mt-1.5"
+                                onError={(e) => { e.currentTarget.style.display = 'none' }}
+                              />
+                            )}
                           </button>
                         </li>
                       )

--- a/nextjs/src/components/recipes/RecipePage.tsx
+++ b/nextjs/src/components/recipes/RecipePage.tsx
@@ -43,9 +43,23 @@ const FIRST_LINE_OFFSET = 4 // px — pad-top so first text line sits on first r
 
 export default function RecipeDetail({ recipe }: RecipeDetailProps) {
   return (
-    <div
-      className="px-5 py-4 text-sm text-[var(--color-text)]"
-      style={{
+    <>
+      {recipe.thumbnail_url && (
+        <div className="w-full h-36 rounded-2xl overflow-hidden mb-3 mx-5" style={{ width: 'calc(100% - 2.5rem)' }}>
+          <img
+            src={recipe.thumbnail_url}
+            alt={recipe.title}
+            className="w-full h-full object-cover"
+            onError={(e) => {
+              const parent = e.currentTarget.parentElement as HTMLDivElement | null
+              if (parent) parent.style.display = 'none'
+            }}
+          />
+        </div>
+      )}
+      <div
+        className="px-5 py-4 text-sm text-[var(--color-text)]"
+        style={{
         fontFamily: 'Nunito, sans-serif',
         backgroundImage:
           'repeating-linear-gradient(transparent, transparent 27px, var(--color-border) 27px, var(--color-border) 28px)',
@@ -150,5 +164,6 @@ export default function RecipeDetail({ recipe }: RecipeDetailProps) {
         </div>
       )}
     </div>
+    </>
   )
 }


### PR DESCRIPTION
Fixes the misplaced sidebar flip from PR #111 — reverts sidebar list items to plain buttons. Replaces the fade transition on the main recipe panel with a book-page-curl animation: entering pages slide+rotateY in from the edge, exiting pages curl away. Swipe left/right on the recipe body to navigate. Arrow buttons + page counter for tap navigation. Closes #89.