### PR TITLE
fix: declare tenacity as explicit ai-service dependency

### DIFF
--- a/ai-service/pyproject.toml
+++ b/ai-service/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "httpx>=0.27",
     "python-multipart>=0.0.9",
     "recipe-scrapers>=15.0",
+    "tenacity>=8.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

`tenacity` is imported in `ai-service/bubbly_chef/tools/llm_client.py` (retry logic for the Ollama LLM client) but was not listed in `ai-service/pyproject.toml`. It resolved only transitively through `langchain-core`. If langchain ever drops or vendors the dependency, the import silently breaks at runtime.

## What lands

- Adds `"tenacity>=8.0"` to the `[project.dependencies]` array in `ai-service/pyproject.toml`, matching the `>=X.Y` lower-bound style used by every other dependency in the file.

## Tests

No install or test run was performed in this worktree per project convention (worktrees share `.git` but not the dev env). To verify in the primary checkout:

```bash
cd ai-service && uv sync
# confirm tenacity appears in the resolved environment
python -c "import tenacity; print(tenacity.__version__)"
```

## Linked

Closes #130

## Out of scope

- Pinning an upper bound — other deps use open lower bounds only; no reason to deviate.
- Any code changes — the import in `llm_client.py` is correct and unchanged.