### PR TITLE
feat: close the expiry→cook loop, seed chat from the tip card, and kill the post-login dead air

### DIFF
--- a/ai-service/bubbly_chef/models/recipe.py
+++ b/ai-service/bubbly_chef/models/recipe.py
@@ -83,7 +83,18 @@ class RecipeConstraints(BaseModel):
     servings: int | None = None
     skill_level: str | None = None
     excluded_ingredients: list[str] = Field(default_factory=list)
-    preferred_ingredients: list[str] = Field(default_factory=list)
+    preferred_ingredients: list[str] = Field(
+        default_factory=list,
+        description="Ingredients the user would like included (soft preference)",
+    )
+    must_use_ingredients: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ingredients the user explicitly wants to use up — e.g. 'what can I make "
+            "with my eggs before they go bad'. Stronger than preferred_ingredients: "
+            "every suggestion must actually use these."
+        ),
+    )
 
 
 class IngredientAvailability(BaseModel):

--- a/ai-service/bubbly_chef/workflows/recipe/nodes.py
+++ b/ai-service/bubbly_chef/workflows/recipe/nodes.py
@@ -100,7 +100,19 @@ RECIPE_CONSTRAINTS_SYSTEM_PROMPT = (
     "Return structured data: cuisine preference, meal_type (breakfast/lunch/dinner/snack), "
     "mood/style, dietary restrictions, time limit, servings, skill level, "
     "and any ingredients they specifically want to include or exclude. "
-    "If a field is not mentioned, leave it as null/empty."
+    "If a field is not mentioned, leave it as null/empty.\n\n"
+    "Distinguish the two ingredient-inclusion fields carefully:\n"
+    "- must_use_ingredients: the user names a specific ingredient they want to USE UP "
+    "or cook WITH. Any phrasing that anchors the request to a named ingredient counts — "
+    "'what can I make with my eggs', 'use up my spinach before it goes bad', "
+    "'I need to finish the chicken', 'something with the leftover rice', "
+    "'recipe using my tomatoes'.\n"
+    "- preferred_ingredients: a softer nice-to-have — 'I'm in the mood for something "
+    "with cheese', 'maybe add mushrooms'.\n\n"
+    "Record only the ingredient name in must_use_ingredients (e.g. 'eggs', not "
+    "'my eggs' or 'eggs before they go bad'). Leave it empty if the user names no "
+    "specific ingredient (e.g. 'what's for dinner?', 'give me a quick pasta recipe' — "
+    "'pasta' there is a dish, not an ingredient the user is using up)."
 )
 
 BRAINSTORM_SYSTEM_PROMPT = """\
@@ -109,6 +121,8 @@ and constraints, suggest 3-4 recipe ideas.
 
 Rules:
 - Each idea should be a recipe name (2-5 words), not a full recipe
+- If "Must use" ingredients are listed, EVERY idea must actually use them — \
+this overrides every other preference
 - Prioritize ingredients marked as expiring soon
 - Match the cuisine/mood if specified
 - ALL suggestions must be for the same meal type — if meal_type is specified, \
@@ -122,6 +136,8 @@ GROUNDED_RECIPE_SYSTEM_PROMPT = """\
 Generate a complete recipe card for "{recipe_name}".
 
 Constraints: {constraints_json}
+Must-use ingredients (the user asked to cook with these — the recipe MUST \
+include them): {must_use_items}
 Priority ingredients (expiring soon — use first): {priority_items}
 Supporting ingredients available: {supporting_items}
 Context: {context}
