### PR TITLE
feat(ui): Chip component + tagToTone helper

### DIFF
--- a/nextjs/src/app/chip-demo/page.tsx
+++ b/nextjs/src/app/chip-demo/page.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import { useState } from 'react'
+import Chip from '@/components/ui/Chip'
+import { tagToTone } from '@/lib/tag-tone'
+
+const ALL_TONES = ['primary', 'accent', 'fresh', 'expiring', 'expired', 'muted'] as const
+
+const SAMPLE_TAGS = [
+  'vegan', 'vegetarian', 'gluten-free', 'dairy-free',
+  'spicy', 'hot', 'sweet', 'dessert',
+  'breakfast', 'lunch', 'dinner', 'snack',
+  'easy', 'quick', 'comfort', 'healthy',
+  'italian', 'mexican', 'asian', 'japanese',
+]
+
+const META_CHIPS = [
+  { emoji: '⏱️', label: '30 min', tone: 'expiring' as const },
+  { emoji: '🍽️', label: '4 servings', tone: 'muted' as const },
+  { emoji: '✨', label: 'Easy', tone: 'fresh' as const },
+]
+
+export default function ChipDemo() {
+  const [selectedTone, setSelectedTone] = useState<string | null>(null)
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+
+  return (
+    <div className="min-h-screen p-8 max-w-xl mx-auto space-y-10"
+         style={{ background: 'var(--color-bg)', fontFamily: 'Nunito, sans-serif' }}>
+
+      <div>
+        <h1 className="text-2xl font-extrabold mb-1" style={{ color: 'var(--color-text)' }}>
+          Chip Component Demo
+        </h1>
+        <p className="text-sm" style={{ color: 'var(--color-muted)' }}>
+          Switch themes via the header picker to see all 5 palettes.
+        </p>
+      </div>
+
+      {/* All tones — static */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          All tones (static)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {ALL_TONES.map(tone => (
+            <Chip key={tone} tone={tone}>{tone}</Chip>
+          ))}
+        </div>
+      </section>
+
+      {/* All tones — with emoji */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          With emoji prefix
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          <Chip tone="primary" emoji="🍯">Sweet</Chip>
+          <Chip tone="fresh" emoji="🌿">Vegan</Chip>
+          <Chip tone="expired" emoji="🌶️">Spicy</Chip>
+          <Chip tone="expiring" emoji="⚡">Quick</Chip>
+          <Chip tone="accent" emoji="🤗">Comfort</Chip>
+          <Chip tone="muted" emoji="🍽️">4 servings</Chip>
+        </div>
+      </section>
+
+      {/* Sizes */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Sizes
+        </h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip tone="primary" size="sm" emoji="🌿">sm chip</Chip>
+          <Chip tone="primary" size="md" emoji="🌿">md chip</Chip>
+        </div>
+      </section>
+
+      {/* Interactive — selected state */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Clickable + selected state (tap to toggle)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {ALL_TONES.map(tone => (
+            <Chip
+              key={tone}
+              tone={tone}
+              selected={selectedTone === tone}
+              onClick={() => setSelectedTone(prev => prev === tone ? null : tone)}
+            >
+              {tone}
+            </Chip>
+          ))}
+        </div>
+        {selectedTone && (
+          <p className="text-xs" style={{ color: 'var(--color-muted)' }}>
+            Selected: <strong>{selectedTone}</strong>
+          </p>
+        )}
+      </section>
+
+      {/* Recipe meta chips */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Recipe meta chips (replaces MetaChip)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {META_CHIPS.map(({ emoji, label, tone }) => (
+            <Chip key={label} tone={tone} emoji={emoji}>{label}</Chip>
+          ))}
+        </div>
+      </section>
+
+      {/* Tag chips via tagToTone */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Recipe tag chips (via tagToTone helper)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {SAMPLE_TAGS.map(tag => {
+            const { tone, emoji } = tagToTone(tag)
+            return (
+              <Chip
+                key={tag}
+                tone={tone}
+                emoji={emoji || undefined}
+                selected={selectedTag === tag}
+                onClick={() => setSelectedTag(prev => prev === tag ? null : tag)}
+              >
+                {tag}
+              </Chip>
+            )
+          })}
+        </div>
+        {selectedTag && (
+          <p className="text-xs" style={{ color: 'var(--color-muted)' }}>
+            Selected: <strong>{selectedTag}</strong> → tone: <strong>{tagToTone(selectedTag).tone}</strong>
+          </p>
+        )}
+      </section>
+
+      {/* Location filter chips (replaces pantry filter buttons) */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Filter chips (replaces pantry location buttons)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {(['All', 'Fridge', 'Freezer', 'Pantry', 'Other'] as const).map((loc, i) => (
+            <Chip
+              key={loc}
+              tone={i === 0 ? 'primary' : 'muted'}
+              selected={i === 0}
+            >
+              {loc}
+            </Chip>
+          ))}
+        </div>
+      </section>
+
+      {/* Suggestion chips (replaces chat suggestion buttons) */}
+      <section className="space-y-3">
+        <h2 className="text-sm font-bold uppercase tracking-wide" style={{ color: 'var(--color-muted)' }}>
+          Suggestion chips (replaces chat suggestion buttons)
+        </h2>
+        <div className="flex flex-wrap gap-2">
+          {[
+            { label: '🍳 What can I make tonight?', tone: 'accent' as const },
+            { label: '🥗 Something healthy', tone: 'fresh' as const },
+            { label: '⚡ Quick meals under 20 min', tone: 'expiring' as const },
+            { label: '🌶️ Spicy recipes', tone: 'expired' as const },
+          ].map(({ label, tone }) => (
+            <Chip key={label} tone={tone} onClick={() => {}}>{label}</Chip>
+          ))}
+        </div>
+      </section>
+
+    </div>
+  )
+}

--- a/nextjs/src/components/ui/Chip.tsx
+++ b/nextjs/src/components/ui/Chip.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import type { ReactNode } from 'react'
+import { springs } from '@/lib/motion'
+
+export type ChipTone =
+  | 'primary'
+  | 'accent'
+  | 'fresh'
+  | 'expiring'
+  | 'expired'
+  | 'muted'
+
+export interface ChipProps {
+  tone?: ChipTone
+  size?: 'sm' | 'md'
+  selected?: boolean
+  emoji?: string
+  onClick?: () => void
+  children: ReactNode
+  ariaLabel?: string
+  className?: string
+}
+
+const TONE_BG: Record<ChipTone, string> = {
+  primary: 'var(--color-primary)',
+  accent: 'var(--color-accent)',
+  fresh: 'var(--color-fresh)',
+  expiring: 'var(--color-expiring)',
+  expired: 'var(--color-expired)',
+  muted: 'var(--color-bg)',
+}
+
+const TONE_TEXT: Record<ChipTone, string> = {
+  primary: 'var(--color-text)',
+  accent: 'var(--color-text)',
+  fresh: 'var(--color-fresh-text)',
+  expiring: 'var(--color-expiring-text)',
+  expired: 'var(--color-expired-text)',
+  muted: 'var(--color-muted)',
+}
+
+const SIZE_CLASS: Record<NonNullable<ChipProps['size']>, string> = {
+  sm: 'px-2 py-0.5 text-xs',
+  md: 'px-3 py-1.5 text-xs',
+}
+
+export default function Chip({
+  tone = 'muted',
+  size = 'md',
+  selected = false,
+  emoji,
+  onClick,
+  children,
+  ariaLabel,
+  className,
+}: ChipProps) {
+  const baseClass = `inline-flex items-center gap-1 ${SIZE_CLASS[size]} rounded-full font-semibold whitespace-nowrap transition-colors border border-[var(--color-border)]`
+  const merged = className ? `${baseClass} ${className}` : baseClass
+
+  const style = {
+    background: selected ? 'var(--color-primary)' : TONE_BG[tone],
+    color: selected ? '#fff' : TONE_TEXT[tone],
+  } as const
+
+  if (onClick) {
+    return (
+      <motion.button
+        type="button"
+        onClick={onClick}
+        aria-label={ariaLabel}
+        aria-pressed={selected}
+        whileTap={{ scale: 0.95 }}
+        transition={springs.snappy}
+        className={merged}
+        style={style}
+      >
+        {emoji && <span aria-hidden>{emoji}</span>}
+        <span>{children}</span>
+      </motion.button>
+    )
+  }
+
+  return (
+    <span className={merged} style={style} aria-label={ariaLabel}>
+      {emoji && <span aria-hidden>{emoji}</span>}
+      <span>{children}</span>
+    </span>
+  )
+}

--- a/nextjs/src/lib/tag-tone.ts
+++ b/nextjs/src/lib/tag-tone.ts
@@ -1,0 +1,36 @@
+import type { ChipTone } from '@/components/ui/Chip'
+
+interface TagToneEntry {
+  tone: ChipTone
+  emoji: string
+}
+
+const TAG_MAP: Record<string, TagToneEntry> = {
+  vegan: { tone: 'fresh', emoji: '🌿' },
+  vegetarian: { tone: 'fresh', emoji: '🥗' },
+  'gluten-free': { tone: 'fresh', emoji: '🌾' },
+  'dairy-free': { tone: 'fresh', emoji: '🥛' },
+  spicy: { tone: 'expired', emoji: '🌶️' },
+  hot: { tone: 'expired', emoji: '🔥' },
+  sweet: { tone: 'primary', emoji: '🍯' },
+  dessert: { tone: 'primary', emoji: '🍰' },
+  breakfast: { tone: 'expiring', emoji: '🍳' },
+  lunch: { tone: 'accent', emoji: '🥪' },
+  dinner: { tone: 'accent', emoji: '🍽️' },
+  snack: { tone: 'expiring', emoji: '🍿' },
+  easy: { tone: 'fresh', emoji: '✨' },
+  quick: { tone: 'expiring', emoji: '⚡' },
+  comfort: { tone: 'accent', emoji: '🤗' },
+  healthy: { tone: 'fresh', emoji: '🥬' },
+  italian: { tone: 'expired', emoji: '🍝' },
+  mexican: { tone: 'expiring', emoji: '🌮' },
+  asian: { tone: 'accent', emoji: '🍜' },
+  japanese: { tone: 'primary', emoji: '🍣' },
+  chinese: { tone: 'expired', emoji: '🥡' },
+  indian: { tone: 'expiring', emoji: '🍛' },
+  french: { tone: 'primary', emoji: '🥐' },
+}
+
+export function tagToTone(tag: string): TagToneEntry {
+  return TAG_MAP[tag.toLowerCase().trim()] ?? { tone: 'muted', emoji: '' }
+}


### PR DESCRIPTION
## Summary

Wave 1.3 part A of the kawaii UI overhaul. Adds the reusable `<Chip>` component and a `tagToTone()` helper for mapping recipe-tag strings to chip tone + emoji. **No existing chip render sites are modified in this PR** — the four replacement targets (RecipeBook MetaChip, RecipeBook tags, pantry location filters, chat suggestion chips) land in a follow-up PR (BubblyChef-8kn) once this and the tokens PR merge.

## Why split this from the replacements

Pre-mortem condition #3 (TS strict breakage on render-site replacements with a discriminated union) and the plan's W1.3 acceptance both call for shipping the component first, then replacing call sites incrementally. Two-PR shape gives a smaller, single-purpose review.

## Component API

```tsx
type ChipTone = 'primary' | 'accent' | 'fresh' | 'expiring' | 'expired' | 'muted'

interface ChipProps {
  tone?: ChipTone           // default 'muted'
  size?: 'sm' | 'md'         // default 'md'
  selected?: boolean         // overrides tone with primary fill + white text
  emoji?: string             // optional leading aria-hidden glyph
  onClick?: () => void       // when present, renders as motion.button with springs.snappy whileTap
  children: ReactNode
  ariaLabel?: string
  className?: string         // appended to base classes
}
```

- Renders as `motion.button` when `onClick` is provided (interactive); plain `<span>` otherwise (decorative).
- Tone palette pulls from theme tokens (`var(--color-fresh)`, `var(--color-expired)`, etc.) — automatically theme-aware where the token is defined per-theme, theme-invariant for `fresh / expiring / expired` (semantic signal colors documented in the tokens PR).

## tag-tone.ts

`tagToTone(tag: string)` returns `{ tone, emoji }`. Maps ~20 common tags (vegan/vegetarian/spicy/sweet/dessert/easy/quick/italian/japanese/...). Unknown tags fall through to `{ tone: 'muted', emoji: '' }` — never throws, never blank-emoji-renders an empty span.

## Dependencies

- **Builds on** `feat/w1-motion` (PR #115) — uses `springs.snappy` for tap feedback.
- **Will be consumed by** `w1-chip-sites` (BubblyChef-8kn) which depends on this + tokens.

## Plan reference

`.agents/plans/2026-05-19-kawaii-redesign.md` — Section "W1.3" + Spec 1

## Bead

BubblyChef-80v

## Test plan

- [x] `cd nextjs && npx tsc --noEmit` — passes (TS strict, no `any`)
- [ ] Visual smoke: render a Chip in Storybook / a scratch page in all 6 tones across all 5 themes
- [ ] Tap interaction: confirm `whileTap` scale animation fires when `onClick` is provided and respects motion preferences (springs.snappy reduces to 0.01s when `prefers-reduced-motion: reduce` once the call site uses `useMotionConfig()` — covered in Wave 2)
- [ ] No render-site changes in this PR (zero diff in RecipeBook/pantry/chat)