### PR TITLE
feat(ui): chat bubble tail + post-message suggestion chips (W2.3)

### DIFF
--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -7,6 +7,7 @@ import BubblesHeader from '@/components/layout/BubblesHeader'
 import BubblesMascot from '@/components/ui/BubblesMascot'
 import RotatingPlaceholder from '@/components/chat/RotatingPlaceholder'
 import MessageBubble from '@/components/chat/MessageBubble'
+import PostMessageChips from '@/components/chat/PostMessageChips'
 import TypingIndicator from '@/components/chat/TypingIndicator'
 import ChatRecipeCard from '@/components/chat/ChatRecipeCard'
 import PantryProposalCard from '@/components/chat/PantryProposalCard'
@@ -58,6 +59,10 @@ export default function ChatPage() {
     const text = input.trim()
     if (!text) return
     setInput('')
+    sendMessage(text)
+  }
+
+  const handleSendText = (text: string) => {
     sendMessage(text)
   }
 
@@ -154,12 +159,18 @@ export default function ChatPage() {
                   msg.role === 'assistant' &&
                   index === messages.length - 1
                 }
+                isLastMessage={
+                  !isStreaming &&
+                  msg.role === 'assistant' &&
+                  index === messages.length - 1
+                }
                 proposalState={proposalStates[msg.id]}
                 saveState={saveStates[msg.id] ?? 'idle'}
                 onApprove={() => approveProposal(msg.id)}
                 onReject={() => rejectProposal(msg.id)}
                 onSave={(recipe) => handleSaveRecipe(msg.id, recipe)}
                 onTryAnother={handleTryAnother}
+                onTellMore={() => handleSendText('Tell me more about this')}
               />
             ))}
 