@@ -284,15 +300,20 @@ def score_and_rank(
     Deterministically score and rank pantry items for recipe grounding.
 
     Scoring:
+    - item in must_use_ingredients: +20 (also tagged `_must_use`)
     - days_until_expiry <= 3: +10
     - days_until_expiry <= 7: +5
     - item name matches cuisine keywords: +3
     - item in preferred_ingredients: +5
     - item in excluded_ingredients: -100
+
+    Scores compose — a must-use item that is also expiring outranks one that
+    isn't, so expiry urgency still orders items within the must-use group.
     """
     cuisine = (constraints.get("cuisine") or "").lower()
     preferred = {p.lower() for p in (constraints.get("preferred_ingredients") or [])}
     excluded = {e.lower() for e in (constraints.get("excluded_ingredients") or [])}
+    must_use = {m.lower() for m in (constraints.get("must_use_ingredients") or [])}
     cuisine_keywords = CUISINE_INGREDIENTS.get(cuisine, set())
 
     today = date.today()
@@ -301,6 +322,11 @@ def score_and_rank(
     for item in pantry_items:
         name_lower = (item.get("name") or "").lower()
         score = 0.0
+
+        # "Use up my X" — dominates expiry so the named ingredient leads the list
+        is_must_use = any(m in name_lower or name_lower in m for m in must_use)
+        if is_must_use:
+            score += 20
 
         # Expiry urgency
         expiry_str = item.get("expiry_date")
@@ -327,7 +353,7 @@ def score_and_rank(
         if any(e in name_lower or name_lower in e for e in excluded):
             score -= 100
 
-        scored.append({**item, "_score": score})
+        scored.append({**item, "_score": score, "_must_use": is_must_use})
 
     scored.sort(key=lambda x: x.get("_score", 0), reverse=True)
     # Filter out excluded items (negative score)
@@ -462,19 +488,31 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
 
     # Build ingredient summary for the prompt
     if scored_items:
-        expiring = [i for i in scored_items if i.get("_score", 0) >= 10]
+        must_use = [i for i in scored_items if i.get("_must_use")]
+        rest = [i for i in scored_items if not i.get("_must_use")]
+        expiring = [i for i in rest if i.get("_score", 0) >= 10]
         supporting = [
-            i for i in scored_items
+            i for i in rest
             if i.get("_score", 0) < 10 and i.get("_score", 0) >= 0
         ]
         expiring_str = ", ".join(i.get("name", "") for i in expiring[:5])
         supporting_str = ", ".join(i.get("name", "") for i in supporting[:10])
-        pantry_context = f"\nExpiring soon (prioritize): {expiring_str or 'none'}"
+        pantry_context = ""
+        if must_use:
+            must_use_str = ", ".join(i.get("name", "") for i in must_use[:5])
+            pantry_context += f"\nMust use (the user asked to cook with these): {must_use_str}"
+        pantry_context += f"\nExpiring soon (prioritize): {expiring_str or 'none'}"
         pantry_context += f"\nOther available: {supporting_str or 'none'}"
     else:
         pantry_context = "\nNo pantry items available — suggest general recipes."
 
     constraints_str = ""
+    # Named ingredients that aren't in the pantry still bind the suggestions.
+    if constraints.get("must_use_ingredients"):
+        constraints_str += (
+            f"\nMust use: {', '.join(constraints['must_use_ingredients'])}"
+            " — every suggestion has to include these"
+        )
     if constraints.get("meal_type"):
         constraints_str += f"\nMeal type: {constraints['meal_type']}"
     if constraints.get("cuisine"):
@@ -567,6 +605,14 @@ async def generate_grounded_recipe(state: WorkflowState) -> WorkflowState:
         if pantry_snapshot:
             scored_items = score_and_rank(pantry_snapshot, constraints)
 
+    # Must-use names come from the constraint itself so ingredients the user
+    # named but doesn't have in the pantry still bind the recipe.
+    must_use_names: list[str] = list(constraints.get("must_use_ingredients") or [])
+    for item in scored_items:
+        name = str(item.get("name") or "")
+        if item.get("_must_use") and name and name not in must_use_names:
+            must_use_names.append(name)
+
     priority_items = [_format_pantry_item_for_prompt(i) for i in scored_items if i.get("_score", 0) >= 5]
     supporting_items = [
         _format_pantry_item_for_prompt(i) for i in scored_items
@@ -583,6 +629,7 @@ async def generate_grounded_recipe(state: WorkflowState) -> WorkflowState:
     prompt = GROUNDED_RECIPE_SYSTEM_PROMPT.format(
         recipe_name=recipe_name,
         constraints_json=constraints_json,
+        must_use_items=", ".join(must_use_names[:5]) or "none specified",
         priority_items=", ".join(priority_items[:8]) or "none specified",
         supporting_items=", ".join(supporting_items[:10]) or "none",
         context=context,

--- a/ai-service/pyproject.toml
+++ b/ai-service/pyproject.toml
@@ -25,8 +25,13 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
-    "ruff>=0.4",
-    "mypy>=1.10",
+    # Upper bounds are load-bearing, not caution. CI installs the newest matching
+    # release, so an unbounded spec means the lint gate changes under you: ruff
+    # 0.16 expanded its default rule set and reports 144 findings on code 0.15
+    # passes clean. Adopting that rule set is tracked in #129 — until then, moving
+    # this bound turns CI red on every branch at once.
+    "ruff>=0.15,<0.16",
+    "mypy>=1.10,<2",
 ]
 
 [tool.ruff]

--- a/ai-service/tests/test_must_use_ingredients.py
+++ b/ai-service/tests/test_must_use_ingredients.py
@@ -1,0 +1,257 @@
+"""Issue #138: "must use this ingredient" hint in the recipe grounding workflow.
+
+Covers the deep-link flow where tapping an expiring pantry item auto-sends
+"What can I make with my eggs before they go bad?" — the grounding workflow
+must bias suggestions toward that ingredient instead of treating it as
+generic chatter.
+"""
+
+from datetime import date, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bubbly_chef.models.recipe import RecipeConstraints
+from bubbly_chef.workflows.recipe.nodes import (
+    brainstorm_recipe_ideas,
+    extract_recipe_constraints,
+    generate_grounded_recipe,
+    score_and_rank,
+)
+from bubbly_chef.workflows.state import LLMRecipeResult
+
+
+def _mock_ai(return_value: Any) -> Any:
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value=return_value)
+    return patch(
+        "bubbly_chef.workflows.recipe.nodes.get_ai_manager",
+        MagicMock(return_value=ai),
+    )
+
+
+def _item(name: str, days_until_expiry: int | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {"name": name, "quantity": 1, "unit": "item"}
+    if days_until_expiry is not None:
+        item["expiry_date"] = (date.today() + timedelta(days=days_until_expiry)).isoformat()
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+
+
+def test_constraints_default_to_empty_must_use() -> None:
+    assert RecipeConstraints().must_use_ingredients == []
+
+
+# ---------------------------------------------------------------------------
+# extract_recipe_constraints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extraction_populates_must_use_ingredients() -> None:
+    """The structured LLM result's must_use_ingredients reaches workflow state."""
+    extracted = RecipeConstraints(meal_type="dinner", must_use_ingredients=["eggs"])
+    with _mock_ai(extracted):
+        result = await extract_recipe_constraints(
+            {"input_text": "What can I make with my eggs before they go bad?"}
+        )
+    assert result["recipe_constraints"]["must_use_ingredients"] == ["eggs"]
+
+
+@pytest.mark.asyncio
+async def test_extraction_prompt_explains_must_use_field() -> None:
+    """The prompt has to teach the model the must-use vs. preferred distinction."""
+    with _mock_ai(RecipeConstraints()) as mock_mgr:
+        await extract_recipe_constraints({"input_text": "what's for dinner?"})
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "must_use_ingredients" in prompt
+    assert "preferred_ingredients" in prompt
+
+
+@pytest.mark.asyncio
+async def test_extraction_without_named_ingredient_stays_empty() -> None:
+    """Regression guard: generic requests must not gain a phantom constraint."""
+    with _mock_ai(RecipeConstraints(meal_type="dinner")):
+        result = await extract_recipe_constraints({"input_text": "what's for dinner?"})
+    assert result["recipe_constraints"]["must_use_ingredients"] == []
+
+
+@pytest.mark.asyncio
+async def test_extraction_failure_still_yields_usable_constraints() -> None:
+    """A failed LLM call must not break the node (pre-existing behaviour)."""
+    ai = MagicMock()
+    ai.complete = AsyncMock(side_effect=RuntimeError("provider down"))
+    with patch(
+        "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+    ):
+        result = await extract_recipe_constraints({"input_text": "use up my eggs"})
+    # Constraints collapse to {} on failure — downstream reads must stay safe
+    assert result["recipe_constraints"].get("must_use_ingredients", []) == []
+    assert result["recipe_constraints"]["meal_type"]  # defaulted from time of day
+    assert score_and_rank([_item("eggs")], result["recipe_constraints"])
+
+
+# ---------------------------------------------------------------------------
+# score_and_rank
+# ---------------------------------------------------------------------------
+
+
+def test_must_use_item_outranks_a_more_urgent_item() -> None:
+    """The named ingredient leads even when something else expires sooner."""
+    items = [_item("milk", days_until_expiry=1), _item("eggs", days_until_expiry=20)]
+    ranked = score_and_rank(items, {"must_use_ingredients": ["eggs"]})
+    assert ranked[0]["name"] == "eggs"
+    assert ranked[0]["_must_use"] is True
+    assert ranked[1]["_must_use"] is False
+
+
+def test_must_use_composes_with_expiry_rather_than_replacing_it() -> None:
+    """Within the must-use group, expiry urgency still orders items."""
+    items = [_item("eggs", days_until_expiry=20), _item("egg noodles", days_until_expiry=1)]
+    ranked = score_and_rank(items, {"must_use_ingredients": ["egg"]})
+    assert [i["name"] for i in ranked] == ["egg noodles", "eggs"]
+    assert ranked[0]["_score"] == 30  # 20 must-use + 10 expiring
+    assert ranked[1]["_score"] == 20
+
+
+def test_must_use_matches_substring_both_directions() -> None:
+    items = [_item("large free-range eggs"), _item("flour")]
+    ranked = score_and_rank(items, {"must_use_ingredients": ["eggs"]})
+    assert ranked[0]["name"] == "large free-range eggs"
+    assert ranked[0]["_must_use"] is True
+
+
+def test_exclusion_still_beats_must_use() -> None:
+    """An excluded ingredient stays filtered out even if also flagged must-use."""
+    items = [_item("eggs"), _item("flour")]
+    ranked = score_and_rank(
+        items, {"must_use_ingredients": ["eggs"], "excluded_ingredients": ["eggs"]}
+    )
+    assert [i["name"] for i in ranked] == ["flour"]
+
+
+def test_empty_must_use_leaves_existing_ranking_unchanged() -> None:
+    """Regression guard: no must-use hint means the old scoring, untouched."""
+    items = [_item("flour"), _item("milk", days_until_expiry=2), _item("basil")]
+    baseline = score_and_rank(items, {"cuisine": "italian"})
+    with_empty = score_and_rank(items, {"cuisine": "italian", "must_use_ingredients": []})
+    assert [i["name"] for i in baseline] == [i["name"] for i in with_empty]
+    assert [i["_score"] for i in baseline] == [10, 3, 0]  # milk, basil, flour
+    assert all(i["_must_use"] is False for i in baseline)
+
+
+# ---------------------------------------------------------------------------
+# brainstorm_recipe_ideas — prompt grounding
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_prompt_surfaces_must_use_ingredient() -> None:
+    scored = score_and_rank(
+        [_item("eggs"), _item("flour")], {"must_use_ingredients": ["eggs"]}
+    )
+    with _mock_ai("**Egg Fried Rice**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "What can I make with my eggs before they go bad?",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {"must_use_ingredients": ["eggs"]},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "Must use" in prompt
+    assert "eggs" in prompt
+    # The must-use item must not be mislabelled as expiring
+    expiring_line = next(li for li in prompt.splitlines() if li.startswith("Expiring soon"))
+    assert "eggs" not in expiring_line
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_surfaces_must_use_ingredient_absent_from_pantry() -> None:
+    """A named ingredient the user doesn't own still binds the suggestions."""
+    with _mock_ai("**Egg Fried Rice**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "something with eggs",
+                "scored_pantry_items": [],
+                "recipe_constraints": {"must_use_ingredients": ["eggs"]},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "Must use: eggs" in prompt
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_prompt_omits_must_use_when_unset() -> None:
+    """Regression guard: no hint means no must-use noise in the prompt."""
+    scored = score_and_rank([_item("flour"), _item("milk", days_until_expiry=1)], {})
+    with _mock_ai("**Pancakes**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "what's for dinner?",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    # The static rule mentions "Must use", but no must-use data line is emitted
+    assert not any(li.startswith("Must use") for li in prompt.splitlines())
+    assert "Expiring soon (prioritize): milk" in prompt
+
+
+# ---------------------------------------------------------------------------
+# generate_grounded_recipe — prompt grounding
+# ---------------------------------------------------------------------------
+
+
+def _llm_recipe() -> LLMRecipeResult:
+    return LLMRecipeResult(
+        title="Egg Fried Rice",
+        ingredients=[{"name": "eggs", "quantity": 2, "unit": "item"}],
+        instructions=["Scramble the eggs."],
+        confidence=0.9,
+    )
+
+
+@pytest.mark.asyncio
+async def test_grounded_recipe_prompt_names_must_use_ingredient() -> None:
+    scored = score_and_rank([_item("eggs"), _item("rice")], {"must_use_ingredients": ["eggs"]})
+    with _mock_ai(_llm_recipe()) as mock_mgr:
+        await generate_grounded_recipe(
+            {
+                "selected_recipe_name": "Egg Fried Rice",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {"must_use_ingredients": ["eggs"]},
+                "warnings": [],
+                "errors": [],
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "Must-use ingredients" in prompt
+    must_use_line = next(li for li in prompt.splitlines() if li.startswith("Must-use"))
+    assert "eggs" in must_use_line
+
+
+@pytest.mark.asyncio
+async def test_grounded_recipe_prompt_without_must_use_is_unchanged() -> None:
+    """Regression guard: the must-use slot degrades to 'none specified'."""
+    scored = score_and_rank([_item("rice")], {})
+    with _mock_ai(_llm_recipe()) as mock_mgr:
+        result = await generate_grounded_recipe(
+            {
+                "selected_recipe_name": "Egg Fried Rice",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {},
+                "warnings": [],
+                "errors": [],
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    must_use_line = next(li for li in prompt.splitlines() if li.startswith("Must-use"))
+    assert "none specified" in must_use_line
+    assert result["proposal"].recipe.title == "Egg Fried Rice"

--- a/docs/agents/roles/frontend.md
+++ b/docs/agents/roles/frontend.md
@@ -20,7 +20,12 @@ presentational components rather than styling from scratch.
 ## Reads (does not edit)
 
 - `nextjs/src/components/**` — imports and composes `ui-ux`'s components; may not
-  change their internals or styling without going through `ui-ux`
+  change their internals or styling without going through `ui-ux`. **Exception:**
+  container components that fetch their own data and own their loading/error state
+  (e.g. `components/dashboard/HeroHome.tsx`) are writable by this role for data,
+  state, and loading structure — but only reusing visual idioms that already exist.
+  Introducing a new one (novel skeleton style, new focus ring, a non-token colour)
+  still goes through `ui-ux`. See the boundary section in `ui-ux.md`.
 - `ai-service/bubbly_chef/models/` — response shapes to build client-side types
   against
 

--- a/docs/agents/roles/ui-ux.md
+++ b/docs/agents/roles/ui-ux.md
@@ -43,6 +43,21 @@ in the route tree*. A component's props interface is the seam — change it only
 after confirming with `frontend` (or via the PM if delegated in parallel), since
 `frontend` is the caller.
 
+**Container components are the exception.** A handful of components under
+`nextjs/src/components/` are not presentational at all — they fetch their own data
+and own their own loading/error state. `dashboard/HeroHome.tsx` is the clearest
+case: it fires three API calls and decides what renders while they're in flight.
+For these, `frontend` writes the data, state, and loading *structure* (which
+regions skeleton, what paints first), and `ui-ux` owns the visual language those
+regions consume — tokens, motion config, the skeleton idiom, focus treatment.
+
+Practically: `frontend` **reusing** an existing visual idiom inside a container is
+not a boundary crossing and needs no sign-off. `frontend` **introducing a new**
+one — a novel skeleton style, a new focus ring, a colour that isn't a token — does,
+and should come back through `ui-ux` or the PM. Accessibility remains this role's
+explicit responsibility (see Conventions), so a11y work inside a container is
+`ui-ux`'s to review even when `frontend` physically made the edit.
+
 ## Conventions
 
 - Tailwind only, no custom CSS files outside the global design-token layer.

--- a/nextjs/src/__tests__/chat-deep-links.test.tsx
+++ b/nextjs/src/__tests__/chat-deep-links.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Issues #143 / #138 — the chat page's deep-link seeds, driven end to end
+ * through the real `ChatPage` component.
+ *
+ * What matters here and can't be checked by the type system:
+ *  - the seeded question is *auto-sent* (the tap on the dashboard/pantry card is
+ *    the single tap both #138 acceptance criteria budget for),
+ *  - it fires exactly once, never again on re-render,
+ *  - and a bare `/chat` stays a clean, empty conversation (#143's explicit
+ *    "no context bleed" criterion).
+ */
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { ThemeProvider } from '@/components/ThemeProvider'
+
+// react-markdown / remark-gfm ship ESM only and jest runs this suite as CJS.
+// Stubbing them keeps the transform out of the picture — this suite never
+// asserts on rendered markdown.
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}))
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => undefined }))
+
+const replace = jest.fn()
+let searchParams = new URLSearchParams('')
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace, push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => searchParams,
+}))
+
+const sendMessage = jest.fn()
+const startNewChat = jest.fn()
+
+jest.mock('@/hooks/useChat', () => ({
+  useChat: () => ({
+    messages: [],
+    isStreaming: false,
+    proposalStates: {},
+    sendMessage,
+    cancelStream: jest.fn(),
+    startNewChat,
+    approveProposal: jest.fn(),
+    rejectProposal: jest.fn(),
+  }),
+}))
+
+jest.mock('@/lib/api/chat', () => ({
+  checkAIHealth: jest.fn(async () => ({ ai_available: true, providers: [] })),
+}))
+
+const fetchRecipe = jest.fn()
+jest.mock('@/lib/api/recipes', () => ({ fetchRecipe: (id: string) => fetchRecipe(id) }))
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const ChatPage = require('@/app/chat/page').default as () => React.JSX.Element
+
+/** The header's ThemePicker needs the real provider (see ThemePicker.test.tsx). */
+function renderChat() {
+  return render(
+    <ThemeProvider>
+      <ChatPage />
+    </ThemeProvider>,
+  )
+}
+
+/** Point the mocked `useSearchParams` at a query string, stable per render. */
+function withParams(query: string) {
+  searchParams = new URLSearchParams(query)
+}
+
+// jsdom ships neither of these, and the chat surface uses both.
+beforeAll(() => {
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia
+  Element.prototype.scrollIntoView = () => {}
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  withParams('')
+})
+
+describe('bare /chat — no context bleed', () => {
+  it('sends nothing and shows no context card', async () => {
+    renderChat()
+
+    await waitFor(() => expect(screen.getByText('Chat with Bubbles')).toBeInTheDocument())
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(screen.queryByText(/Today's tip/i)).toBeNull()
+    expect(screen.queryByText(/Using your/i)).toBeNull()
+  })
+
+  it('ignores params that are not seeds', async () => {
+    withParams('mode=recipe')
+    renderChat()
+
+    await waitFor(() => expect(screen.getByText('Chat with Bubbles')).toBeInTheDocument())
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe('/chat?tip= — dashboard tip handoff (#143)', () => {
+  const tip = 'Pasta water makes sauces silky.'
+
+  it('auto-asks Bubbles to explain the tip, and shows it above the thread', async () => {
+    withParams(new URLSearchParams({ tip }).toString())
+    renderChat()
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    expect(sendMessage).toHaveBeenCalledWith(
+      `Tell me more about this kitchen tip: "${tip}" — why does it work, and when should I use it?`,
+    )
+    expect(screen.getByText("Today's tip")).toBeInTheDocument()
+    expect(screen.getByText(tip)).toBeInTheDocument()
+  })
+
+  it('dismissing the card drops the param so a refresh does not re-fire it', async () => {
+    withParams(new URLSearchParams({ tip }).toString())
+    renderChat()
+
+    await waitFor(() => expect(screen.getByText("Today's tip")).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /dismiss tip context/i }))
+
+    await waitFor(() => expect(screen.queryByText("Today's tip")).toBeNull())
+    expect(replace).toHaveBeenCalledWith('/chat', { scroll: false })
+  })
+})
+
+describe('/chat?use= — expiring item handoff (#138)', () => {
+  it('auto-sends the tuned "with my <name>" question, verbatim name', async () => {
+    withParams(new URLSearchParams({ use: 'eggs', expires: '2026-07-29' }).toString())
+    renderChat()
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    expect(sendMessage).toHaveBeenCalledWith(
+      'What can I make with my eggs before they go bad?',
+    )
+  })
+
+  it('visibly reflects the ingredient and its expiry', async () => {
+    const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    withParams(new URLSearchParams({ use: 'eggs', expires: tomorrow }).toString())
+    renderChat()
+
+    await waitFor(() => expect(screen.getByText('Using your eggs')).toBeInTheDocument())
+    expect(screen.getByText('expires tomorrow')).toBeInTheDocument()
+  })
+
+  it('fires exactly once across re-renders', async () => {
+    withParams(new URLSearchParams({ use: 'spinach' }).toString())
+    const { rerender } = renderChat()
+
+    await waitFor(() => expect(sendMessage).toHaveBeenCalledTimes(1))
+    const tree = (
+      <ThemeProvider>
+        <ChatPage />
+      </ThemeProvider>
+    )
+    rerender(tree)
+    rerender(tree)
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('cook handoff still wins', () => {
+  it('does not auto-send when ?cooking= is present', async () => {
+    fetchRecipe.mockResolvedValue({ id: 'r1', title: 'Carbonara', ingredients: [] })
+    withParams('cooking=r1&use=eggs')
+    renderChat()
+
+    await waitFor(() => expect(fetchRecipe).toHaveBeenCalledWith('r1'))
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(screen.queryByText('Using your eggs')).toBeNull()
+  })
+})

--- a/nextjs/src/__tests__/chat-seed.test.ts
+++ b/nextjs/src/__tests__/chat-seed.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Issues #143 (dashboard tip → primed chat) and #138 (expiring item → seeded
+ * "cook this now" chat).
+ *
+ * The seeded message text is the *only* channel the AI service has for the
+ * must-use ingredient — it runs an LLM structured-output pass over the message,
+ * with no regex fallback and no API field. So these assertions on the exact
+ * wording are load-bearing, not cosmetic: changing them silently breaks the
+ * binding between the tapped item and the recipe that comes back.
+ */
+import {
+  cookThisHref,
+  deriveChatSeed,
+  expiryPhrase,
+  tipChatHref,
+  tipSeedMessage,
+  ingredientSeedMessage,
+} from '@/lib/chat-seed'
+
+/** Parse a `/chat?...` href back into something `deriveChatSeed` can read. */
+function paramsOf(href: string): URLSearchParams {
+  return new URLSearchParams(href.slice(href.indexOf('?') + 1))
+}
+
+describe('no context bleed', () => {
+  it('returns no seed for a bare /chat (bottom-nav entry)', () => {
+    expect(deriveChatSeed(new URLSearchParams(''))).toBeNull()
+  })
+
+  it('returns no seed for unrelated params', () => {
+    expect(deriveChatSeed(new URLSearchParams('mode=recipe&foo=bar'))).toBeNull()
+  })
+
+  it('ignores blank or whitespace-only params', () => {
+    expect(deriveChatSeed(new URLSearchParams('tip='))).toBeNull()
+    expect(deriveChatSeed(new URLSearchParams('use=%20%20'))).toBeNull()
+  })
+
+  it('ignores a stray expires= with no ingredient', () => {
+    expect(deriveChatSeed(new URLSearchParams('expires=2026-07-29'))).toBeNull()
+  })
+})
+
+describe('?use= seed (#138)', () => {
+  it('emits the phrasing the backend extractor was tuned against', () => {
+    expect(ingredientSeedMessage('eggs')).toBe(
+      'What can I make with my eggs before they go bad?',
+    )
+  })
+
+  it('keeps the "with my <name>" anchor the extractor keys on', () => {
+    const seed = deriveChatSeed(new URLSearchParams('use=spinach'))
+    expect(seed?.message).toContain('with my spinach')
+  })
+
+  it('interpolates the pantry name verbatim — no pluralising or title-casing', () => {
+    const name = 'large free-range eggs'
+    const seed = deriveChatSeed(paramsOf(cookThisHref(name)))
+    expect(seed?.message).toBe('What can I make with my large free-range eggs before they go bad?')
+    expect(seed?.card.title).toBe('Using your large free-range eggs')
+  })
+
+  it('reflects the ingredient and its expiry in the context card', () => {
+    const now = new Date('2026-07-28T09:00:00Z')
+    const seed = deriveChatSeed(new URLSearchParams('use=eggs&expires=2026-07-29'), now)
+    expect(seed?.kind).toBe('use')
+    expect(seed?.card.title).toBe('Using your eggs')
+    expect(seed?.card.subtitle).toBe('expires tomorrow')
+  })
+
+  it('falls back to a generic subtitle when no expiry is supplied', () => {
+    const seed = deriveChatSeed(new URLSearchParams('use=eggs'))
+    expect(seed?.card.subtitle).toBe('before it goes bad')
+  })
+
+  it('round-trips names containing spaces and punctuation through the href', () => {
+    const name = "chef's & co. crème fraîche"
+    const seed = deriveChatSeed(paramsOf(cookThisHref(name, '2026-08-01')))
+    expect(seed?.message).toContain(`with my ${name}`)
+  })
+
+  it('gives distinct seeds distinct keys so dismissal does not leak across items', () => {
+    const a = deriveChatSeed(paramsOf(cookThisHref('eggs')))
+    const b = deriveChatSeed(paramsOf(cookThisHref('spinach')))
+    expect(a?.key).not.toBe(b?.key)
+  })
+})
+
+describe('?tip= seed (#143)', () => {
+  const tip = 'Pasta water makes sauces silky.'
+
+  it('carries the tip text verbatim into the message sent to Bubbles', () => {
+    const seed = deriveChatSeed(paramsOf(tipChatHref(tip)))
+    expect(seed?.kind).toBe('tip')
+    expect(seed?.message).toContain(tip)
+  })
+
+  it('asks for the why and the when, which is what the issue calls for', () => {
+    expect(tipSeedMessage(tip)).toBe(
+      `Tell me more about this kitchen tip: "${tip}" — why does it work, and when should I use it?`,
+    )
+  })
+
+  it('shows the tip in a dismissible context card', () => {
+    const seed = deriveChatSeed(paramsOf(tipChatHref(tip)))
+    expect(seed?.card.label).toBe("Today's tip")
+    expect(seed?.card.title).toBe(tip)
+    expect(seed?.card.dismissLabel).toMatch(/dismiss/i)
+  })
+
+  it('wins over ?use= if both are somehow present', () => {
+    expect(deriveChatSeed(new URLSearchParams('tip=Salt+early&use=eggs'))?.kind).toBe('tip')
+  })
+})
+
+describe('expiryPhrase', () => {
+  const now = new Date('2026-07-28T09:00:00Z')
+
+  it.each([
+    ['2026-07-27', 'already expired'],
+    ['2026-07-28', 'expires today'],
+    ['2026-07-29', 'expires tomorrow'],
+    ['2026-08-01', 'expires in 4 days'],
+  ])('%s → %s', (date, expected) => {
+    expect(expiryPhrase(date, now)).toBe(expected)
+  })
+
+  it('returns null for missing or unparseable dates', () => {
+    expect(expiryPhrase(null, now)).toBeNull()
+    expect(expiryPhrase(undefined, now)).toBeNull()
+    expect(expiryPhrase('not-a-date', now)).toBeNull()
+  })
+})

--- a/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
+++ b/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * The two surfaces that hand off into the seeded chat:
+ *  - the dashboard hero CTA and tip card (#138 scope 1, #143)
+ *  - expiring pantry item cards (#138 scope 2)
+ *
+ * These assert on the *href*, because the href is the whole contract: the chat
+ * page's own behaviour is covered in `chat-deep-links.test.tsx`.
+ */
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import HeroHome from '@/components/dashboard/HeroHome'
+import PantryPage from '@/app/pantry/page'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+/** Query string of an anchor, parsed. */
+function hrefParams(el: HTMLElement): URLSearchParams {
+  const href = el.getAttribute('href') ?? ''
+  return new URLSearchParams(href.slice(href.indexOf('?') + 1))
+}
+
+const originalFetch = global.fetch
+afterEach(() => {
+  global.fetch = originalFetch
+  jest.restoreAllMocks()
+})
+
+describe('dashboard hero CTA (#138)', () => {
+  const urgentItem = {
+    id: 'p1',
+    name: 'large free-range eggs',
+    expiry_date: '2026-07-29',
+    days_until_expiry: 1,
+    is_expiring_soon: true,
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/pantry/expiring')) {
+        return jsonResponse({ items: [urgentItem], count: 1 })
+      }
+      if (url.includes('/api/pantry')) {
+        return jsonResponse({ items: [urgentItem], total_count: 1 })
+      }
+      return jsonResponse({ recipes: [], total_count: 0 })
+    }) as unknown as typeof fetch
+  })
+
+  it('deep-links the urgent item into a seeded chat, name verbatim', async () => {
+    render(<HeroHome displayName="ayush" />)
+
+    const cta = await screen.findByRole('link', { name: /find a recipe/i })
+    const params = hrefParams(cta)
+    expect(cta.getAttribute('href')).toMatch(/^\/chat\?/)
+    expect(params.get('use')).toBe('large free-range eggs')
+    expect(params.get('expires')).toBe('2026-07-29')
+  })
+})
+
+describe('dashboard tip card (#143)', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => new Promise<Response>(() => {})) as unknown as typeof fetch
+  })
+
+  it('carries the tip the user is actually looking at', async () => {
+    render(<HeroHome displayName="ayush" />)
+
+    // The tip is corrected after hydration (#135's neutral-render convention),
+    // so read the rendered copy rather than assuming a fixed index.
+    const tipLink = screen.getByRole('link', { name: /Tip:/ })
+    await waitFor(() => expect(hrefParams(tipLink).get('tip')).toBeTruthy())
+
+    const rendered = (tipLink.textContent ?? '').split('Tip:')[1]?.trim()
+    expect(hrefParams(tipLink).get('tip')).toBe(rendered)
+    expect(tipLink.getAttribute('href')).toMatch(/^\/chat\?tip=/)
+  })
+})
+
+describe('expiring pantry cards (#138)', () => {
+  const items = [
+    { id: 'a', name: 'spinach', category: 'produce', location: 'fridge', quantity: 1, unit: 'bag', expiry_date: dateIn(1) },
+    { id: 'b', name: 'yoghurt', category: 'dairy', location: 'fridge', quantity: 2, unit: 'cup', expiry_date: dateIn(-2) },
+    { id: 'c', name: 'rice', category: 'dry_goods', location: 'pantry', quantity: 1, unit: 'kg', expiry_date: dateIn(60) },
+  ]
+
+  function dateIn(days: number): string {
+    return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+  }
+
+  function renderPantry() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+      <ThemeProvider>
+        <QueryClientProvider client={client}>
+          <PantryPage />
+        </QueryClientProvider>
+      </ThemeProvider>,
+    )
+  }
+
+  beforeEach(() => {
+    global.fetch = jest.fn(async () => jsonResponse({ items })) as unknown as typeof fetch
+  })
+
+  it('offers "Cook this" on expiring and expired items only', async () => {
+    renderPantry()
+
+    await screen.findByText('spinach')
+    const cookLinks = screen.getAllByRole('link', { name: /^Cook this/i })
+    const names = cookLinks.map((l) => hrefParams(l).get('use'))
+
+    expect(names).toEqual(expect.arrayContaining(['spinach', 'yoghurt']))
+    expect(names).not.toContain('rice')
+  })
+
+  it('scopes the link to that item, expiry included', async () => {
+    renderPantry()
+
+    const link = await screen.findByRole('link', { name: /Cook this spinach/i })
+    const params = hrefParams(link)
+    expect(link.getAttribute('href')).toMatch(/^\/chat\?/)
+    expect(params.get('use')).toBe('spinach')
+    expect(params.get('expires')).toBe(dateIn(1))
+  })
+
+  it('keeps the card itself an edit target — the link is an extra affordance', async () => {
+    renderPantry()
+
+    // The item name still sits inside its own button (opens the edit modal).
+    const nameEl = await screen.findByText('spinach')
+    expect(nameEl.closest('button')).not.toBeNull()
+    // ...and that button does not nest the link (invalid HTML, dead tap target).
+    expect(nameEl.closest('button')?.querySelector('a')).toBeNull()
+  })
+})

