### PR TITLE
fix: title-case ingredient & pantry item names at render

### DIFF
--- a/nextjs/src/__tests__/format.test.ts
+++ b/nextjs/src/__tests__/format.test.ts
@@ -1,0 +1,40 @@
+import { titleCase } from '@/lib/format'
+
+describe('titleCase', () => {
+  it('capitalises each word of a multi-word food name', () => {
+    expect(titleCase('cheddar cheese')).toBe('Cheddar Cheese')
+  })
+
+  it('capitalises a single-word name', () => {
+    expect(titleCase('eggs')).toBe('Eggs')
+  })
+
+  it('capitalises olive oil', () => {
+    expect(titleCase('olive oil')).toBe('Olive Oil')
+  })
+
+  it('preserves all-uppercase abbreviations like BBQ', () => {
+    expect(titleCase('BBQ sauce')).toBe('BBQ Sauce')
+  })
+
+  it('handles already title-cased input idempotently', () => {
+    expect(titleCase('Whole Milk')).toBe('Whole Milk')
+  })
+
+  it('collapses internal whitespace', () => {
+    expect(titleCase('brown  sugar')).toBe('Brown Sugar')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(titleCase('  garlic  ')).toBe('Garlic')
+  })
+
+  it('lower-cases the rest of a word', () => {
+    expect(titleCase('BUTTER')).toBe('BUTTER') // all-caps — preserved as abbreviation
+    expect(titleCase('bUTTER')).toBe('Butter')  // mixed — normalised
+  })
+
+  it('handles empty string gracefully', () => {
+    expect(titleCase('')).toBe('')
+  })
+})

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -12,6 +12,7 @@ import AddItemModal from '@/components/pantry/AddItemModal'
 import ThemePicker from '@/components/ui/ThemePicker'
 import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAddSheet'
 import { getFoodEmoji } from '@/lib/food-emoji'
