### PR TITLE
feat(ui): replace chip render sites with Chip component (Wave 1B)

### DIFF
--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -11,6 +11,7 @@ import TypingIndicator from '@/components/chat/TypingIndicator'
 import ChatRecipeCard from '@/components/chat/ChatRecipeCard'
 import PantryProposalCard from '@/components/chat/PantryProposalCard'
 import ThemePicker from '@/components/ui/ThemePicker'
+import Chip from '@/components/ui/Chip'
 import { useChat } from '@/hooks/useChat'
 import { checkAIHealth } from '@/lib/api/chat'
 import type { ChatMessage, ChatRecipeData, PantryProposalData } from '@/types/chat'
@@ -188,14 +189,13 @@ export default function ChatPage() {
             </p>
             <div className="flex flex-wrap gap-2 justify-center">
               {SUGGESTIONS.map((s) => (
-                <button
+                <Chip
                   key={s}
-                  type="button"
+                  tone="accent"
                   onClick={() => handleSuggestionClick(s)}
-                  className="bg-[var(--color-surface)] text-[var(--color-text)] text-sm font-medium px-4 py-2 rounded-full border border-[var(--color-border)] hover:bg-[var(--color-border)] transition-colors"
                 >
                   {s}
-                </button>
+                </Chip>
               ))}
             </div>
           </div>

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -12,6 +12,7 @@ import AddItemModal from '@/components/pantry/AddItemModal'
 import ThemePicker from '@/components/ui/ThemePicker'
 import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAddSheet'
 import { getFoodEmoji } from '@/lib/food-emoji'
+import Chip from '@/components/ui/Chip'
 
 interface PantryItem {
   id: string
@@ -187,18 +188,14 @@ function PantryPageInner() {
       {/* Location filter chips */}
       <div className="px-6 mb-4 flex gap-2 overflow-x-auto">
         {LOCATION_FILTERS.map((loc) => (
-          <button
+          <Chip
             key={loc.value}
-            type="button"
+            tone={locationFilter === loc.value ? 'primary' : 'muted'}
+            selected={locationFilter === loc.value}
             onClick={() => setLocationFilter(loc.value)}
-            className={`whitespace-nowrap px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
-              locationFilter === loc.value
-                ? 'bg-[var(--color-primary)] text-white'
-                : 'bg-[var(--color-surface)] text-[var(--color-text)] border border-[var(--color-border)]'
-            }`}
           >
             {loc.label}
-          </button>
+          </Chip>
         ))}
       </div>
 

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -10,6 +10,8 @@ import RecipeDeleteConfirm from './RecipeDeleteConfirm'
 import RecipeImportModal from './RecipeImportModal'
 import CookModal from './CookModal'
 import { springs } from '@/lib/motion'
+import Chip from '@/components/ui/Chip'
+import { tagToTone } from '@/lib/tag-tone'
 
 interface RecipeBookProps {
   recipes: Recipe[]
@@ -27,14 +29,6 @@ function scoreRecipe(r: Recipe, q: string): number {
   if (r.meal_type?.toLowerCase().includes(lq)) score += 1
   if ((r.description ?? '').toLowerCase().includes(lq)) score += 0.5
   return score
-}
-
-function MetaChip({ label }: { label: string }) {
-  return (
-    <span className="inline-block border border-[var(--color-border)] px-2 py-0.5 rounded text-xs text-[var(--color-muted)] font-semibold uppercase tracking-wide">
-      {label}
-    </span>
-  )
 }
 
 // Page-turn animation variants — book-page-curl feel
@@ -451,21 +445,17 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 <div className="px-4 pt-2 pb-3" style={{ paddingLeft: '44px' }}>
                   {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mb-2">
-                      {selectedRecipe.tags.map((tag) => (
-                        <span
-                          key={tag}
-                          className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
-                        >
-                          {tag}
-                        </span>
-                      ))}
+                      {selectedRecipe.tags.map((tag) => {
+                        const { tone, emoji } = tagToTone(tag)
+                        return <Chip key={tag} tone={tone} emoji={emoji || undefined} size="sm">{tag}</Chip>
+                      })}
                     </div>
                   )}
                   <div className="flex flex-wrap gap-1.5 mb-2">
-                    {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
-                    {totalTime && <MetaChip label={totalTime} />}
-                    {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
-                    {selectedRecipe.servings && <MetaChip label={`Serves ${selectedRecipe.servings}`} />}
+                    {selectedRecipe.cuisine && <Chip tone="fresh" emoji="✨">{selectedRecipe.cuisine}</Chip>}
+                    {totalTime && <Chip tone="expiring" emoji="⏱️">{totalTime}</Chip>}
+                    {selectedRecipe.difficulty && <Chip tone="fresh" emoji="✨">{selectedRecipe.difficulty}</Chip>}
+                    {selectedRecipe.servings && <Chip tone="muted" emoji="🍽️">{`Serves ${selectedRecipe.servings}`}</Chip>}
                   </div>
                   {/* Action buttons */}
                   <div className="flex items-center gap-2">
@@ -535,22 +525,18 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 )}
                 {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
                   <div className="flex flex-wrap gap-1.5 mt-2">
-                    {selectedRecipe.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--color-bg)] text-[var(--color-primary-dark)] border border-[var(--color-border)]"
-                      >
-                        {tag}
-                      </span>
-                    ))}
+                    {selectedRecipe.tags.map((tag) => {
+                      const { tone, emoji } = tagToTone(tag)
+                      return <Chip key={tag} tone={tone} emoji={emoji || undefined} size="sm">{tag}</Chip>
+                    })}
                   </div>
                 )}
                 <div className="flex flex-wrap gap-1.5 mt-2">
