### PR TITLE
feat: full-bleed hero thumbnail with title overlay (#112 layout fix)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/ingest.py
+++ b/ai-service/bubbly_chef/api/routes/ingest.py
@@ -63,7 +63,10 @@ async def ingest_recipe_url(
         from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
 
         recipe = await ingest_recipe_from_url(request.url)
-        logger.info(f"Recipe URL ingest success: user={user_id}, title={recipe.title!r}")
+        logger.info(
+            f"Recipe URL ingest success: user={user_id}, title={recipe.title!r}, "
+            f"thumbnail_url={recipe.thumbnail_url!r}"
+        )
         return recipe
 
     except ValueError as e:

--- a/ai-service/bubbly_chef/services/recipe_url_ingestor.py
+++ b/ai-service/bubbly_chef/services/recipe_url_ingestor.py
@@ -32,8 +32,12 @@ async def httpx_get(url: str) -> str:
     """Fetch raw HTML from a URL. Extracted so tests can patch it."""
     headers = {
         "User-Agent": (
-            "Mozilla/5.0 (compatible; BubblyChef/1.0; +https://bubbly-chef.app)"
-        )
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/124.0.0.0 Safari/537.36"
+        ),
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
     }
     async with httpx.AsyncClient(follow_redirects=True, timeout=15.0) as c:
         r = await c.get(url, headers=headers)
@@ -83,6 +87,7 @@ def _scraper_to_recipe_card(scraper: Any, url: str) -> RecipeCard:  # noqa: ANN4
     yields_str: str | None = _safe(scraper.yields)
     description: str | None = _safe(scraper.description)
     image: str | None = _safe(scraper.image)
+    logger.info(f"[scraper] title={title!r} image={image!r}")
 
     return RecipeCard(
         title=title,
@@ -145,6 +150,8 @@ Return a JSON object with these fields:
 - source_type: "url"
 - source_url: "{source_url}"
 
+Do NOT include image_url — omit it entirely or set it to null.
+
 URL: {source_url}
 """
 
@@ -202,16 +209,24 @@ async def ingest_recipe_from_url(url: str) -> RecipeCard:
     logger.info(f"Attempting AI extraction for {url}")
     if html is not None:
         prompt = _AI_EXTRACTION_PROMPT.format(source_url=url, html=html[:8000])
+        no_fetch = False
     else:
         prompt = _AI_NO_FETCH_PROMPT.format(source_url=url)
+        no_fetch = True
     ai_manager = get_ai_manager()
     result = await ai_manager.complete(prompt=prompt, response_schema=RecipeCard)
 
     if isinstance(result, RecipeCard):
         result.source_url = url
         result.source_type = "url"
-        if result.image_url and not result.thumbnail_url:
-            result.thumbnail_url = result.image_url
+        if no_fetch:
+            # Gemini hallucinates CDN URLs for blocked sites — always invalid, never serve them
+            result.image_url = None
+            result.thumbnail_url = None
+        else:
+            if result.image_url and not result.thumbnail_url:
+                result.thumbnail_url = result.image_url
+        logger.info(f"[ai] title={result.title!r} image_url={result.image_url!r} thumbnail_url={result.thumbnail_url!r}")
         return result
 
     # Shouldn't happen but guard anyway

--- a/ai-service/bubbly_chef/services/recipe_url_ingestor.py
+++ b/ai-service/bubbly_chef/services/recipe_url_ingestor.py
@@ -90,6 +90,7 @@ def _scraper_to_recipe_card(scraper: Any, url: str) -> RecipeCard:  # noqa: ANN4
         source_url=url,
         source_type="url",
         image_url=image,
+        thumbnail_url=image,
         total_time_minutes=total_time,
         servings=_parse_servings(yields_str),
         ingredients=[_parse_ingredient(i) for i in raw_ingredients],
@@ -117,6 +118,7 @@ Rules:
 - servings: integer or null
 - cuisine: string or null (e.g. "Italian", "Mexican")
 - dietary_tags: list of strings (e.g. ["vegan", "gluten-free"])
+- image_url: string or null (the recipe's primary image URL, if present in the page)
 - source_type: "url"
 - source_url: "{source_url}"
 
@@ -208,6 +210,8 @@ async def ingest_recipe_from_url(url: str) -> RecipeCard:
     if isinstance(result, RecipeCard):
         result.source_url = url
         result.source_type = "url"
+        if result.image_url and not result.thumbnail_url:
+            result.thumbnail_url = result.image_url
         return result
 
     # Shouldn't happen but guard anyway

--- a/docs/2026-05-19-recipe-import-pipeline-retro.md
+++ b/docs/2026-05-19-recipe-import-pipeline-retro.md
@@ -1,0 +1,83 @@
+# Recipe Import Pipeline — Retro
+
+## Summary
+
+Investigation into the recipe URL import pipeline covering scraper behavior, image handling, duplicate detection, and site compatibility. AllRecipes and Serious Eats block bot scrapers entirely — Gemini handles extraction for those sites. BBC Good Food, NYT Cooking, and Food Network work via recipe-scrapers and return real images. Proxy-based image storage was attempted but blocked by CDN hotlink protection.
+
+---
+
+## Scraper Tier Behavior
+
+Three-tier extraction strategy in `ai-service/bubbly_chef/services/recipe_url_ingestor.py`:
+
+| Tier | Method | Notes |
+|---|---|---|
+| 1 | `scrape_me` (recipe-scrapers strict) | Internal fetch — blocked by AllRecipes/Serious Eats |
+| 2 | `scrape_html` (supported_only=False) | Needs HTML from our httpx_get — also blocked if tier 1 is |
+| 3 | Gemini AI via AIManager | Always works, ~12-15s, no image for blocked sites |
+
+**Site compatibility:**
+
+| Site | Tier Used | Image Available |
+|---|---|---|
+| AllRecipes `/recipe/<id>/` | Gemini (403) | ❌ |
+| Serious Eats | Gemini (403) | ❌ |
+| BBC Good Food | recipe-scrapers strict | ✅ |
+| NYT Cooking | recipe-scrapers strict | ✅ |
+| Food Network | recipe-scrapers strict | ✅ |
+
+---
+
+## Image Handling
+
+**Root cause of missing images:** AllRecipes and Serious Eats return 403 on both `scrape_me` and `httpx_get`. Gemini (no-fetch path) hallucinates plausible-but-invalid CDN URLs — these return 400 when the browser tries to load them.
+
+**Fixes applied:**
+- `_AI_NO_FETCH_PROMPT` explicitly instructs Gemini to omit `image_url`
+- AI no-fetch result path forcibly nulls `image_url` and `thumbnail_url` regardless of what Gemini returns
+- `RecipeBook.tsx` uses `thumbError` state — on `onError`, falls back to plain title header instead of showing broken image
+- `thumbError` resets on `selectedId` change so navigating to a recipe with a real image works correctly
+
+**Server-side proxy attempt:** Added `proxyThumbnail()` in `POST /api/recipes` — fetches external image, uploads to Supabase Storage `recipe-images` bucket, stores public URL. AllRecipes CDN returns `400 text/html` even with Chrome UA — hotlink protection is token/referer-based, not UA-based. Proxy silently falls back to original URL on failure, never blocks save.
+
+**Conclusion:** For AllRecipes and Serious Eats, no image is the correct behavior. The plain header fallback is good UX.
+
+---
+
+## Duplicate Detection
+
+Added `source_url` uniqueness check in `POST /api/recipes` before insert:
+- Returns `409 { error: 'duplicate', existing_id, existing_title }`
+- `handleImportSave` in `RecipeBook.tsx` handles 409: closes modal, navigates to existing recipe, shows toast `"<title> is already in your book."` (auto-dismisses 5s)
+- No DB schema change needed — query is a simple `.eq('source_url', ...)` filter
+
+---
+
+## Debug Logging Added
+
+- `recipe_url_ingestor.py`: `[scraper]` log after Tier 1/2 success showing title + image
+- `recipe_url_ingestor.py`: `[ai]` log after Gemini extraction showing image_url + thumbnail_url
+- `ingest.py` route: success log now includes `thumbnail_url`
+- `api/recipes/route.ts`: `[import]` log shows title + both URL fields from AI service
+- `api/recipes/route.ts`: `[proxy]` logs show fetch status, content-type, buffer size, upload result
+- Both servers log to `/private/tmp/ai-service.log` and `/private/tmp/nextjs-dev.log`
+
+---
+
+## Other Changes
+
+**Import modal UX:** Plain site name text replaced with clickable pill chips (AllRecipes, Serious Eats, BBC Good Food, NYT Cooking, Food Network) opening in new tabs. Instruction copy updated to "Browse a site, copy the recipe URL, and paste it below."
+
+**Thumbnail hero layout:** `RecipeBook.tsx` shows 180px full-bleed hero with gradient title overlay when `thumbnail_url` is present and loads. Falls back to plain header on load failure.
+
+**Thumbnail preservation in import modal:** `RecipeImportModal.tsx` extracts `image_url` from raw AI response as `thumbnail_url` fallback before `Partial<Recipe>` cast drops it.
+
+---
+
+## References
+
+- `ai-service/bubbly_chef/services/recipe_url_ingestor.py`
+- `nextjs/src/app/api/recipes/route.ts`
+- `nextjs/src/app/api/recipes/import/route.ts`
+- `nextjs/src/components/recipes/RecipeImportModal.tsx`
+- `nextjs/src/components/recipes/RecipeBook.tsx`

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -16,6 +16,7 @@
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-kawaii": "^1.6.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"
       },
@@ -10178,6 +10179,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-kawaii": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/react-kawaii/-/react-kawaii-1.6.0.tgz",
+      "integrity": "sha512-cmz9zzuIEplDIPRrtW9MiQsszVZBRzFYFwfxbArskn+0qMLzTQJPq+6avkVDvvTHI9GzvnMc9HhVCwUq+KpJUg==",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -19,6 +19,7 @@
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-kawaii": "^1.6.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },

--- a/nextjs/src/app/api/recipes/import/route.ts
+++ b/nextjs/src/app/api/recipes/import/route.ts
@@ -9,7 +9,7 @@
  */
 
 import { NextResponse } from 'next/server'
-import { aiProxyJson } from '@/lib/api/ai-proxy'
+import { aiProxyFetch } from '@/lib/api/ai-proxy'
 
 export async function POST(request: Request): Promise<NextResponse> {
   let body: unknown
@@ -19,5 +19,25 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
   }
 
-  return aiProxyJson('/v1/ingest/recipe-url', body)
+  const res = await aiProxyFetch('/v1/ingest/recipe-url', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+
+  if (res instanceof NextResponse) return res
+
+  const data = await res.json() as Record<string, unknown>
+
+  if (!res.ok) {
+    console.log('[import] AI service error: status=%d detail=%s', res.status, data?.detail ?? data?.error)
+    return NextResponse.json(
+      { error: data?.detail ?? data?.error ?? 'AI service error' },
+      { status: res.status },
+    )
+  }
+
+  console.log('[import] AI service ok: title=%s thumbnail_url=%s image_url=%s',
+    data?.title, data?.thumbnail_url, data?.image_url)
+  return NextResponse.json(data)
 }

--- a/nextjs/src/app/api/recipes/route.ts
+++ b/nextjs/src/app/api/recipes/route.ts
@@ -1,5 +1,60 @@
 import { NextResponse } from 'next/server'
+import { createClient as createServiceClient } from '@supabase/supabase-js'
 import { requireAuth, errorResponse } from '@/lib/response-helpers'
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY!
+
+/**
+ * Fetch an external image URL and upload it to Supabase Storage.
+ * Returns the public Supabase URL, or null if anything fails.
+ * Keeps the file small by capping at 1 MB download.
+ */
+async function proxyThumbnail(externalUrl: string, userId: string): Promise<string | null> {
+  try {
+    const res = await fetch(externalUrl, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+      },
+      signal: AbortSignal.timeout(8000),
+    })
+    console.log('[proxy] fetch status=%d content-type=%s', res.status, res.headers.get('content-type'))
+    if (!res.ok) return null
+
+    const contentType = res.headers.get('content-type') ?? 'image/jpeg'
+    if (!contentType.startsWith('image/')) {
+      console.log('[proxy] non-image content-type: %s', contentType)
+      return null
+    }
+
+    const buffer = await res.arrayBuffer()
+    console.log('[proxy] buffer size=%d bytes', buffer.byteLength)
+    if (buffer.byteLength > 1_048_576) {
+      console.log('[proxy] image too large (%d bytes), skipping', buffer.byteLength)
+      return null
+    }
+
+    const ext = contentType.includes('webp') ? 'webp' : contentType.includes('png') ? 'png' : 'jpg'
+    const path = `${userId}/${Date.now()}.${ext}`
+
+    const sb = createServiceClient(SUPABASE_URL, SERVICE_ROLE_KEY)
+    const { error } = await sb.storage
+      .from('recipe-images')
+      .upload(path, buffer, { contentType, upsert: false })
+
+    if (error) {
+      console.log('[proxy] storage upload error: %s', error.message)
+      return null
+    }
+
+    const { data } = sb.storage.from('recipe-images').getPublicUrl(path)
+    console.log('[proxy] uploaded → %s', data.publicUrl)
+    return data.publicUrl
+  } catch (err) {
+    console.log('[proxy] exception: %s', err)
+    return null
+  }
+}
 
 export async function GET(request: Request) {
   const result = await requireAuth()
@@ -47,6 +102,31 @@ export async function POST(request: Request) {
 
   const body = await request.json()
 
+  // Duplicate detection — check for existing recipe with same source_url
+  if (body.source_url) {
+    const { data: existing } = await supabase
+      .from('recipes')
+      .select('id, title')
+      .eq('user_id', user.id)
+      .eq('source_url', body.source_url)
+      .maybeSingle()
+
+    if (existing) {
+      return NextResponse.json(
+        { error: 'duplicate', existing_id: existing.id, existing_title: existing.title },
+        { status: 409 },
+      )
+    }
+  }
+
+  // Proxy external thumbnail to Supabase Storage so hotlink-blocking CDNs don't break the image
+  let thumbnailUrl: string | null = body.thumbnail_url ?? null
+  if (thumbnailUrl && thumbnailUrl.startsWith('http')) {
+    const proxied = await proxyThumbnail(thumbnailUrl, user.id)
+    console.log('[recipes POST] thumbnail proxy: %s → %s', thumbnailUrl, proxied ?? 'failed (keeping original)')
+    if (proxied) thumbnailUrl = proxied
+  }
+
   const { data, error } = await supabase
     .from('recipes')
     .insert({
@@ -65,7 +145,7 @@ export async function POST(request: Request) {
       difficulty: body.difficulty,
       source_type: body.source_type || 'chat',
       source_title: body.source_title,
-      thumbnail_url: body.thumbnail_url,
+      thumbnail_url: thumbnailUrl,
       is_draft: body.is_draft || false,
       cuisine: body.cuisine,
       meal_type: body.meal_type,

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -84,6 +84,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   // Local optimistic overrides for favorite state — avoids full re-fetch on toggle
   const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, boolean>>({})
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [thumbError, setThumbError] = useState(false)
 
   useEffect(() => {
     if (!errorMessage) return
@@ -116,6 +117,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   }, [search, filteredRecipes])
 
   const selectedRecipe = recipesWithOverrides.find((r) => r.id === selectedId) ?? recipesWithOverrides[0] ?? null
+
+  // Reset hero image error state whenever the selected recipe changes
+  useEffect(() => { setThumbError(false) }, [selectedId])
 
   const currentIndex = filteredRecipes.findIndex((r) => r.id === selectedId)
 
@@ -233,8 +237,17 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
     })
     setMutating(false)
     setImportDraft(null)
+    if (res.status === 409) {
+      // Already saved — navigate to the existing recipe instead
+      const data = await res.json()
+      setImportOpen(false)
+      if (data.existing_id) setSelectedId(data.existing_id)
+      setErrorMessage(`"${data.existing_title ?? 'This recipe'}" is already in your book.`)
+      return
+    }
     if (res.ok) {
       const saved = await res.json()
+      setImportOpen(false)
       onMutate?.()
       setSelectedId(saved.id ?? null)
     }
@@ -405,8 +418,8 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
         {/* ─── Main recipe panel ─── */}
         {selectedRecipe ? (
           <div className="flex flex-col h-full">
-            {/* Recipe header — hero variant when thumbnail exists */}
-            {selectedRecipe.thumbnail_url ? (
+            {/* Recipe header — hero variant when thumbnail exists and loads successfully */}
+            {selectedRecipe.thumbnail_url && !thumbError ? (
               <div className="flex-shrink-0">
                 {/* Hero image with title overlay */}
                 <div className="relative w-full overflow-hidden" style={{ height: '180px' }}>
@@ -414,9 +427,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     src={selectedRecipe.thumbnail_url}
                     alt={selectedRecipe.title}
                     className="w-full h-full object-cover"
-                    onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).style.display = 'none'
-                    }}
+                    onError={() => setThumbError(true)}
                   />
                   {/* Gradient overlay — title sits on top */}
                   <div

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -405,94 +405,195 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
         {/* ─── Main recipe panel ─── */}
         {selectedRecipe ? (
           <div className="flex flex-col h-full">
-            {/* Recipe header */}
-            <div
-              className="px-5 pt-4 pb-3 flex-shrink-0"
-              style={{ paddingLeft: '40px' }} // clear the hamburger tab
-            >
-              <h2
-                className="text-xl font-extrabold text-[var(--color-text)] leading-tight"
-                style={{ fontFamily: 'Nunito, sans-serif' }}
-              >
-                {selectedRecipe.title}
-              </h2>
-              {selectedRecipe.description && (
-                <p className="text-xs text-[var(--color-muted)] mt-0.5 line-clamp-2">
-                  {selectedRecipe.description}
-                </p>
-              )}
-              {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
-                <div className="flex flex-wrap gap-1.5 mt-2">
-                  {selectedRecipe.tags.map((tag) => (
-                    <span
-                      key={tag}
-                      className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
+            {/* Recipe header — hero variant when thumbnail exists */}
+            {selectedRecipe.thumbnail_url ? (
+              <div className="flex-shrink-0">
+                {/* Hero image with title overlay */}
+                <div className="relative w-full overflow-hidden" style={{ height: '180px' }}>
+                  <img
+                    src={selectedRecipe.thumbnail_url}
+                    alt={selectedRecipe.title}
+                    className="w-full h-full object-cover"
+                    onError={(e) => {
+                      (e.currentTarget as HTMLImageElement).style.display = 'none'
+                    }}
+                  />
+                  {/* Gradient overlay — title sits on top */}
+                  <div
+                    className="absolute inset-0 flex flex-col justify-end px-4 pb-3"
+                    style={{
+                      background: 'linear-gradient(to top, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.18) 55%, transparent 100%)',
+                      paddingLeft: '44px', // clear hamburger tab
+                    }}
+                  >
+                    <h2
+                      className="text-lg font-extrabold text-white leading-tight line-clamp-2"
+                      style={{ fontFamily: 'Nunito, sans-serif', textShadow: '0 1px 4px rgba(0,0,0,0.4)' }}
                     >
-                      {tag}
-                    </span>
-                  ))}
+                      {selectedRecipe.title}
+                    </h2>
+                    {selectedRecipe.description && (
+                      <p className="text-xs text-white/80 mt-0.5 line-clamp-1">
+                        {selectedRecipe.description}
+                      </p>
+                    )}
+                  </div>
                 </div>
-              )}
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
-                {totalTime && <MetaChip label={totalTime} />}
-                {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
-                {selectedRecipe.servings && (
-                  <MetaChip label={`Serves ${selectedRecipe.servings}`} />
+
+                {/* Tags + chips + actions — below the hero */}
+                <div className="px-4 pt-2 pb-3" style={{ paddingLeft: '44px' }}>
+                  {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mb-2">
+                      {selectedRecipe.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
+                        >
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  <div className="flex flex-wrap gap-1.5 mb-2">
+                    {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
+                    {totalTime && <MetaChip label={totalTime} />}
+                    {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
+                    {selectedRecipe.servings && <MetaChip label={`Serves ${selectedRecipe.servings}`} />}
+                  </div>
+                  {/* Action buttons */}
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={handleFavorite}
+                      disabled={mutating}
+                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
+                      title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+                    >
+                      {selectedRecipe.is_favorite ? '❤️' : '🤍'}
+                    </button>
+                    <button
+                      onClick={() => setEditOpen(true)}
+                      disabled={mutating}
+                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      aria-label="Edit recipe"
+                      title="Edit recipe"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      onClick={() => setDeleteOpen(true)}
+                      disabled={mutating}
+                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      aria-label="Delete recipe"
+                      title="Delete recipe"
+                    >
+                      🗑️
+                    </button>
+                    <button
+                      onClick={() => setCookOpen(true)}
+                      className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
+                      style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
+                      aria-label="Cook this recipe"
+                      title="Cook it — deduct ingredients from pantry"
+                    >
+                      Cook it
+                    </button>
+                  </div>
+                  {deleteOpen && (
+                    <RecipeDeleteConfirm
+                      recipeTitle={selectedRecipe.title}
+                      onConfirm={handleDeleteConfirm}
+                      onCancel={() => setDeleteOpen(false)}
+                      deleting={mutating}
+                    />
+                  )}
+                </div>
+              </div>
+            ) : (
+              /* Plain header — no thumbnail */
+              <div
+                className="px-5 pt-4 pb-3 flex-shrink-0"
+                style={{ paddingLeft: '40px' }}
+              >
+                <h2
+                  className="text-xl font-extrabold text-[var(--color-text)] leading-tight"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  {selectedRecipe.title}
+                </h2>
+                {selectedRecipe.description && (
+                  <p className="text-xs text-[var(--color-muted)] mt-0.5 line-clamp-2">
+                    {selectedRecipe.description}
+                  </p>
+                )}
+                {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {selectedRecipe.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
+                  {totalTime && <MetaChip label={totalTime} />}
+                  {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
+                  {selectedRecipe.servings && (
+                    <MetaChip label={`Serves ${selectedRecipe.servings}`} />
+                  )}
+                </div>
+                <div className="flex items-center gap-2 mt-2">
+                  <button
+                    onClick={handleFavorite}
+                    disabled={mutating}
+                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
+                    title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+                  >
+                    {selectedRecipe.is_favorite ? '❤️' : '🤍'}
+                  </button>
+                  <button
+                    onClick={() => setEditOpen(true)}
+                    disabled={mutating}
+                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    aria-label="Edit recipe"
+                    title="Edit recipe"
+                  >
+                    ✏️
+                  </button>
+                  <button
+                    onClick={() => setDeleteOpen(true)}
+                    disabled={mutating}
+                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    aria-label="Delete recipe"
+                    title="Delete recipe"
+                  >
+                    🗑️
+                  </button>
+                  <button
+                    onClick={() => setCookOpen(true)}
+                    className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
+                    style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
+                    aria-label="Cook this recipe"
+                    title="Cook it — deduct ingredients from pantry"
+                  >
+                    Cook it
+                  </button>
+                </div>
+                {deleteOpen && (
+                  <RecipeDeleteConfirm
+                    recipeTitle={selectedRecipe.title}
+                    onConfirm={handleDeleteConfirm}
+                    onCancel={() => setDeleteOpen(false)}
+                    deleting={mutating}
+                  />
                 )}
               </div>
-
-              {/* Action buttons */}
-              <div className="flex items-center gap-2 mt-2">
-                <button
-                  onClick={handleFavorite}
-                  disabled={mutating}
-                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                  aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
-                  title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-                >
-                  {selectedRecipe.is_favorite ? '❤️' : '🤍'}
-                </button>
-                <button
-                  onClick={() => setEditOpen(true)}
-                  disabled={mutating}
-                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                  aria-label="Edit recipe"
-                  title="Edit recipe"
-                >
-                  ✏️
-                </button>
-                <button
-                  onClick={() => setDeleteOpen(true)}
-                  disabled={mutating}
-                  className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                  aria-label="Delete recipe"
-                  title="Delete recipe"
-                >
-                  🗑️
-                </button>
-                {/* Cook it button */}
-                <button
-                  onClick={() => setCookOpen(true)}
-                  className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
-                  style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
-                  aria-label="Cook this recipe"
-                  title="Cook it — deduct ingredients from pantry"
-                >
-                  Cook it
-                </button>
-              </div>
-
-              {/* Delete confirm strip */}
-              {deleteOpen && (
-                <RecipeDeleteConfirm
-                  recipeTitle={selectedRecipe.title}
-                  onConfirm={handleDeleteConfirm}
-                  onCancel={() => setDeleteOpen(false)}
-                  deleting={mutating}
-                />
-              )}
-            </div>
+            )}
 
             {/* Error banner */}
             {errorMessage && (

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -159,7 +159,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
                   }}
                 >
                   {label}
-                  {noImage && <span style={{ color: 'var(--color-expiring)' }}>⚠</span>}
+                  {noImage && <span style={{ color: '#f59e0b' }}>⚠</span>}
                   {' '}↗
                 </a>
               ))}

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -60,7 +60,12 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
 
       const raw = await res.json()
       // AI service wraps in { recipe: ... } envelope
-      const recipe: Partial<Recipe> = 'recipe' in raw ? raw.recipe : raw
+      const rawRecipe = ('recipe' in raw ? raw.recipe : raw) as Record<string, unknown>
+      const recipe: Partial<Recipe> = {
+        ...rawRecipe,
+        // image_url isn't in the Recipe type but scrapers return it — preserve as thumbnail_url
+        thumbnail_url: (rawRecipe.thumbnail_url ?? rawRecipe.image_url ?? null) as string | null,
+      }
       onImported(recipe, trimmed)
     } catch {
       setErrorMsg(ERROR_MESSAGES.fetch_failed)

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -134,8 +134,36 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
               className="text-xs text-[var(--color-muted)]"
               style={{ fontFamily: 'Nunito, sans-serif' }}
             >
-              Paste a link from AllRecipes, NYT Cooking, BBC Good Food, Serious Eats, and more.
+              Browse a site, copy the recipe URL, and paste it below.
             </p>
+            <div className="flex flex-wrap gap-1.5">
+              {[
+                { label: 'AllRecipes', href: 'https://www.allrecipes.com', noImage: true },
+                { label: 'Serious Eats', href: 'https://www.seriouseats.com', noImage: true },
+                { label: 'BBC Good Food', href: 'https://www.bbcgoodfood.com/recipes' },
+                { label: 'NYT Cooking', href: 'https://cooking.nytimes.com' },
+                { label: 'Food Network', href: 'https://www.foodnetwork.com/recipes' },
+              ].map(({ label, href, noImage }) => (
+                <a
+                  key={label}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  title={noImage ? 'Images may not be available for this site' : undefined}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold no-underline hover:opacity-80 active:scale-95 transition-all"
+                  style={{
+                    background: 'var(--color-bg)',
+                    border: '1.5px solid var(--color-border)',
+                    color: 'var(--color-primary-dark)',
+                    fontFamily: 'Nunito, sans-serif',
+                  }}
+                >
+                  {label}
+                  {noImage && <span style={{ color: 'var(--color-expiring)' }}>⚠</span>}
+                  {' '}↗
+                </a>
+              ))}
+            </div>
 
             <input
               type="url"

--- a/nextjs/src/components/recipes/RecipePage.tsx
+++ b/nextjs/src/components/recipes/RecipePage.tsx
@@ -44,19 +44,6 @@ const FIRST_LINE_OFFSET = 4 // px — pad-top so first text line sits on first r
 export default function RecipeDetail({ recipe }: RecipeDetailProps) {
   return (
     <>
-      {recipe.thumbnail_url && (
-        <div className="w-full h-36 rounded-2xl overflow-hidden mb-3 mx-5" style={{ width: 'calc(100% - 2.5rem)' }}>
-          <img
-            src={recipe.thumbnail_url}
-            alt={recipe.title}
-            className="w-full h-full object-cover"
-            onError={(e) => {
-              const parent = e.currentTarget.parentElement as HTMLDivElement | null
-              if (parent) parent.style.display = 'none'
-            }}
-          />
-        </div>
-      )}
       <div
         className="px-5 py-4 text-sm text-[var(--color-text)]"
         style={{


### PR DESCRIPTION
Moves thumbnail_url from mid-page in RecipeDetail to a full-bleed 180px hero at the top of the recipe panel. Title and description overlay the image via a dark-to-transparent gradient. Action buttons, tags, and meta chips appear below the hero in a clean strip. Recipes without thumbnail_url get the existing plain header — no regression. Closes #90 layout follow-up.