### PR TITLE
feat(tokens): shared visual primitives — shadow, backdrop, hero overlay

### DIFF
--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -25,6 +25,25 @@
     --color-expiring-text: #7B5A00;
     --color-fresh: #DCFCE7;
     --color-fresh-text: #166534;
+    /*
+     * Semantic signal tokens (fresh / expiring / expired) are intentionally
+     * theme-invariant — red = bad and green = good across all five themes,
+     * so these are NOT redefined per [data-theme="*"]. Tokens above the
+     * separator (--color-bg ... --color-accent-dark) flex per theme.
+     */
+
+    /* Shared visual primitives — derive from theme tokens via color-mix so
+     * shadows/backdrops automatically adopt the active theme palette. */
+    --shadow-soft: 0 4px 24px color-mix(in srgb, var(--color-primary) 15%, transparent);
+    --shadow-pop: 0 8px 32px color-mix(in srgb, var(--color-primary) 25%, transparent);
+    --color-backdrop: color-mix(in srgb, var(--color-text) 18%, transparent);
+    --color-hero-overlay: linear-gradient(
+      to top,
+      color-mix(in srgb, black 72%, transparent) 0%,
+      color-mix(in srgb, black 18%, transparent) 55%,
+      transparent 100%
+    );
+    --text-shadow-on-image: 0 1px 4px color-mix(in srgb, black 40%, transparent);
   }
 
   /* Theme palettes — applied via data-theme attribute on <html> */

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -286,7 +286,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
         className="relative rounded-2xl overflow-hidden border border-[var(--color-border)]"
         style={{
           background: 'var(--color-surface)',
-          boxShadow: '0 4px 24px color-mix(in srgb, var(--color-primary) 15%, transparent)',
+          boxShadow: 'var(--shadow-soft)',
           minHeight: '520px',
         }}
       >
@@ -298,7 +298,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
               <motion.div
                 key="backdrop"
                 className="absolute inset-0 z-10"
-                style={{ background: 'rgba(0,0,0,0.18)' }}
+                style={{ background: 'var(--color-backdrop)' }}
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}


### PR DESCRIPTION
## Summary

Wave 1.2 of the kawaii UI overhaul. Promotes hardcoded shadow / backdrop / overlay values to reusable CSS variables in `globals.css`. Each new token derives from existing theme tokens via `color-mix`, so all five themes (sakura, mint, lavender, yuzu, bluebell) automatically pick up theme-tinted shadows.

## New tokens

```css
--shadow-soft:           0 4px 24px color-mix(in srgb, var(--color-primary) 15%, transparent);
--shadow-pop:            0 8px 32px color-mix(in srgb, var(--color-primary) 25%, transparent);
--color-backdrop:        color-mix(in srgb, var(--color-text) 18%, transparent);
--color-hero-overlay:    linear-gradient(to top, color-mix(...) 0%, color-mix(...) 55%, transparent 100%);
--text-shadow-on-image:  0 1px 4px color-mix(in srgb, black 40%, transparent);
```

## Theme-invariant signal colors (called out in CSS comment)

`fresh / expiring / expired` are intentionally **not** redefined per `[data-theme="*"]` — red=bad and green=good across all five themes. Documenting this prevents future drift where a contributor "fixes" them per-theme. Pre-mortem condition #2 satisfied.

## Replaces

- `RecipeBook.tsx:289` — `boxShadow: '0 4px 24px color-mix(...)'` → `boxShadow: 'var(--shadow-soft)'`
- `RecipeBook.tsx:301` — `background: 'rgba(0,0,0,0.18)'` → `background: 'var(--color-backdrop)'`

The hero-overlay + text-shadow tokens are unused on `feat/ui-overhaul` today (the hero thumbnail work lives on `feat/ui-recipe-hero-thumbnail`); they ship now so that branch can consume them on rebase rather than re-introducing literals.

## Plan reference

`.agents/plans/2026-05-19-kawaii-redesign.md` — Section "W1.2"

## Bead

BubblyChef-6o1

## Test plan

- [x] `cd nextjs && npx tsc --noEmit` — passes
- [ ] Visual smoke: RecipeBook sidebar overlay + card shadow look right in all 5 themes
- [ ] Visual smoke: yuzu theme shadow should pick up warm-yellow tint (vs sakura's pink); confirms color-mix derivation works
- [ ] Confirm CSS comment on signal-color invariance is preserved