--- a/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
+++ b/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
@@ -77,7 +77,10 @@ describe('dashboard tip card (#143)', () => {
 
     // The tip is corrected after hydration (#135's neutral-render convention),
     // so read the rendered copy rather than assuming a fixed index.
-    const tipLink = screen.getByRole('link', { name: /Tip:/ })
+    // The accessible name is an explicit aria-label ("Ask Bubbles about today's
+    // tip: …") rather than the raw tip text, so screen-reader users are told
+    // what activating the card actually does.
+    const tipLink = screen.getByRole('link', { name: /Ask Bubbles about today's tip/i })
     await waitFor(() => expect(hrefParams(tipLink).get('tip')).toBeTruthy())
 
     const rendered = (tipLink.textContent ?? '').split('Tip:')[1]?.trim()
@@ -141,5 +144,29 @@ describe('expiring pantry cards (#138)', () => {
     expect(nameEl.closest('button')).not.toBeNull()
     // ...and that button does not nest the link (invalid HTML, dead tap target).
     expect(nameEl.closest('button')?.querySelector('a')).toBeNull()
+  })
+
+  // jsdom has no layout engine and no Tailwind at runtime, so these assert on
+  // the utility classes that produce the behaviour rather than measured pixels.
+  it('gives "Cook this" a 44px tap target (WCAG 2.5.5)', async () => {
+    renderPantry()
+
+    const link = await screen.findByRole('link', { name: /Cook this spinach/i })
+    expect(link.className).toContain('min-h-[44px]')
+  })
+
+  it('gives both card controls a visible focus ring', async () => {
+    renderPantry()
+
+    const nameEl = await screen.findByText('spinach')
+    const editButton = nameEl.closest('button')
+    const link = screen.getByRole('link', { name: /Cook this spinach/i })
+
+    for (const el of [editButton, link]) {
+      expect(el?.className).toMatch(/focus-visible:outline-2/)
+      // Inset offset — the card wrapper is overflow-hidden, so an outward ring
+      // would be clipped.
+      expect(el?.className).toContain('focus-visible:outline-offset-[-2px]')
+    }
   })
 })

--- a/nextjs/src/__tests__/loading-ui.test.tsx
+++ b/nextjs/src/__tests__/loading-ui.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * Issue #135 — dead-air after sign-in.
+ *
+ * Covers the two halves of the fix:
+ *  1. `app/loading.tsx` renders a theme-safe skeleton (no hardcoded palette hexes).
+ *  2. `HeroHome` paints the greeting / mascot / tip immediately instead of
+ *     blocking the whole hero behind one all-or-nothing `loading` flag.
+ */
+import { render, screen, waitFor } from '@testing-library/react'
+import Loading from '@/app/loading'
+import HeroHome from '@/components/dashboard/HeroHome'
+
+// Any 6- or 3-digit hex colour literal. The 5-theme system means the skeleton
+// must resolve every colour through a CSS custom property.
+const HEX_COLOR = /#[0-9a-fA-F]{3,8}\b/
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+describe('app/loading.tsx', () => {
+  it('renders a labelled loading state', () => {
+    render(<Loading />)
+    expect(screen.getByRole('status', { name: /loading/i })).toBeInTheDocument()
+  })
+
+  it('uses pulse skeletons', () => {
+    const { container } = render(<Loading />)
+    expect(container.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0)
+  })
+
+  it('opts skeletons out of animation under reduced motion', () => {
+    const { container } = render(<Loading />)
+    const pulses = Array.from(container.querySelectorAll('.animate-pulse'))
+    expect(pulses.every((el) => el.classList.contains('motion-reduce:animate-none'))).toBe(true)
+  })
+
+  it('contains no hardcoded palette colours (works across all 5 themes)', () => {
+    const { container } = render(<Loading />)
+    for (const el of Array.from(container.querySelectorAll<HTMLElement>('*'))) {
+      const inline = el.getAttribute('style') ?? ''
+      const classes = el.getAttribute('class') ?? ''
+      expect(inline).not.toMatch(HEX_COLOR)
+      expect(classes).not.toMatch(HEX_COLOR)
+    }
+  })
+})
+
+describe('HeroHome progressive paint', () => {
+  const originalFetch = global.fetch
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  it('paints the greeting, mascot and tip while the data fetches are still pending', () => {
+    // Never-resolving fetches: this is the "still loading" frame.
+    global.fetch = jest.fn(() => new Promise<Response>(() => {})) as unknown as typeof fetch
+
+    render(<HeroHome displayName="ayush" />)
+
+    // Greeting + name are known server-side, so they must be on screen already.
+    expect(screen.getByText('ayush')).toBeInTheDocument()
+    expect(screen.getByAltText(/^Bubbles /)).toBeInTheDocument()
+    expect(screen.getByText(/Tip:/)).toBeInTheDocument()
+
+    // ...while the data-dependent hero message is still a skeleton.
+    expect(screen.queryByText(/How about|expires|pantry is empty|looking great/)).toBeNull()
+  })
+
+  it('fills in the data-dependent hero message once the fetches resolve', async () => {
+    global.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/api/pantry/expiring')) return jsonResponse({ items: [], count: 0 })
+      if (url.includes('/api/pantry')) return jsonResponse({ items: [], total_count: 0 })
+      return jsonResponse({ recipes: [], total_count: 0 })
+    }) as unknown as typeof fetch
+
+    render(<HeroHome displayName="ayush" />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/Your pantry is empty/)).toBeInTheDocument()
+    )
+    // Greeting never disappeared during the transition.
+    expect(screen.getByText('ayush')).toBeInTheDocument()
+  })
+})

