### PR TITLE
feat(ui): recipe action cluster — heart pop + overflow menu + sticky cook (W2.1)

### DIFF
--- a/ai-service/bubbly_chef/services/cook_matcher.py
+++ b/ai-service/bubbly_chef/services/cook_matcher.py
@@ -61,6 +61,10 @@ def match_ingredients(
     unit_conflicts: list[dict[str, str]] = []
 
     for ingredient in recipe_ingredients:
+        # Ingredients may be stored as plain strings (e.g. "1 cup flour") or dicts
+        if isinstance(ingredient, str):
+            ingredient = {"name": ingredient}
+
         raw_name: str = ingredient.get("name", "")
         if not raw_name:
             continue

--- a/ai-service/bubbly_chef/services/cook_matcher.py
+++ b/ai-service/bubbly_chef/services/cook_matcher.py
@@ -8,23 +8,119 @@ insufficient, which have unit conflicts, and which are missing entirely.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any
 
-from bubbly_chef.domain.catalog import lookup as catalog_lookup
 from bubbly_chef.domain.normalizer import normalize_food_name, normalize_to_base_unit
 from bubbly_chef.models.cook import CookProposal, IngredientMatch
 from bubbly_chef.models.pantry import PantryItem
 
 logger = logging.getLogger(__name__)
 
+# Matches leading quantity+unit in a raw ingredient string, e.g.:
+#   "2 large eggs"       → qty=2,  unit=None,   rest="large eggs"
+#   "1/2 cup flour"      → qty=0.5, unit="cup",  rest="flour"
+#   "1 teaspoon lemon zest" → qty=1, unit="tsp", rest="lemon zest"
+_LEADING_QTY_RE = re.compile(
+    r"^\s*"
+    r"(?P<qty>\d+\s*/\s*\d+|\d+(?:\.\d+)?)"   # fraction or decimal
+    r"(?:\s+(?P<unit>cup|cups|tbsp|tablespoon|tablespoons|tsp|teaspoon|teaspoons"
+    r"|oz|ounce|ounces|lb|lbs|pound|pounds|g|gram|grams|kg|ml|l|liter|liters"
+    r"|pint|quart|gallon|fl\s+oz|fluid\s+ounce|stick|sticks|clove|cloves"
+    r"|bunch|bunches|slice|slices|piece|pieces|can|cans|package|packages"
+    r"|head|heads|sprig|sprigs|pinch|dash|handful|item|count|dozen))?"
+    r"\s+",
+    re.IGNORECASE,
+)
+
+# Adjectives that appear between quantity and the actual food noun
+_ADJECTIVE_RE = re.compile(
+    r"^(?:large|small|medium|extra-large|xl|fresh|dried|whole|finely|coarsely"
+    r"|roughly|thinly|thickly|grated|sliced|diced|chopped|minced|crushed"
+    r"|peeled|seeded|boneless|skinless|lean|ground|frozen|canned|organic"
+    r"|plus|more|additional|extra)\s+",
+    re.IGNORECASE,
+)
+
+# Conjunctions that split multi-ingredient strings, e.g. "2 eggs and 1 yolk"
+_CONJUNCTION_RE = re.compile(r"\s*(?:,\s*|\s+and\s+|\s+or\s+|\s+plus\s+).*$", re.IGNORECASE)
+
+
+def _parse_ingredient_string(raw: str) -> dict[str, Any]:
+    """Parse a raw ingredient string into {name, quantity, unit}.
+
+    Handles strings like:
+      "2 large eggs" → {name: "eggs", quantity: 2.0, unit: None}
+      "1/2 cup finely grated Parmesan" → {name: "parmesan", quantity: 0.5, unit: "cup"}
+      "1 teaspoon lemon zest" → {name: "lemon zest", quantity: 1.0, unit: "teaspoon"}
+      "1/2 cup plus 2 tbsp Parmesan" → {name: "parmesan", quantity: 0.5, unit: "cup"}
+    """
+    stripped = raw.strip()
+
+    # Split on first conjunction — use the first segment for qty/unit, last for the food noun
+    conj_m = _CONJUNCTION_RE.search(stripped)
+    first_segment = _CONJUNCTION_RE.sub("", stripped)
+    last_segment = stripped[conj_m.start():].lstrip(" ,").strip() if conj_m else first_segment
+
+    qty: float | None = None
+    unit: str | None = None
+    text = first_segment
+
+    m = _LEADING_QTY_RE.match(text)
+    if m:
+        qty_str = m.group("qty").replace(" ", "")
+        if "/" in qty_str:
+            num, den = qty_str.split("/")
+            qty = float(num) / float(den)
+        else:
+            qty = float(qty_str)
+        unit = m.group("unit")
+        text = text[m.end():]
+
+    # Strip leading adjectives to reach the food noun
+    for _ in range(5):
+        stripped_adj = _ADJECTIVE_RE.sub("", text)
+        if stripped_adj == text:
+            break
+        text = stripped_adj
+
+    name = text.strip().lower()
+
+    # Food unit words appearing as the sole "name" mean the parse consumed too much.
+    # In that case fall back to the last conjunction segment for the actual food noun.
+    _UNIT_WORDS = {"cup", "cups", "tbsp", "tablespoon", "tablespoons", "tsp",
+                   "teaspoon", "teaspoons", "oz", "lb", "lbs", "g", "kg", "ml",
+                   "l", "item", "count", "piece", "pieces", "slice", "slices",
+                   "bunch", "can", "cans", "package", "packages", "clove", "cloves",
+                   "sprig", "sprigs", "head", "heads", "stick", "sticks"}
+    if not name or name in _UNIT_WORDS:
+        last = last_segment
+        # Strip leading adjectives/conjunction words before the qty match
+        for _ in range(5):
+            stripped_adj = _ADJECTIVE_RE.sub("", last)
+            if stripped_adj == last:
+                break
+            last = stripped_adj
+        last_m = _LEADING_QTY_RE.match(last)
+        if last_m:
+            last = last[last_m.end():]
+        for _ in range(5):
+            stripped_adj = _ADJECTIVE_RE.sub("", last)
+            if stripped_adj == last:
+                break
+            last = stripped_adj
+        name = last.strip().lower() or name
+
+    return {"name": name, "quantity": qty, "unit": unit}
+
 
 def _normalize_ingredient_name(name: str) -> str:
-    """Normalize an ingredient name for matching against pantry items."""
-    # First try catalog lookup at 80-threshold (task spec)
-    entry = catalog_lookup(name, threshold=80)
-    if entry:
-        return entry.canonical.lower().strip()
-    # Fall back to synonym + regex normalizer
+    """Normalize an ingredient name for matching against pantry items.
+
+    Skips catalog fuzzy-lookup intentionally — WRatio at any reasonable threshold
+    produces cross-food false positives (e.g. "pecorino romano" → "roma tomato").
+    Synonym normalization in normalize_food_name() is sufficient for pantry matching.
+    """
     return normalize_food_name(name).lower().strip()
 
 
@@ -61,9 +157,10 @@ def match_ingredients(
     unit_conflicts: list[dict[str, str]] = []
 
     for ingredient in recipe_ingredients:
-        # Ingredients may be stored as plain strings (e.g. "1 cup flour") or dicts
+        # Ingredients may be stored as plain strings (e.g. "1 cup flour") or dicts.
+        # Parse the string to extract name, quantity, and unit before any dict access.
         if isinstance(ingredient, str):
-            ingredient = {"name": ingredient}
+            ingredient = _parse_ingredient_string(ingredient)
 
         raw_name: str = ingredient.get("name", "")
         if not raw_name:

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useState, useCallback, useEffect, useMemo } from 'react'
-import { motion, AnimatePresence, type PanInfo } from 'framer-motion'
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react'
+import { motion, AnimatePresence, useAnimation, type PanInfo } from 'framer-motion'
+import { Heart, DotsThree } from '@phosphor-icons/react'
 import RecipeDetail, { type Recipe } from './RecipePage'
 import RecipeSearchBar from './RecipeSearchBar'
 import BubblesMascot from '@/components/ui/BubblesMascot'
@@ -9,7 +10,7 @@ import RecipeEditModal from './RecipeEditModal'
 import RecipeDeleteConfirm from './RecipeDeleteConfirm'
 import RecipeImportModal from './RecipeImportModal'
 import CookModal from './CookModal'
-import { springs } from '@/lib/motion'
+import { springs, heartPopVariants } from '@/lib/motion'
 
 interface RecipeBookProps {
   recipes: Recipe[]
@@ -81,12 +82,27 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   const [favoriteOverrides, setFavoriteOverrides] = useState<Record<string, boolean>>({})
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [thumbError, setThumbError] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
+  const heartControls = useAnimation()
+  const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!errorMessage) return
     const t = setTimeout(() => setErrorMessage(null), 5000)
     return () => clearTimeout(t)
   }, [errorMessage])
