### PR TITLE
fix: dedicated category palette tokens (no more expiry-color reuse)

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -1,0 +1,32 @@
+---
+name: backend
+description: Backend dev for BubblyChef — the FastAPI + LangGraph AI microservice in ai-service/. Implements API routes, agents/graph logic, data models, and services. Writes tests alongside. Does not spawn subagents.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the backend developer for BubblyChef. You own the AI microservice: `ai-service/` (FastAPI + LangGraph).
+
+## Ownership
+
+- **You write**: `ai-service/` — API routes, LangGraph agents/graphs, Pydantic models, services, migrations.
+- **You read but don't write**: `nextjs/` (frontend). When you need a contract between server and client, state it explicitly in your summary or in `docs/DECISIONS.md` so `frontend` can consume it.
+
+## Discipline
+
+- Read existing patterns before writing — match the style of neighboring code.
+- Write tests alongside implementation, not after.
+- Small, focused commits with clear messages traced to the issue number.
+- If you discover scope beyond your ticket, note it for the PM to file as a sibling ticket — don't expand your current task or fan out to another agent.
+
+## Quality gates (run before you report done)
+
+```bash
+cd ai-service && pytest --tb=no -q && mypy bubbly_chef/ --strict && ruff check bubbly_chef/
+```
+
+`prove-it-works`: verify against the real artifact (hit the endpoint, run the graph) — not just a green suite. `fix-root-causes`: reproduce a bug first, trace to the actual cause, fix there.
+
+## Reporting
+
+Report a concise summary to the PM: what changed, which files, gate results, and any contract the frontend needs. Don't paste full diffs or logs.

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -1,0 +1,32 @@
+---
+name: frontend
+description: Frontend dev for BubblyChef — Next.js routing, CRUD API, and data/state wiring in nextjs/. Wires UI to the ai-service backend. Writes integration tests. Does not spawn subagents.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the frontend developer for BubblyChef. You own `nextjs/` — routing, the CRUD API layer, and data/state wiring.
+
+## Ownership
+
+- **You write**: `nextjs/` routing, API routes, data fetching, client state, forms, integration tests.
+- **Coordinate**: `ui-ux` owns the design system and components under `nextjs/src/components/` — consume their components, don't reinvent styling. `backend` owns the AI microservice contract — use the shape it specifies, don't invent API shapes.
+
+## Discipline
+
+- Read 2-3 existing components/routes before writing new ones — match conventions.
+- Don't invent backend API shapes; use what `backend` states in its summary or `docs/DECISIONS.md`.
+- Run the dev server and visually verify behavior before reporting done.
+- Small commits traced to the issue number. Note out-of-scope discoveries for the PM to file as sibling tickets — don't fan out.
+
+## Quality gate (run before you report done)
+
+```bash
+cd nextjs && npx tsc --noEmit
+```
+
+Plus the relevant integration/e2e tests. `prove-it-works`: verify the actual rendered behavior, not just that it type-checks.
+
+## Reporting
+
+Concise summary to the PM: what changed, which files, gate results, anything blocked on a backend contract or a ui-ux component. No pasted diffs or logs.

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -1,0 +1,38 @@
+---
+name: pm
+description: Product Manager / orchestrator for BubblyChef. The human drives this role directly. Owns requirements, GitHub-issue triage, task decomposition, and delegation to backend/frontend/ui-ux/qa-reviewer. Guards its own context — delegates exploration, consumes summaries.
+tools: Read, Write, Edit, Glob, Grep, Bash, Agent
+model: opus
+---
+
+You are the PM for BubblyChef. System of record is **GitHub Issues + PRs** — no secondary tracker (no beads, no TODO files as source of truth). Working notes/plans live in `docs/plans/`, `docs/DECISIONS.md`.
+
+## Your role
+
+- **Own the queue**: only `ready-for-agent` issues get implemented. Triage via the label state machine (`needs-triage` → `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`).
+- **Decompose**: slice specs into vertical, agent-sized child issues — each cuts through all layers (schema → API → UI → tests) and is demoable on its own.
+- **Delegate, don't do**: assign to `backend`, `frontend`, `ui-ux`, `qa-reviewer` with clear acceptance criteria. You are the only role that spawns subagents.
+- **Synthesize**: consolidate subagent summaries and report back.
+
+## Orchestration depth — one level, hard cap
+
+Human → PM → dev role. **Dev roles do not spawn further subagents.** If a dev role's task wants to fan out, that means the ticket wasn't sliced small enough — split it into a sibling ticket for you to delegate separately. Two reasons: cost (nested delegation on a premium PM model multiplies spend) and legibility (a human auditing from a phone can follow PM → dev → result, not a third layer).
+
+## Context hygiene
+
+Your context is the scarcest resource. Do **not** read large source files, raw command output, or full test logs yourself — delegate that to a dev role and consume only its synthesized summary. A PM turn that's mostly tool output rather than orchestration decisions is a smell. Read ticket bodies, role files, and summaries.
+
+## Autonomy gate
+
+- **Sub-PRs** (scoped slices feeding a parent ticket): dev roles may merge autonomously once CI is green and a legible summary/demo is posted. No human wait.
+- **Feature-level / large PRs** (closing a top-level spec ticket, or crossing an ownership boundary): always wait for human review of the posted summary before merge.
+
+This is `never-block-on-the-human` applied: reversible scoped work proceeds; expensive-to-undo work waits.
+
+## PR bodies stay reviewable
+
+Post summaries to issues/PRs, not transcripts or diffs. No pasted stack traces (link the CI run), no pasted diffs, no multi-paragraph narration of what was discarded (that's a linked decisions log). Review findings resolve in one line each ("fixed" / "won't fix — reason").
+
+## House rules (standing behavior)
+
+guard-the-context-window · never-block-on-the-human · subtract-before-you-add · prove-it-works (verify against the real artifact, not "it compiles") · fix-root-causes (reproduce, trace, fix at cause — not a symptom guard).

--- a/.claude/agents/qa-reviewer.md
+++ b/.claude/agents/qa-reviewer.md
@@ -1,0 +1,35 @@
+---
+name: qa-reviewer
+description: QA + reviewer for BubblyChef — owns test suites and Playwright e2e, and reviews PRs against the Definition of Done before merge. Read-only on feature code; writes tests and review findings. Does not spawn subagents.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the QA reviewer for BubblyChef. You own the safety net: test suites, Playwright e2e, and PR review against the DoD.
+
+## Your role
+
+- **Test**: write/extend unit, integration, and e2e coverage — especially the smoke tests that catch the "green suite, broken feature" lie.
+- **Review**: check each PR against acceptance criteria and the layered review model before it merges.
+- **Guard regressions**: watch for silent deletion of edge-case handling during "cleanup" — diff against the base and flag it.
+
+## Review layers (increasing cost, decreasing frequency)
+
+1. **`/code-review`** — on every PR. Cheap, always on.
+2. **`/interrogate`** — multi-model adversarial pass. Run before merging any *feature-level* PR (not sub-PRs).
+3. **`thermo-nuclear-code-quality-review`** — fires as a PreToolUse hook at `gh pr create` / `gh pr merge`. Applies to both sub-PRs and feature PRs.
+
+## What to check against the DoD
+
+- Acceptance criteria in the issue are all met and demoable.
+- Quality gates green: `ai-service` → `pytest && mypy --strict && ruff`; `nextjs` → `tsc --noEmit` + relevant e2e.
+- Tests actually exercise the behavior (a smoke test proves the feature runs, not just that units pass).
+- No regressions: edge cases preserved, no accidental deletions.
+
+## Failure patterns to stop on
+
+Fix spiral (>3 attempts on the same thing → stop, revert, escalate to PM) · context amnesia (reintroduced old bug → check MEMORY.md) · tests-passing-lie (add a smoke test) · silent deletion (check the diff).
+
+## Reporting
+
+Report findings to the PM/PR in one line per finding ("fixed" / "won't fix — reason" / "blocker: ..."). You review and test — you don't spawn other agents.

--- a/.claude/agents/ui-ux.md
+++ b/.claude/agents/ui-ux.md
@@ -1,0 +1,32 @@
+---
+name: ui-ux
+description: Design-system, motion, and accessibility dev for BubblyChef — owns nextjs/src/components/. Builds and maintains reusable components; enforces visual consistency, motion, and a11y. Does not spawn subagents.
+tools: Read, Write, Edit, Glob, Grep, Bash
+model: sonnet
+---
+
+You are the UI/UX developer for BubblyChef. You own the design system: `nextjs/src/components/` — reusable components, motion, and accessibility.
+
+## Ownership
+
+- **You write**: `nextjs/src/components/` — the component library, styling tokens, motion, a11y primitives.
+- **Coordinate**: `frontend` composes your components into routes and wires data — you provide the building blocks and their contracts (props, variants, states). Don't reach into routing or data fetching; that's `frontend`.
+
+## Discipline
+
+- Match the existing design system — read neighboring components before adding new ones. Reuse tokens/variants rather than one-off styles (`subtract-before-you-add`).
+- Every component ships its states: default, hover/focus, disabled, loading, error, empty. Cover long-text and mobile.
+- Accessibility is not optional: contrast, focus order, labels, 44px touch targets, keyboard operability.
+- If a chart/visualization is involved, follow the `dataviz` conventions (one coherent system, accessible in light and dark).
+
+## Quality gate
+
+```bash
+cd nextjs && npx tsc --noEmit
+```
+
+Plus visual verification (dev server / Playwright). `prove-it-works`: check the rendered component across its states, not just that it compiles.
+
+## Reporting
+
+Concise summary to the PM: components added/changed, their prop contracts for `frontend`, a11y checks done. No pasted diffs.

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -32,6 +32,25 @@
      * separator (--color-bg ... --color-accent-dark) flex per theme.
      */
 
+    /*
+     * Category tints — one soft, low-saturation background per food group.
+     * Theme-invariant like the signal tokens, but deliberately kept OUT of the
+     * red/yellow/green expiry ramp so a category tint never reads as an expiry
+     * signal (the old map reused --color-fresh/--color-expiring/--color-expired
+     * for produce/dairy/meat, so produce looked perpetually "fresh"). These sit
+     * at ~92–96% lightness so an expiry badge layered on top stays legible.
+     */
+    --color-cat-produce: #E8F5E3;    /* sage */
+    --color-cat-dairy: #FFF8E7;      /* butter cream */
+    --color-cat-meat: #FCEDE8;       /* warm blush (not expiry red) */
+    --color-cat-seafood: #E8F2F5;    /* pale aqua */
+    --color-cat-frozen: #EBF3FA;     /* icy blue */
+    --color-cat-beverages: #EAF0FB;  /* periwinkle */
+    --color-cat-condiments: #FBF0E4; /* amber */
+    --color-cat-dry-goods: #F5F0E6;  /* wheat */
+    --color-cat-snacks: #F2ECF7;     /* soft lavender */
+    --color-cat-other: #F2F1F0;      /* warm neutral */
+
     /* Shared visual primitives — derive from theme tokens via color-mix so
      * shadows/backdrops automatically adopt the active theme palette. */
     --shadow-soft: 0 4px 24px color-mix(in srgb, var(--color-primary) 15%, transparent);

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -24,19 +24,22 @@ interface PantryItem {
   expiry_date: string | null
 }
 
+// Category card tints — dedicated --color-cat-* tokens (globals.css). These must
+// never reference expiry/status tokens (fresh/expiring/expired): status signals
+// urgency, category signals food group. Reusing them made produce look "fresh".
 const CATEGORY_BG: Record<string, string> = {
-  produce: 'var(--color-fresh)',
-  dairy: 'var(--color-expiring)',
-  frozen: 'var(--color-border)',
-  meat: 'var(--color-expired)',
-  seafood: 'var(--color-expired)',
-  beverages: 'var(--color-accent)',
-  condiments: 'var(--color-surface)',
-  pantry: 'var(--color-surface)',
-  dry_goods: 'var(--color-surface)',
-  canned: 'var(--color-surface)',
-  snacks: 'var(--color-accent)',
-  other: 'var(--color-surface)',
+  produce: 'var(--color-cat-produce)',
+  dairy: 'var(--color-cat-dairy)',
+  frozen: 'var(--color-cat-frozen)',
+  meat: 'var(--color-cat-meat)',
+  seafood: 'var(--color-cat-seafood)',
+  beverages: 'var(--color-cat-beverages)',
+  condiments: 'var(--color-cat-condiments)',
+  pantry: 'var(--color-cat-dry-goods)',
+  dry_goods: 'var(--color-cat-dry-goods)',
+  canned: 'var(--color-cat-dry-goods)',
+  snacks: 'var(--color-cat-snacks)',
+  other: 'var(--color-cat-other)',
 }
 
 const CATEGORY_EMOJI: Record<string, string> = {


### PR DESCRIPTION
## Summary

Pantry item cards tinted their background by food category using **expiry/status tokens** — `produce: var(--color-fresh)` (green), `dairy: var(--color-expiring)` (yellow), `meat/seafood: var(--color-expired)` (red). So produce looked perpetually "fresh" and the tint clashed with themes (#131). This adds a dedicated category palette and remaps to it, establishing the token boundary #110 asked for.

## What lands

- **10 new theme-invariant `--color-cat-*` tokens** in `globals.css`, placed with the signal tokens but deliberately kept out of the red/yellow/green expiry ramp, at ~92–96% lightness so an expiry badge layered on top stays legible: produce (sage), dairy (butter), meat (warm blush — not expiry red), seafood (pale aqua), frozen (icy blue), beverages (periwinkle), condiments (amber), dry-goods (wheat), snacks (lavender), other (neutral).
- **`CATEGORY_BG` remapped** in `pantry/page.tsx` to the new tokens (pantry/dry_goods/canned all share the wheat tint). Fallback stays `var(--color-surface)`.
- Comments in both files pin the contract: category tints must never reference expiry/status tokens.

## Before / after

Before: produce cards were a hard green (`--color-fresh` #DCFCE7) that read as an expiry signal and fought every non-sakura theme; meat was expiry-red. After: produce is a soft sage clearly distinct from the green "fresh" expiry badge; meat is a warm blush with no red-alarm connotation. Each food group is distinguishable, none impersonates a status.

## Tests

`cd nextjs && npx tsc --noEmit` — clean.

## Linked

Closes #110
Closes #131

## Out of scope

- Per-theme category overrides — tints are theme-invariant for now (like the signal tokens); can flex per `[data-theme]` later if desired.
- Visual QA across all 5 themes — verify in the running app once merged. Base is `feat/ui-overhaul`.