+import { titleCase } from '@/lib/format'
 import Chip from '@/components/ui/Chip'
 
 interface PantryItem {
@@ -249,7 +250,7 @@ function PantryPageInner() {
                         <div className="flex items-center gap-2 mb-1">
                           <span className="text-lg">{getFoodEmoji(item.name, item.category)}</span>
                           <span className="font-semibold text-sm text-[var(--color-text)] truncate">
-                            {item.name}
+                            {titleCase(item.name)}
                           </span>
                         </div>
                         <div className="flex items-center justify-between">

--- a/nextjs/src/components/chat/ChatRecipeCard.tsx
+++ b/nextjs/src/components/chat/ChatRecipeCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import SpringButton from '@/components/ui/SpringButton'
+import { titleCase } from '@/lib/format'
 import type { ChatRecipeData, IngredientAvailability } from '@/types/chat'
 
 interface ChatRecipeCardProps {
@@ -138,7 +139,7 @@ export default function ChatRecipeCard({
                       )}
                       <span>
                         {qtyStr && <span className="font-semibold">{qtyStr} </span>}
-                        {ing.name}
+                        {titleCase(ing.name)}
                       </span>
                     </div>
                     {avail?.status === 'substitute' && avail.substitute_note && (

--- a/nextjs/src/components/chat/PantryProposalCard.tsx
+++ b/nextjs/src/components/chat/PantryProposalCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import SpringButton from '@/components/ui/SpringButton'
+import { titleCase } from '@/lib/format'
 import type { PantryProposalData, PantryProposalAction } from '@/types/chat'
 
 interface PantryProposalCardProps {
@@ -28,7 +29,7 @@ function ActionRow({ action }: { action: PantryProposalAction }) {
         {icon}
       </span>
       <div className="flex-1 min-w-0">
-        <span className="font-semibold text-sm text-[var(--color-text)]">{action.item.name}</span>
+        <span className="font-semibold text-sm text-[var(--color-text)]">{titleCase(action.item.name)}</span>
         {qtyStr && (
           <span className="text-sm text-[var(--color-muted)] ml-1.5">{qtyStr}</span>
         )}

--- a/nextjs/src/components/dashboard/BubblesFeed.tsx
+++ b/nextjs/src/components/dashboard/BubblesFeed.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import BubbleMessage from './BubbleMessage'
+import { titleCase } from '@/lib/format'
 import type { EnrichedPantryItem } from '@/lib/pantry-helpers'
 
 interface Recipe {
@@ -171,7 +172,7 @@ export default function BubblesFeed({ displayName }: BubblesFeedProps) {
           dismissLabel="Not now"
         >
           Heads up! Your{' '}
-          <strong className="font-semibold">{urgentItem.name}</strong> expires{' '}
+          <strong className="font-semibold">{titleCase(urgentItem.name)}</strong> expires{' '}
           {urgentExpiryLabel}! Want me to find a quick recipe using it?
         </BubbleMessage>
       )}

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import BubblesMascot from '@/components/ui/BubblesMascot'
 import FadeInView from '@/components/ui/FadeInView'
+import { titleCase } from '@/lib/format'
 import type { EnrichedPantryItem } from '@/lib/pantry-helpers'
 
 interface Recipe {
@@ -112,7 +113,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
 
   // Compute the single hero message (most important)
   const heroMessage = urgentItem
-    ? `Your ${urgentItem.name} expires ${urgentItem.days_until_expiry === 0 ? 'today' : 'tomorrow'}! Let's cook it up.`
+    ? `Your ${titleCase(urgentItem.name)} expires ${urgentItem.days_until_expiry === 0 ? 'today' : 'tomorrow'}! Let's cook it up.`
     : totalCount === 0
       ? "Your pantry is empty — let's stock up!"
       : recipe

--- a/nextjs/src/lib/format.ts
+++ b/nextjs/src/lib/format.ts
@@ -1,0 +1,29 @@
+/**
+ * Capitalise the first letter of each whitespace-separated word.
+ *
+ * Rules:
+ * - Each word has its first character upper-cased and the rest lower-cased.
+ * - Exception: tokens that are already all-uppercase (e.g. "BBQ", "USA") are
+ *   left entirely as-is so abbreviations survive the transform.
+ * - Leading/trailing whitespace is trimmed; internal runs of whitespace are
+ *   collapsed to a single space.
+ *
+ * Examples:
+ *   "cheddar cheese"  → "Cheddar Cheese"
+ *   "olive oil"       → "Olive Oil"
+ *   "BBQ sauce"       → "BBQ Sauce"
+ *   "all-purpose flour" → "All-purpose Flour"   (hyphen is not a word boundary)
+ */
+export function titleCase(name: string): string {
+  return name
+    .trim()
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .map((word) => {
+      if (word.length === 0) return word
+      // Preserve tokens that are already all-uppercase (abbreviations like BBQ)
+      if (word === word.toUpperCase() && /[A-Z]/.test(word)) return word
+      return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+    })
+    .join(' ')
+}


### PR DESCRIPTION
## Summary

Ingredient and pantry item names stored in the database arrive as lowercase strings (e.g. "cheddar cheese", "eggs"). This PR capitalises them at render time without touching stored data.

## What lands

- New pure helper `nextjs/src/lib/format.ts` — exports `titleCase(name: string): string`. Each whitespace-separated word is capitalised; all-uppercase tokens (e.g. "BBQ") are preserved unchanged.
- `titleCase` applied at every user-facing display site:
  - `nextjs/src/app/pantry/page.tsx` — pantry grid item names (line 253)
  - `nextjs/src/components/chat/PantryProposalCard.tsx` — proposal action rows (line 32)
  - `nextjs/src/components/chat/ChatRecipeCard.tsx` — ingredient list (line 142)
  - `nextjs/src/components/dashboard/BubblesFeed.tsx` — expiry alert bubble (line 175)
  - `nextjs/src/components/dashboard/HeroHome.tsx` — hero message string (line 116)
- Skipped (intentionally not touched): form `<input value>` fields in ScannedItemCard, React keys, emoji/catalog lookups, search filter `.toLowerCase()` comparisons — all use raw values correctly.
- Unit tests at `nextjs/src/__tests__/format.test.ts` mirroring the existing jest style.

## Tests

- Unit tests cover: multi-word food names, single words, all-uppercase abbreviation preservation, idempotency, whitespace collapsing, empty string.
- `npx tsc --noEmit` cannot run in the worktree (no `node_modules`) — run it from the primary checkout on `feat/ui-overhaul` after merging: `cd nextjs && npx tsc --noEmit`.
- Manual: `npm run dev`, visit `/pantry` — items should display as "Cheddar Cheese", "Olive Oil", etc. Chat proposal card and recipe ingredient lists should be title-cased.

## Linked

Closes #132

## Out of scope

- Normalising stored data in the database — display-only fix by design.
- `aria-label` strings in scan flow (those reflect the editable field value, not a standalone display).