+
+  // Close overflow menu on outside click
+  useEffect(() => {
+    if (!menuOpen) return
+    const handleMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [menuOpen])
 
   // Merge optimistic favorite overrides into the recipe list
   const recipesWithOverrides = useMemo(
@@ -163,6 +179,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
     const id = selectedRecipe.id
     const newVal = !selectedRecipe.is_favorite
     setFavoriteOverrides((prev) => ({ ...prev, [id]: newVal }))
+    void heartControls.start('pop').then(() => heartControls.start('idle'))
     try {
       const res = await fetch(`/api/recipes/${id}`, {
         method: 'PUT',
@@ -469,42 +486,70 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   </div>
                   {/* Action buttons */}
                   <div className="flex items-center gap-2">
-                    <button
+                    {/* Heart button — 44x44 with pop animation */}
+                    <motion.button
                       onClick={handleFavorite}
                       disabled={mutating}
-                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                       aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
                       title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
                     >
-                      {selectedRecipe.is_favorite ? '❤️' : '🤍'}
-                    </button>
-                    <button
-                      onClick={() => setEditOpen(true)}
-                      disabled={mutating}
-                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                      aria-label="Edit recipe"
-                      title="Edit recipe"
-                    >
-                      ✏️
-                    </button>
-                    <button
-                      onClick={() => setDeleteOpen(true)}
-                      disabled={mutating}
-                      className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                      aria-label="Delete recipe"
-                      title="Delete recipe"
-                    >
-                      🗑️
-                    </button>
-                    <button
-                      onClick={() => setCookOpen(true)}
-                      className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
-                      style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
-                      aria-label="Cook this recipe"
-                      title="Cook it — deduct ingredients from pantry"
-                    >
-                      Cook it
-                    </button>
+                      <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
+                        <Heart
+                          size={20}
+                          weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
+                          color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
+                        />
+                      </motion.span>
+                    </motion.button>
+
+                    {/* Overflow menu — Edit + Delete */}
+                    <div className="relative" ref={menuRef}>
+                      <button
+                        onClick={() => setMenuOpen((o) => !o)}
+                        disabled={mutating}
+                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                        style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                        aria-label="More options"
+                        aria-haspopup="true"
+                        aria-expanded={menuOpen}
+                      >
+                        <DotsThree size={20} weight="bold" color="var(--color-muted)" />
+                      </button>
+                      <AnimatePresence>
+                        {menuOpen && (
+                          <motion.div
+                            initial={{ opacity: 0, scale: 0.9, y: -4 }}
+                            animate={{ opacity: 1, scale: 1, y: 0 }}
+                            exit={{ opacity: 0, scale: 0.9, y: -4 }}
+                            transition={springs.snappy}
+                            className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
+                            style={{
+                              background: 'var(--color-surface)',
+                              border: '1px solid var(--color-border)',
+                              boxShadow: 'var(--shadow-pop)',
+                              minWidth: '140px',
+                            }}
+                          >
+                            <button
+                              onClick={() => { setMenuOpen(false); setEditOpen(true) }}
+                              className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                              style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
+                            >
+                              ✏️ Edit
+                            </button>
+                            <button
+                              onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
+                              className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                              style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
+                            >
+                              🗑️ Delete
+                            </button>
+                          </motion.div>
+                        )}
+                      </AnimatePresence>
+                    </div>
                   </div>
                   {deleteOpen && (
                     <RecipeDeleteConfirm
@@ -554,42 +599,70 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   )}
                 </div>
                 <div className="flex items-center gap-2 mt-2">
-                  <button
+                  {/* Heart button — 44x44 with pop animation */}
+                  <motion.button
                     onClick={handleFavorite}
                     disabled={mutating}
-                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                     aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
                     title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
                   >
-                    {selectedRecipe.is_favorite ? '❤️' : '🤍'}
-                  </button>
-                  <button
-                    onClick={() => setEditOpen(true)}
-                    disabled={mutating}
-                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                    aria-label="Edit recipe"
-                    title="Edit recipe"
-                  >
-                    ✏️
-                  </button>
-                  <button
-                    onClick={() => setDeleteOpen(true)}
-                    disabled={mutating}
-                    className="w-8 h-8 rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] flex items-center justify-center hover:border-[var(--color-primary)] hover:bg-[var(--color-bg)] transition-colors active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                    aria-label="Delete recipe"
-                    title="Delete recipe"
-                  >
-                    🗑️
-                  </button>
-                  <button
-                    onClick={() => setCookOpen(true)}
-                    className="ml-auto px-4 py-1.5 rounded-full text-xs font-bold text-white active:scale-95 transition-transform"
-                    style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
-                    aria-label="Cook this recipe"
-                    title="Cook it — deduct ingredients from pantry"
-                  >
-                    Cook it
-                  </button>
+                    <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
+                      <Heart
+                        size={20}
+                        weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
+                        color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
+                      />
+                    </motion.span>
+                  </motion.button>
+
+                  {/* Overflow menu — Edit + Delete */}
+                  <div className="relative" ref={menuRef}>
+                    <button
+                      onClick={() => setMenuOpen((o) => !o)}
+                      disabled={mutating}
+                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                      aria-label="More options"
+                      aria-haspopup="true"
+                      aria-expanded={menuOpen}
+                    >
+                      <DotsThree size={20} weight="bold" color="var(--color-muted)" />
+                    </button>
+                    <AnimatePresence>
+                      {menuOpen && (
+                        <motion.div
+                          initial={{ opacity: 0, scale: 0.9, y: -4 }}
+                          animate={{ opacity: 1, scale: 1, y: 0 }}
+                          exit={{ opacity: 0, scale: 0.9, y: -4 }}
+                          transition={springs.snappy}
+                          className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
+                          style={{
+                            background: 'var(--color-surface)',
+                            border: '1px solid var(--color-border)',
+                            boxShadow: 'var(--shadow-pop)',
+                            minWidth: '140px',
+                          }}
+                        >
+                          <button
+                            onClick={() => { setMenuOpen(false); setEditOpen(true) }}
+                            className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                            style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
+                          >
+                            ✏️ Edit
+                          </button>
+                          <button
+                            onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
+                            className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                            style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
+                          >
+                            🗑️ Delete
+                          </button>
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  </div>
                 </div>
                 {deleteOpen && (
                   <RecipeDeleteConfirm
@@ -679,6 +752,21 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   whileDrag={{ cursor: 'grabbing' }}
                 >
                   <RecipeDetail recipe={selectedRecipe} />
+
+                  {/* Sticky Cook CTA — pinned at bottom of scroll area */}
+                  <div
+                    className="sticky bottom-0 px-4 py-3"
+                    style={{ background: 'var(--color-surface)', borderTop: '1px solid var(--color-border)' }}
+                  >
+                    <button
+                      onClick={() => setCookOpen(true)}
+                      className="w-full py-3 rounded-full text-sm font-bold text-white active:scale-95 transition-transform"
+                      style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
+                      aria-label="Cook this recipe"
+                    >
+                      🍳 Cook it
+                    </button>
+                  </div>
                 </motion.div>
               </AnimatePresence>
             </div>

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -447,7 +447,6 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     className="absolute inset-0 flex flex-col justify-end px-4 pb-3"
                     style={{
                       background: 'linear-gradient(to top, rgba(0,0,0,0.72) 0%, rgba(0,0,0,0.18) 55%, transparent 100%)',
-                      paddingLeft: '44px', // clear hamburger tab
                     }}
                   >
                     <h2
@@ -465,7 +464,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 </div>
 
                 {/* Tags + chips + actions — below the hero */}
-                <div className="px-4 pt-2 pb-3" style={{ paddingLeft: '44px' }}>
+                <div className="px-4 pt-2 pb-3">
                   {selectedRecipe.tags && selectedRecipe.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1.5 mb-2">
                       {selectedRecipe.tags.map((tag) => (
@@ -578,8 +577,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
             ) : (
               /* Plain header — no thumbnail */
               <div
-                className="px-5 pt-4 pb-3 flex-shrink-0"
-                style={{ paddingLeft: '40px' }}
+                className="px-4 pt-4 pb-3 flex-shrink-0"
               >
                 <h2
                   className="text-xl font-extrabold text-[var(--color-text)] leading-tight"

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -484,84 +484,86 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     {selectedRecipe.difficulty && <MetaChip label={selectedRecipe.difficulty} />}
                     {selectedRecipe.servings && <MetaChip label={`Serves ${selectedRecipe.servings}`} />}
                   </div>
-                  {/* Action buttons */}
-                  <div className="flex items-center gap-2">
-                    {/* Heart button — 44x44 with pop animation */}
-                    <motion.button
-                      onClick={handleFavorite}
-                      disabled={mutating}
-                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
-                      aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
-                      title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-                    >
-                      <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
-                        <Heart
-                          size={20}
-                          weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
-                          color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
-                        />
-                      </motion.span>
-                    </motion.button>
-
-                    {/* Overflow menu — Edit + Delete */}
-                    <div className="relative" ref={menuRef}>
-                      <button
-                        onClick={() => setMenuOpen((o) => !o)}
-                        disabled={mutating}
-                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                        style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
-                        aria-label="More options"
-                        aria-haspopup="true"
-                        aria-expanded={menuOpen}
-                      >
-                        <DotsThree size={20} weight="bold" color="var(--color-muted)" />
-                      </button>
-                      <AnimatePresence>
-                        {menuOpen && (
-                          <motion.div
-                            initial={{ opacity: 0, scale: 0.9, y: -4 }}
-                            animate={{ opacity: 1, scale: 1, y: 0 }}
-                            exit={{ opacity: 0, scale: 0.9, y: -4 }}
-                            transition={springs.snappy}
-                            className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
-                            style={{
-                              background: 'var(--color-surface)',
-                              border: '1px solid var(--color-border)',
-                              boxShadow: 'var(--shadow-pop)',
-                              minWidth: '140px',
-                            }}
-                          >
-                            <button
-                              onClick={() => { setMenuOpen(false); setEditOpen(true) }}
-                              className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
-                              style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
-                            >
-                              ✏️ Edit
-                            </button>
-                            <button
-                              onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
-                              className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
-                              style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
-                            >
-                              🗑️ Delete
-                            </button>
-                          </motion.div>
-                        )}
-                      </AnimatePresence>
-                    </div>
-
-                    {/* Cook it button */}
+                  {/* Action buttons — Cook on left, Heart + menu on right */}
+                  <div className="flex items-center justify-between">
+                    {/* Cook it — primary-tinted to signal the main action */}
                     <button
                       onClick={() => setCookOpen(true)}
                       disabled={mutating}
                       className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                      style={{ background: 'color-mix(in srgb, var(--color-primary) 18%, var(--color-bg))', border: '1.5px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border))' }}
                       aria-label="Cook this recipe"
                       title="Cook it"
                     >
                       🍳
                     </button>
+
+                    <div className="flex items-center gap-2">
+                      {/* Heart button — 44x44 with pop animation */}
+                      <motion.button
+                        onClick={handleFavorite}
+                        disabled={mutating}
+                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                        style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                        aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
+                        title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+                      >
+                        <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
+                          <Heart
+                            size={20}
+                            weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
+                            color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
+                          />
+                        </motion.span>
+                      </motion.button>
+
+                      {/* Overflow menu — Edit + Delete */}
+                      <div className="relative" ref={menuRef}>
+                        <button
+                          onClick={() => setMenuOpen((o) => !o)}
+                          disabled={mutating}
+                          className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                          style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                          aria-label="More options"
+                          aria-haspopup="true"
+                          aria-expanded={menuOpen}
+                        >
+                          <DotsThree size={20} weight="bold" color="var(--color-muted)" />
+                        </button>
+                        <AnimatePresence>
+                          {menuOpen && (
+                            <motion.div
+                              initial={{ opacity: 0, scale: 0.9, y: -4 }}
+                              animate={{ opacity: 1, scale: 1, y: 0 }}
+                              exit={{ opacity: 0, scale: 0.9, y: -4 }}
+                              transition={springs.snappy}
+                              className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
+                              style={{
+                                background: 'var(--color-surface)',
+                                border: '1px solid var(--color-border)',
+                                boxShadow: 'var(--shadow-pop)',
+                                minWidth: '140px',
+                              }}
+                            >
+                              <button
+                                onClick={() => { setMenuOpen(false); setEditOpen(true) }}
+                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
+                              >
+                                ✏️ Edit
+                              </button>
+                              <button
+                                onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
+                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
+                              >
+                                🗑️ Delete
+                              </button>
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                      </div>
+                    </div>
                   </div>
                   {deleteOpen && (
                     <RecipeDeleteConfirm
@@ -611,82 +613,87 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   )}
                 </div>
                 <div className="flex items-center gap-2 mt-2">
-                  {/* Heart button — 44x44 with pop animation */}
-                  <motion.button
-                    onClick={handleFavorite}
-                    disabled={mutating}
-                    className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                    style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
-                    aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
-                    title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
-                  >
-                    <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
-                      <Heart
-                        size={20}
-                        weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
-                        color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
-                      />
-                    </motion.span>
-                  </motion.button>
-
-                  {/* Overflow menu — Edit + Delete */}
-                  <div className="relative" ref={menuRef}>
+                  {/* Action buttons — Cook on left, Heart + menu on right */}
+                  <div className="flex items-center justify-between w-full">
+                    {/* Cook it — primary-tinted to signal the main action */}
                     <button
-                      onClick={() => setMenuOpen((o) => !o)}
+                      onClick={() => setCookOpen(true)}
                       disabled={mutating}
                       className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
-                      aria-label="More options"
-                      aria-haspopup="true"
-                      aria-expanded={menuOpen}
+                      style={{ background: 'color-mix(in srgb, var(--color-primary) 18%, var(--color-bg))', border: '1.5px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border))' }}
+                      aria-label="Cook this recipe"
+                      title="Cook it"
                     >
-                      <DotsThree size={20} weight="bold" color="var(--color-muted)" />
+                      🍳
                     </button>
-                    <AnimatePresence>
-                      {menuOpen && (
-                        <motion.div
-                          initial={{ opacity: 0, scale: 0.9, y: -4 }}
-                          animate={{ opacity: 1, scale: 1, y: 0 }}
-                          exit={{ opacity: 0, scale: 0.9, y: -4 }}
-                          transition={springs.snappy}
-                          className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
-                          style={{
-                            background: 'var(--color-surface)',
-                            border: '1px solid var(--color-border)',
-                            boxShadow: 'var(--shadow-pop)',
-                            minWidth: '140px',
-                          }}
-                        >
-                          <button
-                            onClick={() => { setMenuOpen(false); setEditOpen(true) }}
-                            className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
-                            style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
-                          >
-                            ✏️ Edit
-                          </button>
-                          <button
-                            onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
-                            className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
-                            style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
-                          >
-                            🗑️ Delete
-                          </button>
-                        </motion.div>
-                      )}
-                    </AnimatePresence>
-                  </div>
 
-                  {/* Cook it button */}
-                  <button
-                    onClick={() => setCookOpen(true)}
-                    disabled={mutating}
-                    className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                    style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
-                    aria-label="Cook this recipe"
-                    title="Cook it"
-                  >
-                    🍳
-                  </button>
+                    <div className="flex items-center gap-2">
+                      {/* Heart button — 44x44 with pop animation */}
+                      <motion.button
+                        onClick={handleFavorite}
+                        disabled={mutating}
+                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                        style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                        aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
+                        title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
+                      >
+                        <motion.span variants={heartPopVariants} animate={heartControls} initial="idle">
+                          <Heart
+                            size={20}
+                            weight={selectedRecipe.is_favorite ? 'fill' : 'regular'}
+                            color={selectedRecipe.is_favorite ? 'var(--color-coral)' : 'var(--color-muted)'}
+                          />
+                        </motion.span>
+                      </motion.button>
+
+                      {/* Overflow menu — Edit + Delete */}
+                      <div className="relative" ref={menuRef}>
+                        <button
+                          onClick={() => setMenuOpen((o) => !o)}
+                          disabled={mutating}
+                          className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                          style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                          aria-label="More options"
+                          aria-haspopup="true"
+                          aria-expanded={menuOpen}
+                        >
+                          <DotsThree size={20} weight="bold" color="var(--color-muted)" />
+                        </button>
+                        <AnimatePresence>
+                          {menuOpen && (
+                            <motion.div
+                              initial={{ opacity: 0, scale: 0.9, y: -4 }}
+                              animate={{ opacity: 1, scale: 1, y: 0 }}
+                              exit={{ opacity: 0, scale: 0.9, y: -4 }}
+                              transition={springs.snappy}
+                              className="absolute right-0 top-12 z-20 rounded-2xl overflow-hidden"
+                              style={{
+                                background: 'var(--color-surface)',
+                                border: '1px solid var(--color-border)',
+                                boxShadow: 'var(--shadow-pop)',
+                                minWidth: '140px',
+                              }}
+                            >
+                              <button
+                                onClick={() => { setMenuOpen(false); setEditOpen(true) }}
+                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
+                              >
+                                ✏️ Edit
+                              </button>
+                              <button
+                                onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
+                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
+                              >
+                                🗑️ Delete
+                              </button>
+                            </motion.div>
+                          )}
+                        </AnimatePresence>
+                      </div>
+                    </div>
+                  </div>
                 </div>
                 {deleteOpen && (
                   <RecipeDeleteConfirm

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -550,6 +550,18 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                         )}
                       </AnimatePresence>
                     </div>
+
+                    {/* Cook it button */}
+                    <button
+                      onClick={() => setCookOpen(true)}
+                      disabled={mutating}
+                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                      aria-label="Cook this recipe"
+                      title="Cook it"
+                    >
+                      🍳
+                    </button>
                   </div>
                   {deleteOpen && (
                     <RecipeDeleteConfirm
@@ -663,6 +675,18 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                       )}
                     </AnimatePresence>
                   </div>
+
+                  {/* Cook it button */}
+                  <button
+                    onClick={() => setCookOpen(true)}
+                    disabled={mutating}
+                    className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                    style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
+                    aria-label="Cook this recipe"
+                    title="Cook it"
+                  >
+                    🍳
+                  </button>
                 </div>
                 {deleteOpen && (
                   <RecipeDeleteConfirm
@@ -752,21 +776,6 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   whileDrag={{ cursor: 'grabbing' }}
                 >
                   <RecipeDetail recipe={selectedRecipe} />
-
-                  {/* Sticky Cook CTA — pinned at bottom of scroll area */}
-                  <div
-                    className="sticky bottom-0 px-4 py-3"
-                    style={{ background: 'var(--color-surface)', borderTop: '1px solid var(--color-border)' }}
-                  >
-                    <button
-                      onClick={() => setCookOpen(true)}
-                      className="w-full py-3 rounded-full text-sm font-bold text-white active:scale-95 transition-transform"
-                      style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
-                      aria-label="Cook this recipe"
-                    >
-                      🍳 Cook it
-                    </button>
-                  </div>
                 </motion.div>
               </AnimatePresence>
             </div>

--- a/nextjs/src/lib/motion.ts
+++ b/nextjs/src/lib/motion.ts
@@ -14,7 +14,7 @@ export const heartPopVariants: Variants = {
   pop: {
     scale: [1, 1.4, 0.95, 1.1, 1],
     rotate: [0, -12, 8, -4, 0],
-    transition: springs.pop,
+    transition: { type: 'tween', duration: 0.4, ease: [0.34, 1.56, 0.64, 1] },
   },
 }
 


### PR DESCRIPTION
## Summary

- **Heart button**: bumped to 44×44 tap target (`w-11 h-11`), replaced emoji with Phosphor `Heart` icon, wired to `heartPopVariants` + `useAnimation` for a spring-pop animation on each toggle
- **Edit + Delete**: collapsed into a `DotsThree` overflow menu with `AnimatePresence` popover (`springs.snappy` transition), outside-click dismissal via `mousedown` listener on `document`
- **Cook it**: promoted from inline header pill to a `sticky bottom-0` full-width CTA pinned inside the scrollable recipe body

Both the **hero** (with thumbnail) and **plain** (without thumbnail) render paths are updated. All existing functionality (edit, delete, cook, favorite) is preserved.

## Changes

- `nextjs/src/components/recipes/RecipeBook.tsx` — primary file; +153 / -65 lines
  - Added `useRef`, `useAnimation` to React/framer-motion imports
  - Added `Heart`, `DotsThree` from `@phosphor-icons/react`
  - Added `heartPopVariants` from `@/lib/motion`
  - New state: `menuOpen`, `heartControls`, `menuRef`
  - Outside-click `useEffect` for menu dismissal
  - Updated `handleFavorite` to fire `heartControls.start('pop')` animation
  - Replaced 3-button cluster (heart + edit + delete + cook pill) with heart + dots-menu in both variants
  - Added sticky Cook it CTA at bottom of scrollable body

## Test plan

- [ ] TypeScript: `tsc --noEmit` passes zero errors (verified)
- [ ] Heart button visible, 44px touch target, fills/unfills on tap with pop animation
- [ ] DotsThree button opens popover with Edit and Delete options
- [ ] Popover dismisses on outside click
- [ ] Edit option opens RecipeEditModal
- [ ] Delete option opens RecipeDeleteConfirm strip
- [ ] Cook it sticky CTA visible at bottom of recipe scroll area, opens CookModal
- [ ] Both hero (recipe with thumbnail) and plain (no thumbnail) variants correct