### PR TITLE
fix: repair recipe generate/refine wiring and pin lint tooling

### DIFF
--- a/ai-service/bubbly_chef/api/routes/recipes_ai.py
+++ b/ai-service/bubbly_chef/api/routes/recipes_ai.py
@@ -65,10 +65,10 @@ async def generate_recipe(
     )
 
     try:
-        from bubbly_chef.ai.manager import get_ai_manager
+        from bubbly_chef.api.deps import get_ai_manager
         from bubbly_chef.services.recipe_generator import generate_recipe as gen_recipe
 
-        ai_manager = await get_ai_manager()
+        ai_manager = get_ai_manager()
 
         # Fetch pantry items for grounding
         pantry_items = []
@@ -128,11 +128,11 @@ async def refine_recipe(
     logger.info(f"Recipe refine: user={user_id}, prompt='{request.prompt[:50]}...'")
 
     try:
-        from bubbly_chef.ai.manager import get_ai_manager
+        from bubbly_chef.api.deps import get_ai_manager
         from bubbly_chef.services.recipe_generator import generate_recipe as gen_recipe
         from bubbly_chef.models.recipe import RecipeCard
 
-        ai_manager = await get_ai_manager()
+        ai_manager = get_ai_manager()
 
         # Build a RecipeCard from the dict for the previous_recipe param
         previous_recipe = RecipeCard(**request.recipe) if request.recipe else None

--- a/ai-service/pyproject.toml
+++ b/ai-service/pyproject.toml
@@ -25,8 +25,11 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
-    "ruff>=0.4",
-    "mypy>=1.10",
+    # Pinned to a minor range: these tools gate CI, and unpinned upper bounds mean
+    # a new default-rule set upstream turns CI red without a code change here.
+    # ruff 0.16 expanded its defaults and reports 144 findings on code 0.15 passes.
+    "ruff>=0.15,<0.16",
+    "mypy>=1.10,<2",
 ]
 
 [tool.ruff]