@@ -237,23 +248,27 @@ export default function ChatPage() {
 interface MessageRendererProps {
   message: ChatMessage
   isLastAssistant: boolean
+  isLastMessage: boolean
   proposalState?: 'pending' | 'approved' | 'rejected'
   saveState: 'idle' | 'saving' | 'saved' | 'error'
   onApprove: () => void
   onReject: () => void
   onSave: (recipe: ChatRecipeData) => void
   onTryAnother: () => void
+  onTellMore: () => void
 }
 
 function MessageRenderer({
   message,
   isLastAssistant,
+  isLastMessage,
   proposalState,
   saveState,
   onApprove,
   onReject,
   onSave,
   onTryAnother,
+  onTellMore,
 }: MessageRendererProps) {
   // User messages — simple bubble
   if (message.role === 'user') {
@@ -306,5 +321,15 @@ function MessageRenderer({
 
   // Default: text message with markdown (skip empty streaming messages — typing indicator handles those)
   if (!message.content && isLastAssistant) return null
-  return <MessageBubble message={message} />
+  return (
+    <>
+      <MessageBubble message={message} />
+      {isLastMessage && (
+        <PostMessageChips
+          onTryAnother={onTryAnother}
+          onTellMore={onTellMore}
+        />
+      )}
+    </>
+  )
 }

--- a/nextjs/src/components/chat/MessageBubble.tsx
+++ b/nextjs/src/components/chat/MessageBubble.tsx
@@ -21,12 +21,34 @@ export default function MessageBubble({ message }: MessageBubbleProps) {
     >
       <div
         className={[
-          'px-4 py-2.5 text-sm leading-relaxed',
+          'relative px-4 py-2.5 text-sm leading-relaxed',
           isUser
             ? 'bg-[var(--color-primary)] text-white rounded-2xl rounded-br-md max-w-[80%]'
             : 'bg-[var(--color-surface)] text-[var(--color-text)] rounded-2xl rounded-bl-md border border-[var(--color-border)] max-w-[85%]',
         ].join(' ')}
       >
+        {/* Assistant bubble tail — points left toward mascot */}
+        {!isUser && (
+          <span
+            className="absolute -left-2 top-3 w-0 h-0"
+            style={{
+              borderTop: '6px solid transparent',
+              borderBottom: '6px solid transparent',
+              borderRight: '8px solid var(--color-surface)',
+            }}
+          />
+        )}
+        {/* User bubble tail — points right */}
+        {isUser && (
+          <span
+            className="absolute -right-2 top-3 w-0 h-0"
+            style={{
+              borderTop: '6px solid transparent',
+              borderBottom: '6px solid transparent',
+              borderLeft: '8px solid var(--color-primary)',
+            }}
+          />
+        )}
         {isUser ? (
           <p className="whitespace-pre-wrap break-words">{message.content}</p>
         ) : (

--- a/nextjs/src/components/chat/PostMessageChips.tsx
+++ b/nextjs/src/components/chat/PostMessageChips.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import type { ReactNode } from 'react'
+
+interface PostMessageChipsProps {
+  onSave?: () => void
+  onTryAnother?: () => void
+  onTellMore?: () => void
+}
+
+interface ChipProps {
+  emoji: string
+  onClick: () => void
+  children: ReactNode
+  variant?: 'primary' | 'accent' | 'muted'
+}
+
+function Chip({ emoji, onClick, children, variant = 'primary' }: ChipProps) {
+  const variantClass =
+    variant === 'primary'
+      ? 'bg-[var(--color-primary)] text-white'
+      : variant === 'accent'
+        ? 'bg-[var(--color-accent)] text-[var(--color-text)]'
+        : 'bg-[var(--color-surface)] text-[var(--color-muted)] border border-[var(--color-border)]'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={[
+        'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold',
+        'transition-all active:scale-95 hover:opacity-90',
+        variantClass,
+      ].join(' ')}
+    >
+      <span>{emoji}</span>
+      <span>{children}</span>
+    </button>
+  )
+}
+
+export default function PostMessageChips({
+  onSave,
+  onTryAnother,
+  onTellMore,
+}: PostMessageChipsProps) {
+  return (
+    <div className="flex flex-wrap gap-2 mt-2 ml-10">
+      {onSave && (
+        <Chip variant="primary" emoji="🔖" onClick={onSave}>
+          Save this
+        </Chip>
+      )}
+      {onTryAnother && (
+        <Chip variant="accent" emoji="🔄" onClick={onTryAnother}>
+          Try another
+        </Chip>
+      )}
+      {onTellMore && (
+        <Chip variant="muted" emoji="💬" onClick={onTellMore}>
+          Tell me more
+        </Chip>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Issue / Design

W2.3 of the BubblyChef kawaii redesign — speech-bubble polish and contextual action chips in the chat UI.

## Design decisions

- **Bubble tails**: CSS triangle via inline border trick (`w-0 h-0` + border-side solid). Assistant tail points left toward the mascot; user tail points right. Uses `var(--color-surface)` / `var(--color-primary)` so both light and dark themes work automatically.
- **PostMessageChips**: Self-contained component with an inline `Chip` primitive (no external dependency — `@/components/ui/Chip` does not exist yet). Variants map to existing CSS custom property tokens.
- **Chips only on last settled message**: `isLastMessage` is `true` only when `!isStreaming && role === 'assistant' && index === messages.length - 1`, so chips disappear while streaming and reappear once the response is complete.
- **`onSave` prop omitted at call site** for now (wired when recipe-in-context detection lands).

## Changes

- `nextjs/src/components/chat/MessageBubble.tsx` — add `relative` wrapper + `<span>` tail elements
- `nextjs/src/components/chat/PostMessageChips.tsx` — new component
- `nextjs/src/app/chat/page.tsx` — import + wire `isLastMessage` prop + `onTellMore` handler

## Test plan

- [ ] Assistant bubbles show left-pointing tail; user bubbles show right-pointing tail
- [ ] Chips appear after the last assistant text response (not after recipe cards or pantry proposals)
- [ ] Chips are hidden while streaming; reappear once stream settles
- [ ] Clicking "Try another" sends "Give me a different recipe"
- [ ] Clicking "Tell me more" sends "Tell me more about this"
- [ ] Chips are absent on all prior messages (not just the last)
- [ ] TypeScript check: zero new errors (`npx tsc --noEmit`)