### PR TITLE
feat(motion): central spring config + reduced-motion helper

### DIFF
--- a/nextjs/src/components/layout/BottomNav.tsx
+++ b/nextjs/src/components/layout/BottomNav.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen,
 } from '@phosphor-icons/react/dist/ssr'
 import type { ComponentType } from 'react'
+import { springs } from '@/lib/motion'
 
 interface IconProps {
   size?: number
@@ -56,7 +57,7 @@ export default function BottomNav() {
                   layoutId="nav-pill"
                   className="absolute inset-x-1 inset-y-1 rounded-2xl"
                   style={{ background: 'var(--color-primary)', opacity: 0.15 }}
-                  transition={{ type: 'spring', stiffness: 500, damping: 30 }}
+                  transition={springs.snappy}
                 />
               )}
               <motion.div

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -9,6 +9,7 @@ import RecipeEditModal from './RecipeEditModal'
 import RecipeDeleteConfirm from './RecipeDeleteConfirm'
 import RecipeImportModal from './RecipeImportModal'
 import CookModal from './CookModal'
+import { springs } from '@/lib/motion'
 
 interface RecipeBookProps {
   recipes: Recipe[]
@@ -58,12 +59,7 @@ const pageVariants = {
   }),
 }
 
-const pageTransition = {
-  type: 'spring' as const,
-  stiffness: 260,
-  damping: 28,
-  mass: 0.8,
-}
+const pageTransition = springs.page
 
 const SWIPE_THRESHOLD = 50
 const VELOCITY_THRESHOLD = 300

--- a/nextjs/src/lib/motion.ts
+++ b/nextjs/src/lib/motion.ts
@@ -1,0 +1,55 @@
+import { useReducedMotion, type Transition, type Variants } from 'framer-motion'
+
+export const springs = {
+  soft: { type: 'spring', stiffness: 260, damping: 24, mass: 0.7 },
+  snappy: { type: 'spring', stiffness: 500, damping: 30, mass: 0.7 },
+  pop: { type: 'spring', stiffness: 700, damping: 18, mass: 0.5 },
+  page: { type: 'spring', stiffness: 260, damping: 28, mass: 0.8 },
+} as const satisfies Record<string, Transition>
+
+const reducedTransition: Transition = { duration: 0.01 }
+
+export const heartPopVariants: Variants = {
+  idle: { scale: 1, rotate: 0 },
+  pop: {
+    scale: [1, 1.4, 0.95, 1.1, 1],
+    rotate: [0, -12, 8, -4, 0],
+    transition: springs.pop,
+  },
+}
+
+export const staggerContainer: Variants = {
+  hidden: { opacity: 0 },
+  show: {
+    opacity: 1,
+    transition: { staggerChildren: 0.04, delayChildren: 0.05 },
+  },
+}
+
+export const staggerItem: Variants = {
+  hidden: { y: 6, opacity: 0 },
+  show: { y: 0, opacity: 1, transition: springs.snappy },
+}
+
+type SpringName = keyof typeof springs
+
+export interface MotionConfig {
+  springs: Record<SpringName, Transition>
+  reduced: boolean
+}
+
+export function useMotionConfig(): MotionConfig {
+  const reduced = useReducedMotion() ?? false
+  if (reduced) {
+    return {
+      reduced: true,
+      springs: {
+        soft: reducedTransition,
+        snappy: reducedTransition,
+        pop: reducedTransition,
+        page: reducedTransition,
+      },
+    }
+  }
+  return { reduced: false, springs }
+}


### PR DESCRIPTION
## Summary

Foundation primitive for the kawaii UI overhaul (Wave 1.1). Adds `nextjs/src/lib/motion.ts` exporting standardized spring presets and a `useMotionConfig()` hook that respects `prefers-reduced-motion`. Replaces the inline transition objects in `BottomNav.tsx` and `RecipeBook.tsx` with the shared config.

## Why

Each component currently re-defines its own spring values (BottomNav: stiffness 500/damping 30; RecipeBook: stiffness 260/damping 28; etc.). Wave 2+ deliverables (heart pop, chip taps, EmptyState reveals, celebration confetti) will all consume the same vocabulary — having one source of truth prevents drift and makes reduced-motion handling a one-line opt-in.

## Exported API

- `springs.{soft, snappy, pop, page}` — Transition presets
- `heartPopVariants` — used by Wave 2.1 favorite button
- `staggerContainer` / `staggerItem` — used by Wave 2 list reveals
- `useMotionConfig()` — returns spring map + `reduced` flag, swaps in 0.01s duration when `prefers-reduced-motion: reduce` is set

## Behaviour change

- **BottomNav nav-pill transition** — was `{ stiffness: 500, damping: 30 }`, now uses `springs.snappy` which adds `mass: 0.7`. The visual difference is barely perceptible (slightly more weight on the pill spring).
- **RecipeBook page-turn transition** — values unchanged (260/28/0.8); the spring object now lives in `motion.ts`.
- No animation regression on reduced-motion users — they get the existing animations until they opt into the new `useMotionConfig()` hook in Wave 2.

## Plan reference

`.agents/plans/2026-05-19-kawaii-redesign.md` — Section "Wave 1.1" + Spec 2

## Bead

BubblyChef-vua

## Test plan

- [x] `cd nextjs && npx tsc --noEmit` — passes locally
- [ ] Visual smoke: BottomNav active-tab pill animates smoothly across all 5 themes
- [ ] Visual smoke: RecipeBook page swipe still feels right
- [ ] Reviewer applies `prefers-reduced-motion: reduce` in DevTools and verifies hook short-circuits to instant transition (will be wired in Wave 2 components)