--- a/nextjs/src/__tests__/loading-ui.test.tsx
+++ b/nextjs/src/__tests__/loading-ui.test.tsx
@@ -8,6 +8,7 @@
  */
 import { render, screen, waitFor } from '@testing-library/react'
 import Loading from '@/app/loading'
+import ProfileLoading from '@/app/profile/loading'
 import HeroHome from '@/components/dashboard/HeroHome'
 
 // Any 6- or 3-digit hex colour literal. The 5-theme system means the skeleton
@@ -43,6 +44,36 @@ describe('app/loading.tsx', () => {
       expect(inline).not.toMatch(HEX_COLOR)
       expect(classes).not.toMatch(HEX_COLOR)
     }
+  })
+})
+
+describe('app/profile/loading.tsx', () => {
+  it('renders a labelled loading state', () => {
+    render(<ProfileLoading />)
+    expect(screen.getByRole('status', { name: /loading profile/i })).toBeInTheDocument()
+  })
+
+  it('opts skeletons out of animation under reduced motion', () => {
+    const { container } = render(<ProfileLoading />)
+    const pulses = Array.from(container.querySelectorAll('.animate-pulse'))
+    expect(pulses.length).toBeGreaterThan(0)
+    expect(pulses.every((el) => el.classList.contains('motion-reduce:animate-none'))).toBe(true)
+  })
+
+  it('contains no hardcoded palette colours (works across all 5 themes)', () => {
+    const { container } = render(<ProfileLoading />)
+    for (const el of Array.from(container.querySelectorAll<HTMLElement>('*'))) {
+      expect(el.getAttribute('style') ?? '').not.toMatch(HEX_COLOR)
+      expect(el.getAttribute('class') ?? '').not.toMatch(HEX_COLOR)
+    }
+  })
+
+  it('is profile-shaped, not dashboard-shaped', () => {
+    const { container } = render(<ProfileLoading />)
+    // The profile page opens with the chowder header strip + overlapping avatar.
+    expect(container.querySelector('.chowder-panel')).not.toBeNull()
+    // The dashboard fallback's three-up action card row must NOT appear here.
+    expect(container.querySelector('.grid-cols-3')).toBeNull()
   })
 })
 

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -10,6 +10,7 @@ import RotatingPlaceholder from '@/components/chat/RotatingPlaceholder'
 import MessageBubble from '@/components/chat/MessageBubble'
 import PostMessageChips from '@/components/chat/PostMessageChips'
 import CookingContextCard from '@/components/chat/CookingContextCard'