--- a/ai-service/tests/test_recipes_ai_routes.py
+++ b/ai-service/tests/test_recipes_ai_routes.py
@@ -1,0 +1,123 @@
+"""Tests for /v1/recipes/generate and /v1/recipes/refine.
+
+Regression coverage for the wiring of these two routes. Both previously did::
+
+    from bubbly_chef.ai.manager import get_ai_manager   # wrong module
+    ai_manager = await get_ai_manager()                 # not a coroutine
+
+`get_ai_manager` lives in `bubbly_chef.api.deps` and is synchronous, so every
+request raised ImportError inside the route's blanket ``except Exception`` and
+came back as an opaque HTTP 500. Asserting a 200 here catches both mistakes —
+a wrong import module and a spurious await — because either one trips the same
+except branch.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from bubbly_chef.api.auth import get_current_user_id
+from bubbly_chef.main import create_app
+
+TEST_USER_ID = "test-user-123"
+
+_ROUTE_MODULE = "bubbly_chef.api.routes.recipes_ai"
+
+
+@pytest.fixture
+def app():
+    """Create a fresh FastAPI app with auth dependency overridden."""
+    _app = create_app()
+
+    async def _fake_user_id() -> str:
+        return TEST_USER_ID
+
+    _app.dependency_overrides[get_current_user_id] = _fake_user_id
+    return _app
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    """Async HTTP client wired to the test app."""
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+
+
+def _fake_generation_result() -> MagicMock:
+    """Mimic the RecipeGenerationResult shape the routes unpack."""
+    recipe = MagicMock()
+    recipe.model_dump.return_value = {"title": "Tomato Pasta", "ingredients": [], "steps": []}
+
+    result = MagicMock()
+    result.recipe = recipe
+    result.ingredients_status = []
+    result.missing_count = 0
+    result.have_count = 2
+    result.partial_count = 0
+    result.pantry_match_score = 1.0
+    return result
+
+
+def _patched_deps(gen_mock: AsyncMock) -> Any:
+    """Patch the repository and the recipe generator the routes import lazily."""
+    repo = MagicMock()
+    repo.get_all_pantry_items = AsyncMock(return_value=[])
+
+    return (
+        patch(f"{_ROUTE_MODULE}.get_repository", AsyncMock(return_value=repo)),
+        patch("bubbly_chef.services.recipe_generator.generate_recipe", gen_mock),
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_resolves_ai_manager_and_returns_200(client):
+    """POST /v1/recipes/generate wires up without ImportError."""
+    gen_mock = AsyncMock(return_value=_fake_generation_result())
+    repo_patch, gen_patch = _patched_deps(gen_mock)
+
+    with repo_patch, gen_patch, patch("bubbly_chef.api.deps.get_ai_manager") as get_mgr:
+        get_mgr.return_value = MagicMock()
+
+        response = await client.post(
+            "/v1/recipes/generate",
+            json={"prompt": "quick pasta dinner", "use_pantry": True},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["recipe"]["title"] == "Tomato Pasta"
+    # Synchronous call — awaiting it would raise inside the route.
+    get_mgr.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_refine_resolves_ai_manager_and_returns_200(client):
+    """POST /v1/recipes/refine wires up without ImportError."""
+    gen_mock = AsyncMock(return_value=_fake_generation_result())
+    repo_patch, gen_patch = _patched_deps(gen_mock)
+
+    with repo_patch, gen_patch, patch("bubbly_chef.api.deps.get_ai_manager") as get_mgr:
+        get_mgr.return_value = MagicMock()
+
+        response = await client.post(
+            "/v1/recipes/refine",
+            json={"recipe": {}, "prompt": "make it vegetarian"},
+        )
+
+    assert response.status_code == 200, response.text
+    get_mgr.assert_called_once_with()
+
+
+def test_routes_import_get_ai_manager_from_deps():
+    """`get_ai_manager` is defined in api.deps, not ai.manager.
+
+    A direct guard against the import drifting back: `ai.manager` exports the
+    AIManager class and its errors, but never the accessor.
+    """
+    import bubbly_chef.ai.manager as ai_manager_module
+    from bubbly_chef.api.deps import get_ai_manager
+
+    assert not hasattr(ai_manager_module, "get_ai_manager")
+    assert callable(get_ai_manager)


### PR DESCRIPTION
## Summary

`POST /v1/recipes/generate` and `POST /v1/recipes/refine` have been returning HTTP 500 in production. Both imported `get_ai_manager` from `bubbly_chef.ai.manager`, where it does not exist — it lives in `bubbly_chef.api.deps` — and then `await`ed it, though it is synchronous. Each route wraps its body in `except Exception`, so the `ImportError` was converted into an opaque 500 instead of surfacing as a crash.

The frontend calls both endpoints (`nextjs/src/lib/api/recipes.ts:22,42`), so recipe generation and refinement are affected. The chat-driven recipe path is **not** affected — `workflows/router.py:27` already imports from `api.deps`.

Found by running `mypy --strict`, which `CLAUDE.md` lists as a quality gate but CI does not run.

## What lands

- `recipes_ai.py` — import `get_ai_manager` from `bubbly_chef.api.deps` and call it synchronously, at both call sites (generate + refine).
- `tests/test_recipes_ai_routes.py` — new. Asserts both routes return 200 rather than 500, plus a guard documenting which module owns the accessor.
- `pyproject.toml` — pin `ruff>=0.15,<0.16` and `mypy>=1.10,<2`. Both were unbounded, so CI resolved to whatever was newest at run time; ruff 0.16 expanded its default rule set and reports 144 findings on code that 0.15 passes clean. This is why a branch that was CI-green in May would not be green today.

## Tests

Verified the tests reproduce the bug before fixing it: reverted to the original import and both new tests failed with `ImportError: cannot import name 'get_ai_manager' from 'bubbly_chef.ai.manager'`, surfacing as the opaque 500. They pass after the fix.

```
pytest    79 passed, 10 skipped
ruff      All checks passed!   (bubbly_chef/, pinned 0.15.8)
```

## Demo

n/a — no visual surface. The behavioural change is 500 → 200 on two API routes.

## Linked issue

None — found while setting up the quality gates. Happy to file one retroactively if you'd prefer the trace.

## Out of scope

- **`mypy --strict` reports 73 further pre-existing errors** across 10 files. Not addressed here; it is not currently a CI gate despite being documented as one. Worth its own issue.
- The 144 ruff-0.16 findings are pinned around, not fixed. Also worth its own issue if you want to move onto the newer rule set.
- `tenacity` is imported by `tools/llm_client.py:152` but absent from `pyproject.toml` dependencies — it currently resolves transitively via langchain, i.e. works by accident. Left alone here to keep this PR focused.

---

- [ ] `/code-review` run
- [ ] `/interrogate` run (feature-level PRs only)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01EYZf3dywrC59n2QRza3xbc)_