-                  {selectedRecipe.cuisine && <MetaChip label={selectedRecipe.cuisine} />}
-                  {totalTime && <MetaChip label={totalTime} />}
-                  {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
+                  {selectedRecipe.cuisine && <Chip tone="fresh" emoji="✨">{selectedRecipe.cuisine}</Chip>}
+                  {totalTime && <Chip tone="expiring" emoji="⏱️">{totalTime}</Chip>}
+                  {selectedRecipe.difficulty && <Chip tone="fresh" emoji="✨">{selectedRecipe.difficulty}</Chip>}
                   {selectedRecipe.servings && (
-                    <MetaChip label={`Serves ${selectedRecipe.servings}`} />
+                    <Chip tone="muted" emoji="🍽️">{`Serves ${selectedRecipe.servings}`}</Chip>
                   )}
                 </div>
                 <div className="flex items-center gap-2 mt-2">


### PR DESCRIPTION
## Summary

Replaces raw chip/badge markup across 4 render sites with the new `<Chip>` component (merged in Wave 1A, commit 53cf98a).

### Sites changed

1. **`nextjs/src/components/recipes/RecipeBook.tsx` — MetaChip → Chip**
   - Deleted the `MetaChip` inline component
   - Cuisine/difficulty chips: `tone="fresh" emoji="✨"`
   - Time chips: `tone="expiring" emoji="⏱️"`
   - Servings chips: `tone="muted" emoji="🍽️"`
   - Applied to both hero-header and plain-header render paths

2. **`nextjs/src/components/recipes/RecipeBook.tsx` — tag pills → Chip + tagToTone**
   - Replaced raw `<span>` tag pills with `<Chip>` using `tagToTone()` for semantic tone + emoji mapping
   - Applied to both hero-header and plain-header render paths

3. **`nextjs/src/app/pantry/page.tsx` — location filter buttons → Chip**
   - Selected filter: `tone="primary" selected={true}`
   - Unselected filter: `tone="muted" selected={false}`
   - `onClick` wired to existing `setLocationFilter` handler

4. **`nextjs/src/app/chat/page.tsx` — suggestion chips → Chip**
   - Initial-state quick-start prompts replaced with `tone="accent"`
   - `onClick` wired to existing `handleSuggestionClick` handler

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [ ] Visually verify RecipeBook meta chips render with correct colors/emojis
- [ ] Visually verify pantry location filter selected state highlights correctly
- [ ] Visually verify chat suggestion chips render with accent tone