+import ChatContextCard from '@/components/chat/ChatContextCard'
 import TypingIndicator from '@/components/chat/TypingIndicator'
 import ChatRecipeCard from '@/components/chat/ChatRecipeCard'
 import PantryProposalCard from '@/components/chat/PantryProposalCard'
@@ -19,6 +20,7 @@ import EmptyState from '@/components/ui/EmptyState'
 import { useChat } from '@/hooks/useChat'
 import { checkAIHealth } from '@/lib/api/chat'
 import { fetchRecipe } from '@/lib/api/recipes'
+import { deriveChatSeed } from '@/lib/chat-seed'
 import type { Recipe } from '@/components/recipes/RecipePage'
 import type {
   ChatMessage,
@@ -79,16 +81,28 @@ function ChatSurface() {
   // the param, so the context resets for free when the user cooks again.
   const cookingRecipeId = searchParams.get('cooking')
 
+  // Deep-link seeds: /chat?tip=… (#143) and /chat?use=…&expires=… (#138).
+  // Null for a bare /chat, which is what keeps the bottom-nav entry a clean,
+  // empty conversation. The cook handoff wins if both are somehow present.
+  const seed = useMemo(
+    () => (cookingRecipeId ? null : deriveChatSeed(searchParams)),
+    [cookingRecipeId, searchParams],
+  )
+
   const [input, setInput] = useState('')
   const [aiAvailable, setAiAvailable] = useState(true)
   const [saveStates, setSaveStates] = useState<Record<string, 'idle' | 'saving' | 'saved' | 'error'>>({})
   const [loadedRecipe, setLoadedRecipe] = useState<Recipe | null>(null)
   const [dismissedRecipeId, setDismissedRecipeId] = useState<string | null>(null)
+  const [dismissedSeedKey, setDismissedSeedKey] = useState<string | null>(null)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   // The recipe only needs to ride along on the first message — the backend
   // pins it to the conversation session for subsequent turns.
   const contextSentRef = useRef(false)
+  // Same one-shot idiom for the seeded auto-send: fires once per mount, never
+  // again on re-render, and never after the user has taken over the thread.
+  const seedSentRef = useRef(false)
 
   // Check AI health on mount
   useEffect(() => {
@@ -142,6 +156,27 @@ function ChatSurface() {
     return cookingContext
   }
 
+  // Auto-send the seeded question so a tap on the dashboard tip / an expiring
+  // item lands straight on Bubbles' answer — the tap on the card is the "1 tap"
+  // both #138 acceptance criteria budget for. The seed rides in the message
+  // *text*, not a context payload: the AI service only honours `cooking_recipe`
+  // as client context, and the must-use ingredient is recovered by an LLM pass
+  // over the message itself.
+  useEffect(() => {
+    if (!seed || seedSentRef.current) return
+    seedSentRef.current = true
+    // The seed *is* the first message, so the cook-context slot is spent.
+    contextSentRef.current = true
+    sendMessage(seed.message)
+  }, [seed, sendMessage])
+
+  const dismissSeedCard = () => {
+    // Hide immediately, then drop the params so a refresh doesn't resurrect the
+    // card (or re-fire the auto-send on a fresh mount).
+    setDismissedSeedKey(seed?.key ?? null)
+    router.replace('/chat', { scroll: false })
+  }
+
   const dismissCookingCard = () => {
     // Hide immediately, then drop the param so a refresh doesn't resurrect it.
     setDismissedRecipeId(cookingRecipeId)
@@ -151,6 +186,13 @@ function ChatSurface() {
   const handleNewChat = () => {
     // New conversation — the backend session is gone, so resend the context.
     contextSentRef.current = false
+    // A seeded banner over an empty thread would be a lie; drop it (and its
+    // params) rather than leave it hanging. `seedSentRef` stays set so the
+    // fresh thread doesn't surprise the user with another auto-sent question.
+    if (seed) {
+      setDismissedSeedKey(seed.key)
+      router.replace('/chat', { scroll: false })
+    }
     startNewChat()
   }
 
@@ -224,6 +266,9 @@ function ChatSurface() {
 
   const hasMessages = messages.length > 0
 
+  // Derived like the cook card: shown until the user dismisses this exact seed.
+  const activeSeed = seed && seed.key !== dismissedSeedKey ? seed : null
+
   return (
     <div className="flex flex-col h-screen pb-20">
       {/* Header */}
@@ -269,6 +314,21 @@ function ChatSurface() {
           )}
         </AnimatePresence>
 
+        {/* Deep-link seed context (?tip= / ?use=) — same slot, same idiom */}
+        <AnimatePresence>
+          {activeSeed && (
+            <ChatContextCard
+              key={activeSeed.key}
+              emoji={activeSeed.card.emoji}
+              label={activeSeed.card.label}
+              title={activeSeed.card.title}
+              subtitle={activeSeed.card.subtitle}
+              dismissLabel={activeSeed.card.dismissLabel}
+              onDismiss={dismissSeedCard}
+            />
+          )}
+        </AnimatePresence>
+
         {hasMessages ? (
           <div className="flex flex-col gap-3">
             {messages.map((msg, index) => (
@@ -307,7 +367,7 @@ function ChatSurface() {
              is above it, so the two don't fight for the same space. */
           <div
             className={`flex flex-col items-center justify-center text-center pb-8 ${
-              cookingRecipe ? 'pt-4' : 'h-full'
+              cookingRecipe || activeSeed ? 'pt-4' : 'h-full'
             }`}
           >
             <EmptyState

--- a/nextjs/src/app/loading.tsx
+++ b/nextjs/src/app/loading.tsx
@@ -1,0 +1,81 @@
+import BubblesMascot from '@/components/ui/BubblesMascot'
+
+/**
+ * Route-level Suspense fallback (issue #135).
+ *
+ * Next.js renders this immediately on navigation while the server component for
+ * the segment (and anything nested below it) is still awaiting data — without it
+ * the previous page stays frozen on screen with zero feedback.
+ *
+ * Every colour comes from a CSS custom property so the skeleton is correct in all
+ * five themes (sakura / mint / lavender / yuzu / bluebell). `motion-reduce:animate-none`
+ * mirrors the reduced-motion path the framer-motion components take via `useMotionConfig()`.
+ */
+
+const PULSE = 'rounded animate-pulse motion-reduce:animate-none'
+const PULSE_BG = { background: 'var(--color-border)' } as const
+
+export default function Loading() {
+  return (
+    <div className="min-h-screen pb-24" role="status" aria-label="Loading">
+      <span className="sr-only">Loading…</span>
+
+      {/* Header strip — mirrors BubblesHeader so the shell doesn't jump */}
+      <div className="p-4 pb-3 flex items-center gap-3 border-b border-[var(--color-border)]">
+        <BubblesMascot state="thinking" size={36} />
+        <div className="flex-1 min-w-0">
+          <h1 className="text-lg font-extrabold text-[var(--color-text)] leading-tight">
+            Bubbles
+          </h1>
+          <p className="text-xs text-[var(--color-muted)]">Warming up the kitchen…</p>
+        </div>
+      </div>
+
+      <div className="px-4 pt-6 max-w-lg mx-auto flex flex-col items-center">
+        {/* Greeting line */}
+        <span className={`${PULSE} w-40 h-3.5`} style={PULSE_BG} />
+
+        {/* Hero mascot */}
+        <div className="mt-4 mb-4">
+          <BubblesMascot state="thinking" size={120} />
+        </div>
+
+        {/* Speech bubble */}
+        <div className="relative max-w-sm w-full mx-auto mb-6">
+          <div
+            className="absolute -top-2 left-1/2 -translate-x-1/2 w-4 h-4 rotate-45 border-l border-t border-[var(--color-border)]"
+            style={{ background: 'var(--color-surface)' }}
+          />
+          <div
+            className="relative rounded-2xl p-4 flex flex-col items-center gap-2 shadow-sm border border-[var(--color-border)]"
+            style={{ background: 'var(--color-surface)' }}
+          >
+            <span className={`${PULSE} w-11/12 h-3`} style={PULSE_BG} />
+            <span className={`${PULSE} w-2/3 h-3`} style={PULSE_BG} />
+            <span className={`${PULSE} w-28 h-7 rounded-full mt-2`} style={PULSE_BG} />
+          </div>
+        </div>
+
+        {/* Action card row */}
+        <div className="grid grid-cols-3 gap-3 w-full max-w-sm mb-6">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className={`${PULSE} h-[88px] rounded-2xl border border-[var(--color-border)]`}
+              style={PULSE_BG}
+            />
+          ))}
+        </div>
+
+        {/* Tip strip */}
+        <div
+          className="flex items-center gap-3 rounded-2xl px-4 py-3 border border-[var(--color-border)] max-w-sm w-full"
+          style={{ background: 'var(--color-surface)' }}
+        >
+          <span className={`${PULSE} w-5 h-5 rounded-full flex-shrink-0`} style={PULSE_BG} />
+          <span className={`${PULSE} flex-1 h-3`} style={PULSE_BG} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -260,7 +260,10 @@ function PantryPageInner() {
                         <button
                           type="button"
                           onClick={() => handleOpenEdit(item)}
-                          className="p-3 text-left w-full flex-1"
+                          // Inset focus outline: the card wrapper is
+                          // `overflow-hidden`, so an outward ring/offset would be
+                          // clipped and invisible to keyboard users.
+                          className="p-3 text-left w-full flex-1 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
                         >
                           <div className="flex items-center gap-2 mb-1">
                             <span className="text-lg">{getFoodEmoji(item.name, item.category)}</span>
@@ -285,7 +288,11 @@ function PantryPageInner() {
                           <Link
                             href={cookThisHref(item.name, item.expiry_date)}
                             aria-label={`Cook this ${item.name}`}
-                            className="border-t border-[var(--color-border)] px-3 py-2 text-xs font-semibold text-[var(--color-primary-dark)] text-center hover:bg-[var(--color-border)] transition-colors"
+                            // WCAG 2.5.5: the label stays `text-xs` so the card
+                            // grid doesn't reflow, but the box around it is a
+                            // full 44px tap target — same trick ThemePicker uses
+                            // (24px swatch inside a 44×44 button).
+                            className="border-t border-[var(--color-border)] px-3 min-h-[44px] flex items-center justify-center text-xs font-semibold text-[var(--color-primary-dark)] text-center hover:bg-[var(--color-border)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
                           >
                             🍳 Cook this
                           </Link>

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import SpringButton from '@/components/ui/SpringButton'
@@ -12,6 +13,7 @@ import AddItemModal from '@/components/pantry/AddItemModal'
 import ThemePicker from '@/components/ui/ThemePicker'
 import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAddSheet'
 import { getFoodEmoji } from '@/lib/food-emoji'
+import { cookThisHref } from '@/lib/chat-seed'
 import Chip from '@/components/ui/Chip'
 
 interface PantryItem {
@@ -63,6 +65,15 @@ function daysUntilExpiry(date: string | null): number | null {
   if (!date) return null
   const diff = new Date(date).getTime() - Date.now()
   return Math.ceil(diff / (1000 * 60 * 60 * 24))
+}
+
+/**
+ * Expired or expiring soon — the same 0–3 day window `pantry-helpers`'
+ * `is_expiring_soon` uses, plus anything already past. These are the cards that
+ * get the "Cook this" deep link (#138).
+ */
+function isUrgent(days: number | null): boolean {
+  return days !== null && days <= 3
 }
 
 function expiryBadge(days: number | null) {
@@ -236,33 +247,50 @@ function PantryPageInner() {
                     const days = daysUntilExpiry(item.expiry_date)
                     const badge = expiryBadge(days)
                     return (
-                      <motion.button
+                      // Wrapper is a div, not a button: an urgent item nests a
+                      // "Cook this" link, and a link inside a button is invalid.
+                      <motion.div
                         key={item.id}
-                        type="button"
-                        onClick={() => handleOpenEdit(item)}
-                        className="rounded-2xl p-3 border border-[var(--color-border)] text-left hover:border-[var(--color-primary)] transition-colors"
+                        className="rounded-2xl border border-[var(--color-border)] overflow-hidden hover:border-[var(--color-primary)] transition-colors flex flex-col"
                         style={{ background: CATEGORY_BG[item.category?.toLowerCase() ?? ''] ?? 'var(--color-surface)' }}
                         initial={{ opacity: 0, y: 8 }}
                         animate={{ opacity: 1, y: 0 }}
                         transition={{ delay: i * 0.04, duration: 0.25 }}
                       >
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="text-lg">{getFoodEmoji(item.name, item.category)}</span>
-                          <span className="font-semibold text-sm text-[var(--color-text)] truncate">
-                            {item.name}
-                          </span>
-                        </div>
-                        <div className="flex items-center justify-between">
-                          <span className="text-xs text-[var(--color-muted)]">
-                            {item.quantity} {item.unit}
-                          </span>
-                          {badge && (
-                            <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
-                              {badge.label}
+                        <button
+                          type="button"
+                          onClick={() => handleOpenEdit(item)}
+                          className="p-3 text-left w-full flex-1"
+                        >
+                          <div className="flex items-center gap-2 mb-1">
+                            <span className="text-lg">{getFoodEmoji(item.name, item.category)}</span>
+                            <span className="font-semibold text-sm text-[var(--color-text)] truncate">
+                              {item.name}
                             </span>
-                          )}
-                        </div>
-                      </motion.button>
+                          </div>
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs text-[var(--color-muted)]">
+                              {item.quantity} {item.unit}
+                            </span>
+                            {badge && (
+                              <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
+                                {badge.label}
+                              </span>
+                            )}
+                          </div>
+                        </button>
+
+                        {/* One tap from an expiring item to a recipe that uses it */}
+                        {isUrgent(days) && (
+                          <Link
+                            href={cookThisHref(item.name, item.expiry_date)}
+                            aria-label={`Cook this ${item.name}`}
+                            className="border-t border-[var(--color-border)] px-3 py-2 text-xs font-semibold text-[var(--color-primary-dark)] text-center hover:bg-[var(--color-border)] transition-colors"
+                          >
+                            🍳 Cook this
+                          </Link>
+                        )}
+                      </motion.div>
                     )
                   })}
                 </div>

--- a/nextjs/src/app/profile/loading.tsx
+++ b/nextjs/src/app/profile/loading.tsx
@@ -1,0 +1,72 @@
+/**
+ * Route-level Suspense fallback for `/profile`.
+ *
+ * `app/profile/page.tsx` is an async server component (it awaits
+ * `supabase.auth.getUser()`), so the segment suspends on navigation. Without a
+ * fallback here the *root* `app/loading.tsx` is used — and that one is
+ * deliberately dashboard-shaped (hero mascot, speech bubble, three action
+ * cards), so you'd briefly see a fake dashboard on the way to the profile.
+ * This skeleton mirrors the profile page's own layout instead: header strip,
+ * overlapping avatar, name block, dietary pills, About rows.
+ *
+ * Every colour resolves through a CSS custom property so the skeleton is
+ * correct in all five themes. `motion-reduce:animate-none` mirrors the
+ * reduced-motion path the framer-motion components take via `useMotionConfig()`.
+ */
+
+const PULSE = 'rounded animate-pulse motion-reduce:animate-none'
+const PULSE_BG = { background: 'var(--color-border)' } as const
+
+export default function Loading() {
+  return (
+    <div className="pb-24" role="status" aria-label="Loading profile">
+      <span className="sr-only">Loading profile…</span>
+
+      {/* Header strip with the avatar slot straddling its bottom edge */}
+      <div className="relative">
+        <div className="chowder-panel h-28" />
+        <div className="absolute left-1/2 -translate-x-1/2 bottom-0 translate-y-1/2">
+          <span
+            className={`${PULSE} block w-20 h-20 rounded-full border border-[var(--color-border)]`}
+            style={{ background: 'var(--color-surface)' }}
+          />
+        </div>
+      </div>
+
+      {/* Display name + email */}
+      <div className="mt-14 mb-6 px-6 flex flex-col items-center gap-2">
+        <span className={`${PULSE} w-32 h-5`} style={PULSE_BG} />
+        <span className={`${PULSE} w-44 h-3`} style={PULSE_BG} />
+      </div>
+
+      <div className="px-6 space-y-6 max-w-md mx-auto">
+        {/* Dietary preferences */}
+        <section>
+          <span className={`${PULSE} block w-36 h-3 mb-3`} style={PULSE_BG} />
+          <div className="flex flex-wrap gap-2">
+            {[72, 56, 92, 84].map((w) => (
+              <span
+                key={w}
+                className={`${PULSE} h-8 rounded-full`}
+                style={{ ...PULSE_BG, width: w }}
+              />
+            ))}
+          </div>
+        </section>
+
+        {/* About */}
+        <section>
+          <span className={`${PULSE} block w-20 h-3 mb-3`} style={PULSE_BG} />
+          <div className="bg-[var(--color-surface)] rounded-2xl border border-[var(--color-border)] divide-y divide-[var(--color-border)]">
+            {[0, 1].map((i) => (
+              <div key={i} className="px-4 py-3 flex justify-between items-center">
+                <span className={`${PULSE} w-16 h-3`} style={PULSE_BG} />
+                <span className={`${PULSE} w-24 h-3`} style={PULSE_BG} />
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/nextjs/src/components/chat/ChatContextCard.tsx
+++ b/nextjs/src/components/chat/ChatContextCard.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { useMotionConfig } from '@/lib/motion'
+
+interface ChatContextCardProps {
+  /** Decorative glyph — the card's label carries the meaning. */
+  emoji: string
+  /** Small uppercase eyebrow, e.g. "Today's tip". */
+  label: string
+  title: string
+  subtitle?: string
+  /** Accessible name for the dismiss control. */
+  dismissLabel: string
+  onDismiss: () => void
+}
+
+/**
+ * Generic deep-link context banner for the chat thread — shows what the
+ * conversation was opened *about* (a tip, an expiring ingredient) so the user
+ * can see the handoff without scrolling back to their auto-sent first message.
+ *
+ * Same shape and tokens as `CookingContextCard`, which stays as-is because the
+ * cook flow's copy is bespoke; if a third variant appears, fold that one in here.
+ * Dismissible because the handoff is a convenience, not a mode to be stuck in.
+ */
+export default function ChatContextCard({
+  emoji,
+  label,
+  title,
+  subtitle,
+  dismissLabel,
+  onDismiss,
+}: ChatContextCardProps) {
+  const { springs } = useMotionConfig()
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -8 }}
+      transition={springs.snappy}
+      className="mb-4 rounded-2xl px-4 py-3 flex items-start gap-3"
+      style={{
+        background: 'var(--color-surface)',
+        border: '1px solid var(--color-border)',
+        boxShadow: 'var(--shadow-soft)',
+      }}
+    >
+      <span aria-hidden="true" className="text-lg leading-none mt-0.5">
+        {emoji}
+      </span>
+
+      <div className="flex-1 min-w-0">
+        <p
+          className="text-[11px] font-bold uppercase tracking-wide text-[var(--color-muted)]"
+          style={{ fontFamily: 'Nunito, sans-serif' }}
+        >
+          {label}
+        </p>
+        <p
+          className="text-sm font-extrabold text-[var(--color-text)] leading-snug"
+          style={{ fontFamily: 'Nunito, sans-serif' }}
+        >
+          {title}
+        </p>
+        {subtitle && (
+          <p
+            className="text-xs text-[var(--color-muted)] mt-0.5"
+            style={{ fontFamily: 'Nunito, sans-serif' }}
+          >
+            {subtitle}
+          </p>
+        )}
+      </div>
+
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label={dismissLabel}
+        className="w-11 h-11 -mr-2 -mt-2 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:text-[var(--color-text)] active:scale-95 transition-transform"
+      >
+        <span aria-hidden="true" className="text-base leading-none">
+          ✕
+        </span>
+      </button>
+    </motion.div>
+  )
+}

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { motion } from 'framer-motion'
 import BubblesMascot from '@/components/ui/BubblesMascot'
 import FadeInView from '@/components/ui/FadeInView'
+import { cookThisHref, tipChatHref } from '@/lib/chat-seed'
 import type { EnrichedPantryItem } from '@/lib/pantry-helpers'
 
 interface Recipe {
@@ -153,8 +154,10 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
           ? `${expiringCount} item${expiringCount > 1 ? 's' : ''} expiring soon — time to cook!`
           : 'Your kitchen is looking great!'
 
+  // The urgent-item CTA deep-links into a chat seeded with that ingredient
+  // (#138), so one tap lands on a recipe that actually uses it.
   const heroAction = urgentItem
-    ? { label: 'Find a recipe', href: '/chat?mode=recipe' }
+    ? { label: 'Find a recipe', href: cookThisHref(urgentItem.name, urgentItem.expiry_date) }
     : totalCount === 0
       ? { label: 'Scan receipt', href: '/pantry?add=scan' }
       : recipe
@@ -268,7 +271,9 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
 
       {/* Tip of the day — compact */}
       <FadeInView delay={0.6}>
-        <Link href="/chat" className="block max-w-sm w-full">
+        {/* href is derived from the same `tip` the card renders, so the
+            post-hydration correction moves both together (#143). */}
+        <Link href={tipChatHref(tip)} className="block max-w-sm w-full">
           <div
             className="flex items-center gap-3 rounded-2xl px-4 py-3 border border-[var(--color-border)]"
             style={{ background: 'var(--color-surface)' }}

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -273,7 +273,13 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
       <FadeInView delay={0.6}>
         {/* href is derived from the same `tip` the card renders, so the
             post-hydration correction moves both together (#143). */}
-        <Link href={tipChatHref(tip)} className="block max-w-sm w-full">
+        {/* Without an explicit label the accessible name is just the raw tip
+            text, which gives no hint that activating it opens a chat. */}
+        <Link
+          href={tipChatHref(tip)}
+          aria-label={`Ask Bubbles about today's tip: ${tip}`}
+          className="block max-w-sm w-full"
+        >
           <div
             className="flex items-center gap-3 rounded-2xl px-4 py-3 border border-[var(--color-border)]"
             style={{ background: 'var(--color-surface)' }}

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -49,6 +49,28 @@ interface HeroHomeProps {
   displayName: string
 }
 
+/**
+ * Shared skeleton idiom — same pulse + `var(--color-border)` fill used by the
+ * route-level fallback in `app/loading.tsx`, so there's only one loading look.
+ * Rendered as a `<span className="block">` so it stays valid inside `<p>`.
+ */
+function Skeleton({
+  className,
+  onColor = false,
+}: {
+  className?: string
+  /** Sitting on top of a gradient card, where `--color-border` would disappear. */
+  onColor?: boolean
+}) {
+  return (
+    <span
+      className={`block rounded animate-pulse motion-reduce:animate-none ${className ?? ''}`}
+      style={{ background: onColor ? 'rgb(255 255 255 / 0.45)' : 'var(--color-border)' }}
+      aria-hidden="true"
+    />
+  )
+}
+
 export default function HeroHome({ displayName }: HeroHomeProps) {
   const [loading, setLoading] = useState(true)
   const [data, setData] = useState<HomeData>({
@@ -105,9 +127,19 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
     fetchAll()
   }, [])
 
-  const greeting = getGreeting()
-  const emoji = getGreetingEmoji()
-  const tip = tips[new Date().getDay() % tips.length]
+  // The greeting/tip are derived from the *client's* clock, which can disagree with
+  // the server's. Now that this block renders on the first pass (rather than behind
+  // the old all-or-nothing `loading` gate), we follow the ThemeProvider convention:
+  // render a neutral value on both passes, then correct it in an effect after
+  // hydration. That keeps the greeting instant without a hydration mismatch.
+  const [clockReady, setClockReady] = useState(false)
+  useEffect(() => {
+    setClockReady(true)
+  }, [])
+
+  const greeting = clockReady ? getGreeting() : 'Hello'
+  const emoji = clockReady ? getGreetingEmoji() : '👋'
+  const tip = tips[(clockReady ? new Date().getDay() : 0) % tips.length]
   const { totalCount, expiringCount, urgentItem, recipe } = data
 
   // Compute the single hero message (most important)
@@ -130,16 +162,6 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
         : expiringCount > 0
           ? { label: 'View pantry', href: '/pantry' }
           : { label: 'Ask Bubbles', href: '/chat' }
-
-  if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-3">
-        <div className="w-28 h-28 rounded-full animate-pulse" style={{ background: 'var(--color-border)' }} />
-        <div className="w-48 h-4 rounded animate-pulse" style={{ background: 'var(--color-border)' }} />
-        <div className="w-32 h-3 rounded animate-pulse mt-1" style={{ background: 'var(--color-border)' }} />
-      </div>
-    )
-  }
 
   return (
     <div className="flex flex-col items-center">
@@ -168,17 +190,28 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
           <div
             className="relative rounded-2xl p-4 text-center shadow-sm border border-[var(--color-border)]"
             style={{ background: 'var(--color-surface)' }}
+            aria-busy={loading}
           >
-            <p className="text-[var(--color-text)] font-medium text-sm leading-relaxed">
-              {heroMessage}
-            </p>
-            <Link
-              href={heroAction.href}
-              className="inline-block mt-3 text-xs font-semibold px-5 py-2 rounded-full text-white"
-              style={{ background: 'var(--color-primary)' }}
-            >
-              {heroAction.label}
-            </Link>
+            {loading ? (
+              <div className="flex flex-col items-center gap-2">
+                <Skeleton className="w-11/12 h-3" />
+                <Skeleton className="w-2/3 h-3" />
+                <Skeleton className="w-28 h-7 rounded-full mt-2" />
+              </div>
+            ) : (
+              <>
+                <p className="text-[var(--color-text)] font-medium text-sm leading-relaxed">
+                  {heroMessage}
+                </p>
+                <Link
+                  href={heroAction.href}
+                  className="inline-block mt-3 text-xs font-semibold px-5 py-2 rounded-full text-white"
+                  style={{ background: 'var(--color-primary)' }}
+                >
+                  {heroAction.label}
+                </Link>
+              </>
+            )}
           </div>
         </div>
       </FadeInView>
@@ -190,6 +223,8 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             emoji: '🔥',
             label: 'Use Soon',
             detail: expiringCount > 0 ? `${expiringCount} item${expiringCount > 1 ? 's' : ''}` : 'All fresh!',
+            // Only this card's detail depends on fetched data.
+            pending: loading,
             href: '/pantry',
             gradient: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%)',
           },
@@ -197,6 +232,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             emoji: '📷',
             label: 'Scan',
             detail: 'Receipt',
+            pending: false,
             href: '/pantry?add=scan',
             gradient: 'linear-gradient(135deg, var(--color-accent) 0%, var(--color-accent-dark) 100%)',
           },
@@ -204,6 +240,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             emoji: '✨',
             label: 'Ask',
             detail: 'Bubbles',
+            pending: false,
             href: '/chat',
             gradient: 'linear-gradient(135deg, var(--color-primary-dark) 0%, var(--color-accent-dark) 100%)',
           },
@@ -218,7 +255,11 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
               >
                 <span className="text-2xl mb-1">{card.emoji}</span>
                 <span className="text-sm font-bold">{card.label}</span>
-                <span className="text-[10px] opacity-80 mt-0.5">{card.detail}</span>
+                {card.pending ? (
+                  <Skeleton onColor className="w-10 h-2 mt-1.5 mb-0.5" />
+                ) : (
+                  <span className="text-[10px] opacity-80 mt-0.5">{card.detail}</span>
+                )}
               </motion.div>
             </Link>
           </FadeInView>
@@ -241,16 +282,20 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
         </Link>
       </FadeInView>
 
-      {/* Pantry status bar */}
-      {totalCount > 0 && (
+      {/* Pantry status bar — data-dependent, so it skeletons until the fetches land */}
+      {(loading || totalCount > 0) && (
         <FadeInView delay={0.7}>
-          <div className="mt-4 text-center">
-            <p className="text-xs text-[var(--color-muted)]">
-              🧺 {totalCount} item{totalCount !== 1 ? 's' : ''} in pantry
-              {expiringCount > 0 && (
-                <span> · <span style={{ color: 'var(--color-primary)' }}>{expiringCount} expiring</span></span>
-              )}
-            </p>
+          <div className="mt-4 flex justify-center text-center">
+            {loading ? (
+              <Skeleton className="w-36 h-3" />
+            ) : (
+              <p className="text-xs text-[var(--color-muted)]">
+                🧺 {totalCount} item{totalCount !== 1 ? 's' : ''} in pantry
+                {expiringCount > 0 && (
+                  <span> · <span style={{ color: 'var(--color-primary)' }}>{expiringCount} expiring</span></span>
+                )}
+              </p>
+            )}
           </div>
         </FadeInView>
       )}

--- a/nextjs/src/lib/chat-seed.ts
+++ b/nextjs/src/lib/chat-seed.ts
@@ -1,0 +1,150 @@
+/**
+ * Chat deep-link seeds — issues #143 and #138.
+ *
+ * Two URL params prime `/chat` with a first message that is auto-sent on load:
+ *
+ *   /chat?tip=<tip text>                  — "explain today's tip" (#143)
+ *   /chat?use=<name>[&expires=<ISO date>] — "cook this before it goes bad" (#138)
+ *
+ * Both mirror the existing `?cooking=` handoff: read the param, show a
+ * dismissible context card above the thread, and prime the conversation.
+ *
+ * IMPORTANT — the seed lives in the *message text*, not in a context payload.
+ * The AI service only recognises one client-supplied context key
+ * (`cooking_recipe`); anything else is ignored, and the must-use ingredient is
+ * recovered by an LLM structured-output call over the message itself. So the
+ * ingredient name and the tip text have to appear verbatim in `message`, and
+ * the `"with my <name>"` phrasing below is the one the backend prompt was
+ * tuned against. Don't reword it without re-tuning `recipe/nodes.py`.
+ */
+
+/** Minimal read surface shared by `URLSearchParams` and Next's readonly variant. */
+export interface ReadableSearchParams {
+  get(name: string): string | null
+}
+
+export type ChatSeedKind = 'tip' | 'use'
+
+export interface ChatSeedCard {
+  emoji: string
+  label: string
+  title: string
+  subtitle?: string
+  dismissLabel: string
+}
+
+export interface ChatSeed {
+  /** Stable identity — gates the one-shot auto-send and the dismissal. */
+  key: string
+  kind: ChatSeedKind
+  /** Auto-sent as the conversation's first message. */
+  message: string
+  card: ChatSeedCard
+}
+
+/** Trimmed param value, or null when absent/blank. */
+function param(params: ReadableSearchParams, name: string): string | null {
+  const raw = params.get(name)
+  if (raw === null) return null
+  const trimmed = raw.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+// ─── Link builders ────────────────────────────────────────────────────────────
+
+/** Dashboard tip card → chat primed to explain that tip. */
+export function tipChatHref(tip: string): string {
+  return `/chat?${new URLSearchParams({ tip }).toString()}`
+}
+
+/** Expiring item (hero CTA or pantry card) → chat primed to cook it. */
+export function cookThisHref(name: string, expiryDate?: string | null): string {
+  const params = new URLSearchParams({ use: name })
+  if (expiryDate) params.set('expires', expiryDate)
+  return `/chat?${params.toString()}`
+}
+
+// ─── Message builders ─────────────────────────────────────────────────────────
+
+export function tipSeedMessage(tip: string): string {
+  return `Tell me more about this kitchen tip: "${tip}" — why does it work, and when should I use it?`
+}
+
+/**
+ * The ingredient name is interpolated verbatim (no re-pluralising, no
+ * title-casing): the backend matches it against the pantry by substring in both
+ * directions, so "eggs" correctly hits an item named "large free-range eggs".
+ */
+export function ingredientSeedMessage(name: string): string {
+  return `What can I make with my ${name} before they go bad?`
+}
+
+// ─── Expiry phrasing ──────────────────────────────────────────────────────────
+
+/**
+ * Human phrasing for an ISO expiry date, matching `pantry-helpers`' day maths
+ * (midnight-today → expiry, rounded up). Returns null for a missing/unparseable
+ * date so callers can fall back.
+ */
+export function expiryPhrase(
+  expiryDate: string | null | undefined,
+  now: Date = new Date(),
+): string | null {
+  if (!expiryDate) return null
+  const expiry = new Date(expiryDate)
+  if (Number.isNaN(expiry.getTime())) return null
+
+  const today = new Date(now)
+  today.setHours(0, 0, 0, 0)
+  const days = Math.ceil((expiry.getTime() - today.getTime()) / (1000 * 60 * 60 * 24))
+
+  if (days < 0) return 'already expired'
+  if (days === 0) return 'expires today'
+  if (days === 1) return 'expires tomorrow'
+  return `expires in ${days} days`
+}
+
+// ─── Seed derivation ──────────────────────────────────────────────────────────
+
+/**
+ * Read the seed out of the URL. Returns null when neither param is present —
+ * which is what keeps a bare `/chat` (bottom nav) a clean, empty conversation.
+ */
+export function deriveChatSeed(
+  params: ReadableSearchParams,
+  now: Date = new Date(),
+): ChatSeed | null {
+  const tip = param(params, 'tip')
+  if (tip) {
+    return {
+      key: `tip:${tip}`,
+      kind: 'tip',
+      message: tipSeedMessage(tip),
+      card: {
+        emoji: '💡',
+        label: "Today's tip",
+        title: tip,
+        dismissLabel: 'Dismiss tip context',
+      },
+    }
+  }
+
+  const name = param(params, 'use')
+  if (name) {
+    const expires = param(params, 'expires')
+    return {
+      key: `use:${name}:${expires ?? ''}`,
+      kind: 'use',
+      message: ingredientSeedMessage(name),
+      card: {
+        emoji: '⏳',
+        label: 'Cook this now',
+        title: `Using your ${name}`,
+        subtitle: expiryPhrase(expires, now) ?? 'before it goes bad',
+        dismissLabel: 'Dismiss expiring item context',
+      },
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

Clears three of the tickets filed last session but never started. "Expiring soon" stops being a read-only stat and becomes a one-tap launch into a recipe seeded with the ingredient you need to use up; the dashboard tip card stops dumping you into an empty chat; and navigation stops leaving the previous page frozen with no feedback.

Based on `feat/ui-overhaul`, **not `main`** — the cook flow #138 rides on exists only there. Same stacking as #137/#141/#142.

## What lands

**#138 — expiry → cook, both halves**
- Backend: `RecipeConstraints` gains `must_use_ingredients`. A soft `preferred_ingredients` (+5) already existed, but the brainstorm node never put it in its prompt — so on exactly this path the hint was extracted and then discarded. Must-use scores +20 and composes with expiry urgency rather than replacing it.
- Frontend: `/chat?use=<name>&expires=<iso>` from the urgent-item hero CTA and a "Cook this" affordance on expiring pantry cards, with a context card reflecting the item and its expiry.

**#143 — tip card carries its tip.** `/chat?tip=` auto-asks Bubbles why the tip works and when to use it, with a dismissible context card. Mirrors the existing `?cooking=` pattern.

**#135 — loading feedback.** Root `app/loading.tsx` (covers all nested routes) plus a profile-shaped one, after an audit found exactly two routes await on the server. `HeroHome` no longer gates the whole hero behind one flag: greeting, mascot, card chrome and tip paint on the first frame; only data-dependent regions skeleton, inside their final frames so nothing shifts.

**Plus** a role-file update resolving the `frontend`/`ui-ux` boundary on container components (see Out of scope).

### One design decision worth knowing
The seeds ride in the **message text**, not a context payload. `workflows/router.py:559` only ever reads the `cooking_recipe` key from the client `context` dict and silently ignores every other — so the payload this was originally specced with would have been dead weight. Consequence: **the `?use=` message wording is load-bearing.** Extraction is an LLM structured-output call on that sentence with no regex fallback, so an equality test pins the string, with a comment saying why.

## Tests

```
pytest   128 passed, 10 skipped     (113 baseline + 15)
ruff     All checks passed          (0.15.8, pinned <0.16 per #129)
tsc      clean
jest     69 passed                  (24 baseline → 69)
mypy     zero new errors on changed files
```

`qa-reviewer` pass run against all three issues' acceptance criteria — no blockers. Findings and their resolution:

| Finding | Resolution |
|---|---|
| `/profile` is async; got the dashboard-shaped fallback | fixed — profile-shaped fallback added |
| "Cook this" tap target ~32px vs 44px | fixed |
| Tip link had no accessible name | fixed |
| No focus ring on the two pantry card controls | fixed (inset — the card is `overflow-hidden`, an outward ring is clipped invisible) |
| LLM extraction itself is untested | won't fix here — filed #145, needs a provider key |
| "Cook this" shows on already-expired items, copy contradicts itself | won't fix — filed #146, product call |
| No focus treatment anywhere in the app | won't fix here — filed #147, design-system change |

⚠️ `/code-review` and `/interrogate` were **not** run — neither skill is installed in this environment. The `qa-reviewer` pass is what stands in for layer 1; layer 2 is still outstanding for a feature-level PR.

## Demo

**None captured.** There's no `.env.local` in this checkout, so authed routes 307 to `/login` and the two Supabase-awaiting pages can't prerender. Everything above is type-check, unit-test and static-analysis evidence — no live drive, no screenshots. Given this PR is mostly visual, that's a real gap in verification, and #134 (capture video demos) exists precisely for it.

Specifically unverified: browser behaviour of the deep links, real extraction quality, rendering across the 5 themes, tap targets on device, and whether the skeletons actually improve perceived latency.

## Linked issue

Closes #135
Closes #138
Closes #143

## Out of scope

- **Role boundary resolved, not papered over.** `HeroHome.tsx` fetches its own data but lives in `ui-ux`'s directory — the seam `CLAUDE.md` predicted. Both role files now record the split: `frontend` owns data/state/loading structure in container components, `ui-ux` owns the visual language and reviews a11y there regardless of who edited. **The a11y changes in this PR want `ui-ux` sign-off** under that rule.
- Constraints are dropped entirely on the brainstorm follow-up turn (loses cuisine and dietary too) — pre-existing, filed as #144, the `BubblyChef-747` note in `CLAUDE.md` that never had an issue.
- `ChatContextCard` is a near-duplicate of `CookingContextCard`; folding them is a `ui-ux` call.
- "Cook this" threshold is `days <= 3`, matching `is_expiring_soon`, so amber 4–5 day items get no affordance.
- Pre-existing ESLint error in `pantry/page.tsx` (`react-hooks/set-state-in-effect`, untouched `?add=` effect) — verified pre-existing by stash-and-relint.
- Pre-existing Next 16 deprecation: `middleware` file convention → `proxy`. Not filed; say the word.

---

- [ ] `/code-review` run — skill not available here
- [ ] `/interrogate` run (feature-level PRs only) — skill not available here
- [ ] CI green
- [ ] Demo captured (blocked on env — see above)


---
_Generated by [Claude Code](https://claude.ai/code/session_012EMHQcQ2DXZhPGKboPTxgC)_