### PR TITLE
feat: close the expiry loop, plus keyboard accessibility and trustworthy lint gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      - name: ESLint
+        run: npx eslint src/
+
       - name: Jest
         run: npm test -- --ci
 

--- a/docs/plans/2026-07-28-expiring-soon-loop.md
+++ b/docs/plans/2026-07-28-expiring-soon-loop.md
@@ -1,0 +1,68 @@
+# Expiring Soon — closing the waste-prevention loop
+
+_Brainstorm, 2026-07-28. Framed by the user's steer: the feature feels "lost" because it is **not actionable** (seeing "expires tomorrow" doesn't take you anywhere) and **not proactive** (it only surfaces when you happen to open the app — usually too late). Scope for now: **ideate + file issues**, not build._
+
+---
+
+## The problem, precisely
+
+BubblyChef's whole promise is **scan → stock → cook before it goes to waste**. Expiry is the mechanism that should make that promise real. Today it's a **read-only stat**:
+
+- Data is solid: `pantry-helpers.ts` computes `days_until_expiry`, `is_expiring_soon` (≤3 days), `is_expired`; there's a `/api/pantry/expiring?days=N` route and `buildPantryListResponse` returns `expiring_soon_count` / `expired_count`.
+- Surfaces are passive and scattered: dashboard hero *sometimes* leads with the most-urgent item, a "Use Soon" count card, a status-bar footnote, and card tints on the pantry page.
+- The loop never closes. It tells you *that* something is expiring; it never (a) walks you into cooking it, nor (b) reaches out before you forget.
+
+Two gaps, matching the user's read:
+
+1. **Not actionable** — every expiry surface should be a launchpad into the cook/recipe flow seeded with the expiring ingredient, and should let you resolve the item ("cooked it" / "used it" / "tossed it").
+2. **Not proactive** — the app must reach out (notification/nudge) so expiry works when the user *isn't* already looking. This is partially owned by existing issue **#43** (in-app notification center).
+
+---
+
+## Direction A — Make it ACTIONABLE (in-app, when the user is looking)
+
+### A1. Expiry surfaces deep-link into "cook this now" (highest ROI, small)
+The dashboard urgent-item CTA and each expiring pantry card should launch the recipe/chat flow **pre-seeded with the expiring ingredient**. The cook flow already exists on PR #74 (`CookModal`, `/chat?cooking=`), so this is mostly wiring a query param + a prompt seed, not new infrastructure.
+
+- Dashboard hero: "2 eggs expire tomorrow" → button → `/chat?mode=recipe&use=eggs` (or `/recipes?use=eggs`) that opens with "recipes using eggs, cookable now."
+- Pantry card (expiring): tap → same seeded flow, scoped to that item.
+- Acceptance: from any expiring surface, ≤1 tap to a recipe suggestion that actually uses that ingredient.
+
+### A2. A dedicated "Use Soon" triage view (medium)
+Not a count — a real screen (or a filtered pantry mode) listing everything expiring, sorted by urgency, each row with:
+- one-tap **Find a recipe** (→ A1 seeded flow),
+- one-tap **resolve**: "Used it up" (decrement/remove) / "Tossed it" (remove + optional waste-log).
+Turns diffuse anxiety into a clearable checklist. Reachable from the "Use Soon" card and bottom nav.
+
+### A3. Resolve/close-the-loop actions everywhere (small–medium, enables the reward loop)
+Give every expiring item a lightweight way to say what happened to it. Without this the app can never know it *helped* — which is what makes proactive nudges feel earned rather than nagging. Minimal: "Used it up" / "Tossed" buttons that mutate stock. Data captured here feeds a future "you saved N items this week" payoff (out of scope now, but design the mutation so it's recordable).
+
+---
+
+## Direction B — Make it PROACTIVE (when the user is NOT looking)
+
+> Owned largely by existing issue **#43** (in-app notification center for expiry alerts and pantry nudges). This section is the *expiry-specific* framing to fold into / cross-link with #43 — do not file a duplicate.
+
+### B1. Morning nudge / digest
+A once-daily surface (in-app notification bell to start; push later) — "3 things expiring today, dinner ideas inside" — that opens straight into the A2 triage or an A1 seeded recipe. In-app-only first (no push infra, no permissions) so it's shippable without native work.
+
+### B2. Threshold escalation
+Tiered urgency, not a flat ≤3-day flag: `expiring_soon` (≤3d) vs `expires_today`/`expired`. Copy + Bubbles mood escalate with the tier. `pantry-helpers.ts` already computes the raw days; add a tier derivation.
+
+### B3. Trust the dates (prerequisite, links #3)
+Proactive nudges built on wrong dates train users to ignore them. Produce expiry estimation is filed as **#3**. Flag as a dependency: the nudge feature's value is capped by estimation accuracy.
+
+---
+
+## Sequencing / dependencies
+
+- **A1** is the wedge: small, rides on PR #74's cook flow, immediately makes expiry feel alive. Do first.
+- **A3** (resolve actions) unlocks the eventual reward loop and should land near A1/A2.
+- **A2** is the natural home once A1 + A3 exist.
+- **B1/B2** fold into **#43**; gated in value by **#3** (estimation accuracy).
+- Cross-cutting: **#131/#110** (category vs expiry color collision — in flight) matters here because expiry tinting and category tinting currently fight each other; a clean category palette makes expiry tint legible as an *urgency* signal.
+
+## Explicitly out of scope for now
+- Native push notifications / permissions (in-app bell first).
+- The "you saved N items / waste stats" reward screen (A3 captures the data; the payoff UI is a later pass).
+- Any expiry-estimation ML work beyond what #3 covers.

--- a/nextjs/src/__tests__/a11y-issue-10.test.tsx
+++ b/nextjs/src/__tests__/a11y-issue-10.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Issue #10 — keyboard + screen-reader operability pass.
+ *
+ * Three things asserted here, matching the three claims in the PM report
+ * that are actually testable in jsdom (no browser, no real AT):
+ *  1. BottomNav marks the active tab with `aria-current="page"`.
+ *  2. Pantry item cards give their edit button an accessible name that
+ *     states the action, not just the item's visible text.
+ *  3. The shared `useModalFocusTrap` hook (wired into AddItemModal and
+ *     RecipeEditModal as the stays-mounted and mounts-to-open cases) moves
+ *     focus in on open, traps Tab inside the panel, and returns focus to
+ *     the trigger on close.
+ */
+import React, { useState } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import BottomNav from '@/components/layout/BottomNav'
+import PantryPage from '@/app/pantry/page'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import AddItemModal from '@/components/pantry/AddItemModal'
+import RecipeEditModal from '@/components/recipes/RecipeEditModal'
+import type { Recipe } from '@/components/recipes/RecipePage'
+
+let mockPathname = '/'
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), refresh: jest.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+describe('BottomNav aria-current (#10)', () => {
+  afterEach(() => {
+    mockPathname = '/'
+  })
+
+  it('marks only the active tab as aria-current="page"', () => {
+    mockPathname = '/pantry'
+    render(<BottomNav />)
+
+    const pantryLink = screen.getByRole('link', { name: 'Pantry' })
+    expect(pantryLink).toHaveAttribute('aria-current', 'page')
+
+    for (const label of ['Home', 'Chat', 'Recipes']) {
+      expect(screen.getByRole('link', { name: label })).not.toHaveAttribute('aria-current')
+    }
+  })
+
+  it('names the nav landmark so a screen reader can distinguish it from any other nav', () => {
+    render(<BottomNav />)
+    expect(screen.getByRole('navigation', { name: 'Primary' })).toBeInTheDocument()
+  })
+})
+
+describe('Pantry edit button accessible name (#10)', () => {
+  const originalFetch = global.fetch
+  afterEach(() => {
+    global.fetch = originalFetch
+    jest.restoreAllMocks()
+  })
+
+  it('states the action and the item, not just the item', async () => {
+    global.fetch = jest.fn(async () =>
+      jsonResponse({
+        items: [
+          { id: 'p1', name: 'milk', category: 'dairy', location: 'fridge', quantity: 1, unit: 'gallon', expiry_date: null },
+        ],
+      }),
+    ) as unknown as typeof fetch
+
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    render(
+      <QueryClientProvider client={client}>
+        <ThemeProvider>
+          <PantryPage />
+        </ThemeProvider>
+      </QueryClientProvider>,
+    )
+
+    // Distinct from a bare "Milk" name — the button states what it does.
+    expect(await screen.findByRole('button', { name: 'Edit Milk' })).toBeInTheDocument()
+  })
+})
+
+describe('useModalFocusTrap — stays-mounted case (AddItemModal) (#10)', () => {
+  function Harness() {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open add item
+        </button>
+        <AddItemModal isOpen={open} onClose={() => setOpen(false)} />
+      </>
+    )
+  }
+
+  it('moves focus into the panel on open and back to the trigger on close', () => {
+    render(<Harness />)
+
+    const trigger = screen.getByRole('button', { name: 'Open add item' })
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    // First focusable field in the panel — the modal has no autoFocus of its
+    // own, so this is entirely the hook's doing.
+    const nameInput = screen.getByPlaceholderText('e.g., Milk, Eggs, Rice...')
+    expect(document.activeElement).toBe(nameInput)
+
+    // Escape closes it (AddItemModal has no onKeyDown of its own — this is
+    // the hook), and focus lands back on whatever opened it.
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(document.activeElement).toBe(trigger)
+  })
+
+  it('traps Tab inside the panel — wraps at both ends', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open add item' }))
+
+    const nameInput = screen.getByPlaceholderText('e.g., Milk, Eggs, Rice...')
+    const submitButton = screen.getByRole('button', { name: 'Add to Pantry' })
+
+    submitButton.focus()
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(nameInput)
+
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(submitButton)
+  })
+})
+
+describe('useModalFocusTrap — mounts-to-open case (RecipeEditModal) (#10)', () => {
+  const recipe: Recipe = {
+    id: 'r1',
+    user_id: 'u1',
+    created_at: '2026-01-01',
+    title: 'Soup',
+    description: '',
+    tags: [],
+    ingredients: [],
+    instructions: [],
+  } as unknown as Recipe
+
+  function Harness() {
+    const [open, setOpen] = useState(false)
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>
+          Open edit
+        </button>
+        {open && (
+          <RecipeEditModal
+            recipe={recipe}
+            onSave={async () => {}}
+            onClose={() => setOpen(false)}
+          />
+        )}
+      </>
+    )
+  }
+
+  it('focuses the panel on mount and returns focus to the trigger on unmount', async () => {
+    render(<Harness />)
+
+    const trigger = screen.getByRole('button', { name: 'Open edit' })
+    trigger.focus()
+    fireEvent.click(trigger)
+
+    const dialog = await screen.findByRole('dialog', { name: 'Edit Recipe' })
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(document.activeElement).toBe(trigger))
+  })
+})

--- a/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
+++ b/nextjs/src/__tests__/deep-link-entrypoints.test.tsx
@@ -164,11 +164,10 @@ describe('expiring pantry cards (#138)', () => {
     const editButton = nameEl.closest('button')
     const link = screen.getByRole('link', { name: /Cook this spinach/i })
 
+    // Design-system utility (globals.css, #147) — inset variant, since the card
+    // wrapper is overflow-hidden and an outward ring/offset would be clipped.
     for (const el of [editButton, link]) {
-      expect(el?.className).toMatch(/focus-visible:outline-2/)
-      // Inset offset — the card wrapper is overflow-hidden, so an outward ring
-      // would be clipped.
-      expect(el?.className).toContain('focus-visible:outline-offset-[-2px]')
+      expect(el?.className).toMatch(/\bfocus-ring-inset\b/)
     }
   })
 })

--- a/nextjs/src/__tests__/focus-ring.test.tsx
+++ b/nextjs/src/__tests__/focus-ring.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Issue #147 — no visible focus indicator anywhere in the app.
+ *
+ * Mirrors the theme-safety guard in `loading-ui.test.tsx`: the whole point of
+ * `--color-focus-ring` aliasing `--color-text` (rather than hardcoding a hex)
+ * is that it must re-resolve correctly under all five `[data-theme="*"]`
+ * blocks. A literal hex anywhere in the focus-ring token/utility definitions
+ * would defeat that and silently break four of the five themes.
+ *
+ * Two halves:
+ *  1. `globals.css` defines the token + both ring utilities, with no hex
+ *     literal in that block.
+ *  2. The components this issue named (shared atoms + the confirmed
+ *     `focus:outline-none` sites) actually apply `focus-ring`/`focus-ring-inset`
+ *     — not just that the utility exists somewhere unused.
+ */
+import fs from 'fs'
+import path from 'path'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Chip from '@/components/ui/Chip'
+import SpringButton from '@/components/ui/SpringButton'
+import BottomNav from '@/components/layout/BottomNav'
+
+// Any 6- or 3-digit hex colour literal.
+const HEX_COLOR = /#[0-9a-fA-F]{3,8}\b/
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}))
+
+function globalsCss(): string {
+  return fs.readFileSync(
+    path.join(__dirname, '../app/globals.css'),
+    'utf8'
+  )
+}
+
+/**
+ * The token declaration is a single line inside `:root`, textually *before*
+ * the five `[data-theme="*"]` blocks (which legitimately contain hex literals
+ * for the palettes) — so it's checked as its own line, not a wider slice that
+ * would sweep those theme blocks in too.
+ */
+function focusRingTokenLine(css: string): string {
+  const line = css
+    .split('\n')
+    .find((l) => l.includes('--color-focus-ring:'))
+  expect(line).toBeDefined()
+  return line as string
+}
+
+/**
+ * The utility rules live in their own `@layer utilities` block at the bottom
+ * of the file, entirely after every `[data-theme="*"]` block — so slicing
+ * from its start to EOF is safe and doesn't need to dodge palette hex values.
+ */
+function focusRingUtilityBlock(css: string): string {
+  const start = css.indexOf('@layer utilities {')
+  expect(start).toBeGreaterThan(-1)
+  return css.slice(start)
+}
+
+describe('globals.css focus-ring definition', () => {
+  const css = globalsCss()
+
+  it('aliases --color-text via var(), not a hardcoded hex', () => {
+    const line = focusRingTokenLine(css)
+    expect(line).toMatch(/--color-focus-ring:\s*var\(--color-text\)/)
+    expect(line).not.toMatch(HEX_COLOR)
+  })
+
+  it('defines both the outward and inset utility classes', () => {
+    expect(css).toMatch(/\.focus-ring\s*\{/)
+    expect(css).toMatch(/\.focus-ring:focus-visible\s*\{/)
+    expect(css).toMatch(/\.focus-ring-inset\s*\{/)
+    expect(css).toMatch(/\.focus-ring-inset:focus-visible\s*\{/)
+  })
+
+  it('only styles :focus-visible, not :focus (no ring on mouse click)', () => {
+    const block = focusRingUtilityBlock(css)
+    // outline-color is only ever set inside a :focus-visible block.
+    const outlineColorLines = block
+      .split('\n')
+      .filter((l) => l.includes('outline-color'))
+    expect(outlineColorLines.length).toBe(2) // .focus-ring + .focus-ring-inset
+  })
+
+  it('contains no hardcoded hex colour in the utility rule bodies', () => {
+    expect(focusRingUtilityBlock(css)).not.toMatch(HEX_COLOR)
+  })
+})
+
+describe('focus-ring applied to shared design-system atoms', () => {
+  it('Chip always carries focus-ring, even with a custom className', () => {
+    render(<Chip onClick={() => {}} className="extra-class">Snack</Chip>)
+    const chip = screen.getByRole('button', { name: 'Snack' })
+    expect(chip.className).toMatch(/\bfocus-ring\b/)
+    expect(chip.className).not.toMatch(HEX_COLOR)
+  })
+
+  it('SpringButton carries focus-ring under both the default and a custom className', () => {
+    const { rerender } = render(<SpringButton>Default</SpringButton>)
+    expect(screen.getByRole('button', { name: 'Default' }).className).toMatch(/\bfocus-ring\b/)
+
+    rerender(<SpringButton className="totally-custom">Custom</SpringButton>)
+    expect(screen.getByRole('button', { name: 'Custom' }).className).toMatch(/\bfocus-ring\b/)
+  })
+
+  it('BottomNav tabs carry a focus ring (inset — pinned to the viewport edge)', () => {
+    render(<BottomNav />)
+    for (const link of screen.getAllByRole('link')) {
+      expect(link.className).toMatch(/\bfocus-ring-inset\b/)
+    }
+  })
+})

--- a/nextjs/src/__tests__/pantry-resolve-route.test.ts
+++ b/nextjs/src/__tests__/pantry-resolve-route.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ *
+ * Issue #140 — POST /api/pantry/[id]/resolve
+ *
+ * Frozen contract:
+ *   request  { outcome: 'used' | 'tossed' }
+ *   success  200 { resolved: true, id, outcome, event_id }
+ *   errors   400 invalid/missing outcome · 401 unauthenticated ·
+ *            404 item not found / not owned by caller
+ *
+ * Route handlers need the Web Fetch API globals (Request/Response) that
+ * Node provides natively but jsdom (this project's default test
+ * environment — see jest.config.js) does not; hence the environment
+ * override above, scoped to just this file.
+ */
+jest.mock('@/lib/response-helpers', () => {
+  const actual = jest.requireActual('@/lib/response-helpers')
+  return {
+    ...actual,
+    requireAuth: jest.fn(),
+  }
+})
+
+import { NextResponse } from 'next/server'
+import { POST } from '@/app/api/pantry/[id]/resolve/route'
+import { requireAuth } from '@/lib/response-helpers'
+
+const mockRequireAuth = requireAuth as jest.Mock
+
+const USER = { id: 'user-1' }
+
+function makeParams(id: string) {
+  return { params: Promise.resolve({ id }) }
+}
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Request
+}
+
+/**
+ * Chainable stand-in for a Supabase `PostgrestFilterBuilder`. `.eq()` chains;
+ * `.single()` resolves like the real client. Chains ending without `.single()`
+ * (the delete chain) are awaited directly, so the object itself must be
+ * thenable.
+ */
+function makeChain(result: { data: unknown; error: unknown }) {
+  const chain: Record<string, unknown> = {
+    select: jest.fn(() => chain),
+    insert: jest.fn(() => chain),
+    delete: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    single: jest.fn(async () => result),
+    then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  }
+  return chain
+}
+
+interface SupabaseMockConfig {
+  fetchResult: { data: unknown; error: unknown }
+  insertResult?: { data: unknown; error: unknown }
+  deleteResult?: { data: unknown; error: unknown }
+}
+
+function makeSupabase({ fetchResult, insertResult, deleteResult }: SupabaseMockConfig) {
+  const selectChain = makeChain(fetchResult)
+  const insertChain = makeChain(insertResult ?? { data: { id: 'event-1' }, error: null })
+  const deleteChain = makeChain(deleteResult ?? { data: null, error: null })
+
+  // Kept stable across calls (not recreated per `from()` invocation) so tests
+  // can assert on what the route actually passed to `.insert(...)`.
+  const insertMock = jest.fn<ReturnType<typeof makeChain>, [Record<string, unknown>]>(
+    () => insertChain,
+  )
+
+  const from = jest.fn((table: string) => {
+    if (table === 'pantry_items') {
+      return {
+        select: jest.fn(() => selectChain),
+        delete: jest.fn(() => deleteChain),
+      }
+    }
+    if (table === 'pantry_events') {
+      return {
+        insert: insertMock,
+      }
+    }
+    throw new Error(`unexpected table: ${table}`)
+  })
+
+  return { from, selectChain, insertChain, deleteChain, insertMock }
+}
+
+describe('POST /api/pantry/[id]/resolve', () => {
+  beforeEach(() => {
+    mockRequireAuth.mockReset()
+  })
+
+  it('401s when unauthenticated', async () => {
+    const unauthorized = NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    mockRequireAuth.mockResolvedValue(unauthorized)
+
+    const res = await POST(makeRequest({ outcome: 'used' }), makeParams('item-1'))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('400s on a missing outcome', async () => {
+    mockRequireAuth.mockResolvedValue([makeSupabase({ fetchResult: { data: null, error: null } }), USER])
+
+    const res = await POST(makeRequest({}), makeParams('item-1'))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('400s on an invalid outcome (e.g. "cooked", which is reserved for the cook-confirm flow)', async () => {
+    mockRequireAuth.mockResolvedValue([makeSupabase({ fetchResult: { data: null, error: null } }), USER])
+
+    const res = await POST(makeRequest({ outcome: 'cooked' }), makeParams('item-1'))
+
+    expect(res.status).toBe(400)
+  })
+
+  it('404s when the item does not exist or is not owned by the caller', async () => {
+    const supabase = makeSupabase({ fetchResult: { data: null, error: { message: 'no rows' } } })
+    mockRequireAuth.mockResolvedValue([supabase, USER])
+
+    const res = await POST(makeRequest({ outcome: 'used' }), makeParams('someone-elses-item'))
+
+    expect(res.status).toBe(404)
+    expect(supabase.from).toHaveBeenCalledWith('pantry_items')
+  })
+
+  it('resolves a "used" item: inserts the event, deletes the item, returns the frozen shape', async () => {
+    const item = {
+      id: 'item-1',
+      name: 'Eggs',
+      quantity: 6,
+      unit: 'count',
+      expiry_date: null,
+    }
+    const supabase = makeSupabase({
+      fetchResult: { data: item, error: null },
+      insertResult: { data: { id: 'event-abc' }, error: null },
+    })
+    mockRequireAuth.mockResolvedValue([supabase, USER])
+
+    const res = await POST(makeRequest({ outcome: 'used' }), makeParams('item-1'))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json).toEqual({
+      resolved: true,
+      id: 'item-1',
+      outcome: 'used',
+      event_id: 'event-abc',
+    })
+  })
+
+  it('resolves a "tossed" item the same way', async () => {
+    const item = { id: 'item-2', name: 'Milk', quantity: 1, unit: 'carton', expiry_date: null }
+    const supabase = makeSupabase({
+      fetchResult: { data: item, error: null },
+      insertResult: { data: { id: 'event-xyz' }, error: null },
+    })
+    mockRequireAuth.mockResolvedValue([supabase, USER])
+
+    const res = await POST(makeRequest({ outcome: 'tossed' }), makeParams('item-2'))
+    const json = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(json.outcome).toBe('tossed')
+    expect(json.event_id).toBe('event-xyz')
+  })
+
+  it('records a negative days_until_expiry for an already-expired item', async () => {
+    const yesterday = new Date()
+    yesterday.setDate(yesterday.getDate() - 3)
+    const item = {
+      id: 'item-3',
+      name: 'Yogurt',
+      quantity: 1,
+      unit: 'cup',
+      expiry_date: yesterday.toISOString().slice(0, 10),
+    }
+    const supabase = makeSupabase({
+      fetchResult: { data: item, error: null },
+      insertResult: { data: { id: 'event-3' }, error: null },
+    })
+    mockRequireAuth.mockResolvedValue([supabase, USER])
+
+    await POST(makeRequest({ outcome: 'tossed' }), makeParams('item-3'))
+
+    const insertCall = supabase.insertMock.mock.calls[0][0]
+    expect(insertCall.days_until_expiry).toBeLessThan(0)
+    expect(insertCall.item_name).toBe('Yogurt')
+    expect(insertCall.outcome).toBe('tossed')
+  })
+
+  it('does not report success if the delete fails after the event is written', async () => {
+    const item = { id: 'item-4', name: 'Bread', quantity: 1, unit: 'loaf', expiry_date: null }
+    const supabase = makeSupabase({
+      fetchResult: { data: item, error: null },
+      insertResult: { data: { id: 'event-4' }, error: null },
+      deleteResult: { data: null, error: { message: 'delete failed' } },
+    })
+    mockRequireAuth.mockResolvedValue([supabase, USER])
+
+    const res = await POST(makeRequest({ outcome: 'used' }), makeParams('item-4'))
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/nextjs/src/__tests__/resolve-actions.test.tsx
+++ b/nextjs/src/__tests__/resolve-actions.test.tsx
@@ -61,6 +61,25 @@ describe('ResolveActions', () => {
     expect(mockResolve).not.toHaveBeenCalled()
   })
 
+  it('moves focus into the confirm swap, and back out again on cancel', async () => {
+    render(<ResolveActions itemId="p1" itemName="milk" onResolved={jest.fn()} />)
+
+    const tossButton = screen.getByRole('button', { name: /toss milk/i })
+    tossButton.focus()
+    fireEvent.click(tossButton)
+
+    // The "Tossed it" button that triggered the swap has just unmounted —
+    // focus must land on a control in the confirm view, not <body>.
+    const cancelButton = screen.getByRole('button', { name: /cancel/i })
+    expect(document.activeElement).toBe(cancelButton)
+
+    fireEvent.click(cancelButton)
+
+    // Cancelling unmounts the confirm view — focus must return to the
+    // "Tossed it" button rather than being dropped.
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: /toss milk/i }))
+  })
+
   it('disables both actions while a resolve is in flight (no double-tap)', async () => {
     let resolveRequest!: (value: unknown) => void
     mockResolve.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve }))

--- a/nextjs/src/__tests__/resolve-actions.test.tsx
+++ b/nextjs/src/__tests__/resolve-actions.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Issue #140 — "Used it up" / "Tossed it" pantry item resolve actions.
+ *
+ * `ResolveActions` is the shared control used by both the pantry grid
+ * (`app/pantry/page.tsx`) and the Use Soon triage view
+ * (`app/pantry/use-soon/page.tsx`), so it's covered here in isolation rather
+ * than duplicated per call site.
+ */
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import ResolveActions from '@/components/pantry/ResolveActions'
+import { resolvePantryItem } from '@/lib/api/pantry'
+
+jest.mock('@/lib/api/pantry', () => ({
+  resolvePantryItem: jest.fn(),
+}))
+
+const mockResolve = resolvePantryItem as jest.Mock
+
+describe('ResolveActions', () => {
+  beforeEach(() => {
+    mockResolve.mockReset()
+  })
+
+  it('"Used it up" resolves immediately — no confirm step', async () => {
+    mockResolve.mockResolvedValue({ resolved: true, id: 'p1', outcome: 'used', event_id: 'e1' })
+    const onResolved = jest.fn()
+
+    render(<ResolveActions itemId="p1" itemName="eggs" onResolved={onResolved} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /mark eggs used up/i }))
+
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('p1', 'used'))
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
+
+  it('"Tossed it" requires a second, explicit tap before resolving', async () => {
+    mockResolve.mockResolvedValue({ resolved: true, id: 'p1', outcome: 'tossed', event_id: 'e2' })
+    const onResolved = jest.fn()
+
+    render(<ResolveActions itemId="p1" itemName="milk" onResolved={onResolved} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /toss milk/i }))
+    // First tap only opens the inline confirm — nothing resolved yet.
+    expect(mockResolve).not.toHaveBeenCalled()
+    expect(screen.getByText(/toss milk\?/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /yes, toss it/i }))
+
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('p1', 'tossed'))
+    expect(onResolved).toHaveBeenCalledTimes(1)
+  })
+
+  it('"Cancel" backs out of the toss confirm without resolving', async () => {
+    render(<ResolveActions itemId="p1" itemName="milk" onResolved={jest.fn()} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /toss milk/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    expect(screen.getByRole('button', { name: /mark milk used up/i })).toBeInTheDocument()
+    expect(mockResolve).not.toHaveBeenCalled()
+  })
+
+  it('disables both actions while a resolve is in flight (no double-tap)', async () => {
+    let resolveRequest!: (value: unknown) => void
+    mockResolve.mockReturnValue(new Promise((resolve) => { resolveRequest = resolve }))
+
+    render(<ResolveActions itemId="p1" itemName="eggs" onResolved={jest.fn()} />)
+
+    const usedButton = screen.getByRole('button', { name: /mark eggs used up/i })
+    fireEvent.click(usedButton)
+    fireEvent.click(usedButton)
+
+    expect(mockResolve).toHaveBeenCalledTimes(1)
+
+    resolveRequest({ resolved: true, id: 'p1', outcome: 'used', event_id: 'e1' })
+    await waitFor(() => {})
+  })
+
+  it('surfaces a failed resolve instead of swallowing it', async () => {
+    mockResolve.mockRejectedValue(
+      new Error('Recorded the event but failed to remove the item from the pantry'),
+    )
+    const onResolved = jest.fn()
+
+    render(<ResolveActions itemId="p1" itemName="bread" onResolved={onResolved} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /mark bread used up/i }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(/recorded the event but failed to remove/i)
+    // The row must not be treated as cleared — the caller's refetch was never triggered.
+    expect(onResolved).not.toHaveBeenCalled()
+    // ...and the controls come back so the user can retry.
+    expect(screen.getByRole('button', { name: /mark bread used up/i })).not.toBeDisabled()
+  })
+})

--- a/nextjs/src/__tests__/use-soon.test.tsx
+++ b/nextjs/src/__tests__/use-soon.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Issue #139 — the "Use Soon" triage view at `/pantry/use-soon`.
+ */
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import UseSoonPage from '@/app/pantry/use-soon/page'
+import { resolvePantryItem } from '@/lib/api/pantry'
+
+jest.mock('@/lib/api/pantry', () => ({
+  resolvePantryItem: jest.fn(),
+}))
+
+const mockResolve = resolvePantryItem as jest.Mock
+
+function jsonResponse(body: unknown): Response {
+  return { ok: true, json: async () => body } as Response
+}
+
+/** Query string of an anchor, parsed. */
+function hrefParams(el: HTMLElement): URLSearchParams {
+  const href = el.getAttribute('href') ?? ''
+  return new URLSearchParams(href.slice(href.indexOf('?') + 1))
+}
+
+function renderPage() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <UseSoonPage />
+    </QueryClientProvider>,
+  )
+}
+
+const originalFetch = global.fetch
+afterEach(() => {
+  global.fetch = originalFetch
+  jest.restoreAllMocks()
+  mockResolve.mockReset()
+})
+
+describe('Use Soon triage view (#139)', () => {
+  const items = [
+    // Intentionally out of urgency order in the API response — the page must sort.
+    { id: 'b', name: 'rice', category: 'dry_goods', quantity: 1, unit: 'kg', expiry_date: '2026-08-01', days_until_expiry: 4, is_expired: false, is_expiring_soon: false },
+    { id: 'a', name: 'large free-range eggs', category: 'dairy', quantity: 6, unit: 'count', expiry_date: '2026-07-25', days_until_expiry: -3, is_expired: true, is_expiring_soon: false },
+    { id: 'c', name: 'spinach', category: 'produce', quantity: 1, unit: 'bag', expiry_date: '2026-07-29', days_until_expiry: 1, is_expired: false, is_expiring_soon: true },
+  ]
+
+  it('sorts by days_until_expiry ascending — expired first, then soonest', async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ items })) as unknown as typeof fetch
+    renderPage()
+
+    await screen.findByText('Large Free-range Eggs')
+
+    const rendered = screen.getAllByText(/^(Large Free-range Eggs|Spinach|Rice)$/)
+    expect(rendered.map((el) => el.textContent)).toEqual(['Large Free-range Eggs', 'Spinach', 'Rice'])
+  })
+
+  it('carries the raw (non-title-cased) item name in the "Find a recipe" href', async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ items })) as unknown as typeof fetch
+    renderPage()
+
+    const link = await screen.findByRole('link', { name: /find a recipe for large free-range eggs/i })
+    const params = hrefParams(link)
+    expect(params.get('use')).toBe('large free-range eggs')
+    expect(params.get('expires')).toBe('2026-07-25')
+  })
+
+  it('renders the kawaii empty state when nothing is expiring', async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ items: [] })) as unknown as typeof fetch
+    renderPage()
+
+    expect(await screen.findByText(/nothing's about to expire/i)).toBeInTheDocument()
+  })
+
+  it('removes a row once it is resolved', async () => {
+    // First fetch (mount) returns the full list; every fetch after that
+    // (i.e. the refetch the resolve's invalidation triggers) returns the
+    // item already gone. A call counter — rather than swapping the mock or a
+    // timed reassignment — sidesteps any race against exactly when React
+    // Query's refetch actually fires relative to the resolve promise settling.
+    let calls = 0
+    global.fetch = jest.fn(async () => {
+      calls += 1
+      return jsonResponse({ items: calls === 1 ? items : items.filter((i) => i.id !== 'a') })
+    }) as unknown as typeof fetch
+    mockResolve.mockResolvedValue({ resolved: true, id: 'a', outcome: 'used', event_id: 'e1' })
+
+    renderPage()
+
+    await screen.findByText('Large Free-range Eggs')
+
+    const usedButton = screen.getByRole('button', { name: /mark large free-range eggs used up/i })
+    fireEvent.click(usedButton)
+
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('a', 'used'))
+    await waitFor(() => expect(screen.queryByText('Large Free-range Eggs')).toBeNull())
+  })
+
+  it('reaches the client function with both outcomes', async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ items })) as unknown as typeof fetch
+    mockResolve.mockResolvedValue({ resolved: true, id: 'c', outcome: 'tossed', event_id: 'e2' })
+
+    renderPage()
+
+    await screen.findByText('Spinach')
+
+    fireEvent.click(screen.getByRole('button', { name: /toss spinach/i }))
+    fireEvent.click(screen.getByRole('button', { name: /yes, toss it/i }))
+
+    await waitFor(() => expect(mockResolve).toHaveBeenCalledWith('c', 'tossed'))
+  })
+})

--- a/nextjs/src/app/api/pantry/[id]/resolve/route.ts
+++ b/nextjs/src/app/api/pantry/[id]/resolve/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server'
+import { requireAuth, errorResponse, notFound } from '@/lib/response-helpers'
+import { daysUntilExpiry } from '@/lib/pantry-helpers'
+
+const VALID_OUTCOMES = ['used', 'tossed'] as const
+type ResolveOutcome = (typeof VALID_OUTCOMES)[number]
+
+function isValidOutcome(value: unknown): value is ResolveOutcome {
+  return typeof value === 'string' && (VALID_OUTCOMES as readonly string[]).includes(value)
+}
+
+/**
+ * Resolve an expiring pantry item: record what happened to it (used it up /
+ * tossed it) and remove it from the pantry. Issue #140.
+ *
+ * `pantry_events` is append-only (INSERT/SELECT only, no UPDATE/DELETE — see
+ * migration 00007), so the event is written first and the item is deleted
+ * second. If the delete fails after the event is recorded, we do not retry
+ * or roll back the event (the table has no delete policy to undo it with) —
+ * we surface a 500 so the caller knows the item is still in the pantry
+ * despite the event existing, rather than reporting success for a resolve
+ * that didn't actually clear the item.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const result = await requireAuth()
+  if (result instanceof NextResponse) return result
+  const [supabase, user] = result
+  const { id } = await params
+
+  const body = await request.json().catch(() => null)
+  const outcome = (body as { outcome?: unknown } | null)?.outcome
+
+  if (!isValidOutcome(outcome)) {
+    return errorResponse('outcome must be "used" or "tossed"', 400)
+  }
+
+  const { data: item, error: fetchError } = await supabase
+    .from('pantry_items')
+    .select('*')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .single()
+
+  if (fetchError || !item) return notFound('Pantry item')
+
+  const { data: event, error: insertError } = await supabase
+    .from('pantry_events')
+    .insert({
+      user_id: user.id,
+      pantry_item_id: item.id,
+      item_name: item.name,
+      outcome,
+      quantity: item.quantity,
+      unit: item.unit,
+      days_until_expiry: daysUntilExpiry(item.expiry_date),
+    })
+    .select()
+    .single()
+
+  if (insertError || !event) {
+    return errorResponse('Failed to record the resolve event', 500)
+  }
+
+  const { error: deleteError } = await supabase
+    .from('pantry_items')
+    .delete()
+    .eq('id', item.id)
+    .eq('user_id', user.id)
+
+  if (deleteError) {
+    // The event is already written; the item is still in the pantry. Don't
+    // report success — that would leave a resolved event for an item a user
+    // can still see sitting there.
+    return errorResponse('Recorded the event but failed to remove the item from the pantry', 500)
+  }
+
+  return NextResponse.json({
+    resolved: true,
+    id: item.id,
+    outcome,
+    event_id: event.id,
+  })
+}

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -281,7 +281,7 @@ function ChatSurface() {
               <button
                 type="button"
                 onClick={handleNewChat}
-                className="text-xs font-semibold text-[var(--color-primary-dark)] bg-[var(--color-surface)] px-3 py-1.5 rounded-full hover:bg-[var(--color-border)] transition-colors"
+                className="focus-ring text-xs font-semibold text-[var(--color-primary-dark)] bg-[var(--color-surface)] px-3 py-1.5 rounded-full hover:bg-[var(--color-border)] transition-colors"
               >
                 New Chat
               </button>
@@ -412,7 +412,7 @@ function ChatSurface() {
             // button is replaced by Stop below — so typing cannot interleave two
             // requests.
             aria-label="Message Bubbles"
-            className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] text-sm"
+            className="focus-ring w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] focus:border-[var(--color-accent)] text-sm"
           />
           {/* Placeholder hides once anything is typed; no longer tied to streaming,
               since the field is now usable mid-stream. */}

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -63,6 +63,24 @@
       transparent 100%
     );
     --text-shadow-on-image: 0 1px 4px color-mix(in srgb, black 40%, transparent);
+
+    /*
+     * Focus ring — the one design-system-wide answer to WCAG 2.4.7 (issue #147).
+     * Deliberately aliases --color-text, not --color-primary-dark/--color-accent-dark.
+     * Those read as the "obvious" accent choice, but checked against every theme's
+     * --color-surface they measure as low as ~1.7:1 (yuzu) and never clear ~3.2:1
+     * (best case, lavender) — under the 3:1 WCAG 1.4.11 floor for non-text UI
+     * components on at least 4 of the 5 themes. --color-text is the one token each
+     * theme already guarantees is dark enough to read as body copy on every light
+     * surface it ships (surface/bg/category tints/gradient card stops), which measures
+     * 7.3–9.7:1 against --color-surface across all five palettes — so the ring is
+     * legible by construction instead of needing a per-theme override.
+     * Aliased (not hardcoded) so it re-resolves per [data-theme="*"] automatically,
+     * the same trick --shadow-soft already relies on above.
+     */
+    --color-focus-ring: var(--color-text);
+    --focus-ring-width: 2px;
+    --focus-ring-offset: 2px;
   }
 
   /* Theme palettes — applied via data-theme attribute on <html> */
@@ -151,4 +169,39 @@
   background-image:
     repeating-linear-gradient(0deg, transparent, transparent 5px, rgba(255,255,255,0.08) 5px, rgba(255,255,255,0.08) 6px),
     repeating-linear-gradient(90deg, transparent, transparent 5px, rgba(255,255,255,0.06) 5px, rgba(255,255,255,0.06) 6px);
+}
+
+/*
+ * Focus ring utilities (issue #147) — the single mechanism for keyboard focus
+ * across the app. Two variants:
+ *
+ *  .focus-ring         outward ring (default) — use on anything whose parent
+ *                       does NOT clip overflow. This is almost everything:
+ *                       buttons, links, inputs, selects, nav items.
+ *  .focus-ring-inset    ring drawn inward — required wherever the element sits
+ *                       inside an `overflow-hidden` ancestor (rounded cards,
+ *                       clipped dropdown panels), since an outward ring/offset
+ *                       gets clipped there and becomes invisible to keyboard
+ *                       users. Same color/width token, just a negative offset.
+ *
+ * Only :focus-visible is styled (not :focus), matching every browser's own
+ * heuristic for "was this focused via keyboard" — no extra `:focus { outline:
+ * none }` reset needed to suppress a mouse-click ring.
+ */
+@layer utilities {
+  .focus-ring {
+    outline: var(--focus-ring-width) solid transparent;
+    outline-offset: var(--focus-ring-offset);
+  }
+  .focus-ring:focus-visible {
+    outline-color: var(--color-focus-ring);
+  }
+
+  .focus-ring-inset {
+    outline: var(--focus-ring-width) solid transparent;
+    outline-offset: calc(-1 * var(--focus-ring-width));
+  }
+  .focus-ring-inset:focus-visible {
+    outline-color: var(--color-focus-ring);
+  }
 }

--- a/nextjs/src/app/login/page.tsx
+++ b/nextjs/src/app/login/page.tsx
@@ -77,7 +77,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
+                className="focus-ring w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
                 placeholder="you@email.com"
               />
             </div>
@@ -93,7 +93,7 @@ export default function LoginPage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
+                className="focus-ring w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
                 placeholder="Min 6 characters"
               />
             </div>
@@ -118,7 +118,7 @@ export default function LoginPage() {
             <button
               type="button"
               onClick={() => { setIsSignUp(!isSignUp); setError(null) }}
-              className="text-[var(--color-accent)] underline font-medium"
+              className="focus-ring text-[var(--color-accent)] underline font-medium rounded"
             >
               {isSignUp ? 'Sign In' : 'Sign Up'}
             </button>

--- a/nextjs/src/app/page.tsx
+++ b/nextjs/src/app/page.tsx
@@ -12,11 +12,15 @@ export default async function HomePage() {
     user?.user_metadata?.username ?? user?.email?.split('@')[0] ?? 'friend'
 
   return (
-    <main className="min-h-screen pb-24">
+    // Not a <main> — the root layout (nextjs/src/app/layout.tsx) already
+    // wraps every route in one; a second, nested <main> here would give
+    // screen-reader "jump to main content" users two landmark regions
+    // to choose from on the same page for no reason.
+    <div className="min-h-screen pb-24">
       <BubblesHeader showSubtitle rightSlot={<ThemePicker />} />
       <div className="px-4 pt-4 max-w-lg mx-auto">
         <HeroHome displayName={displayName} />
       </div>
-    </main>
+    </div>
   )
 }

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, Suspense } from 'react'
+import { useState, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { motion } from 'framer-motion'
@@ -123,14 +123,20 @@ function PantryPageInner() {
   const [addSheetOpen, setAddSheetOpen] = useState(false)
   const [addSheetTab, setAddSheetTab] = useState<PantryAddTab>('scan')
 
-  // Handle ?add=scan or ?add=type URL params
-  useEffect(() => {
-    const addParam = searchParams.get('add')
+  // Handle ?add=scan or ?add=type URL params. Adjusted during render rather
+  // than in an effect (React docs: "Adjusting state when a prop changes") —
+  // `seenAddParam` tracks the last `add` value we've already reacted to, so
+  // this only opens the sheet when the param actually changes (e.g. a fresh
+  // `?add=scan` link), not on every unrelated re-render.
+  const addParam = searchParams.get('add')
+  const [seenAddParam, setSeenAddParam] = useState<string | null>(null)
+  if (addParam !== seenAddParam) {
+    setSeenAddParam(addParam)
     if (addParam === 'scan' || addParam === 'type') {
       setAddSheetTab(addParam)
       setAddSheetOpen(true)
     }
-  }, [searchParams])
+  }
 
   // Client-side filtering
   const filteredItems = allItems.filter((item) => {
@@ -258,6 +264,14 @@ function PantryPageInner() {
                         <button
                           type="button"
                           onClick={() => handleOpenEdit(item)}
+                          // Visible text already names the item ("Milk"), but
+                          // on its own that just reads as "button, milk, 3
+                          // item, fresh" to a screen reader — no hint this
+                          // opens an edit form. aria-label states the action;
+                          // it intentionally doesn't repeat quantity/expiry
+                          // (those are announced by ResolveActions/the "Cook
+                          // this" link right below, keyed to the same name).
+                          aria-label={`Edit ${titleCase(item.name)}`}
                           // Inset focus ring (design-system utility, #147): the
                           // card wrapper is `overflow-hidden`, so an outward
                           // ring/offset would be clipped and invisible to

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -15,7 +15,9 @@ import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAdd
 import { getFoodEmoji } from '@/lib/food-emoji'
 import { titleCase } from '@/lib/format'
 import { cookThisHref } from '@/lib/chat-seed'
+import { expiryBadge } from '@/lib/expiry-badge'
 import Chip from '@/components/ui/Chip'
+import ResolveActions from '@/components/pantry/ResolveActions'
 
 interface PantryItem {
   id: string
@@ -78,14 +80,6 @@ function daysUntilExpiry(date: string | null): number | null {
  */
 function isUrgent(days: number | null): boolean {
   return days !== null && days <= 3
-}
-
-function expiryBadge(days: number | null) {
-  if (days === null) return null
-  if (days <= 0) return { label: 'Expired', color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
-  if (days <= 2) return { label: `${days}d left`, color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
-  if (days <= 5) return { label: `${days}d left`, color: 'bg-[var(--color-expiring)] text-[var(--color-expiring-text)]' }
-  return { label: `${days}d left`, color: 'bg-[var(--color-fresh)] text-[var(--color-fresh-text)]' }
 }
 
 function groupByCategory(items: PantryItem[]) {
@@ -281,7 +275,7 @@ function PantryPageInner() {
                               {item.quantity} {item.unit}
                             </span>
                             {badge && (
-                              <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.color}`}>
+                              <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${badge.className}`}>
                                 {badge.label}
                               </span>
                             )}
@@ -301,6 +295,17 @@ function PantryPageInner() {
                           >
                             🍳 Cook this
                           </Link>
+                        )}
+
+                        {/* Resolve out of the pantry entirely — issue #140 */}
+                        {isUrgent(days) && (
+                          <div className="border-t border-[var(--color-border)] p-2">
+                            <ResolveActions
+                              itemId={item.id}
+                              itemName={item.name}
+                              onResolved={() => queryClient.invalidateQueries({ queryKey: ['pantry'] })}
+                            />
+                          </div>
                         )}
                       </motion.div>
                     )

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -196,7 +196,7 @@ function PantryPageInner() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search items..."
-          className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)] placeholder:text-[var(--color-muted)]"
+          className="focus-ring w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)] placeholder:text-[var(--color-muted)]"
         />
       </div>
 
@@ -264,10 +264,11 @@ function PantryPageInner() {
                         <button
                           type="button"
                           onClick={() => handleOpenEdit(item)}
-                          // Inset focus outline: the card wrapper is
-                          // `overflow-hidden`, so an outward ring/offset would be
-                          // clipped and invisible to keyboard users.
-                          className="p-3 text-left w-full flex-1 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+                          // Inset focus ring (design-system utility, #147): the
+                          // card wrapper is `overflow-hidden`, so an outward
+                          // ring/offset would be clipped and invisible to
+                          // keyboard users.
+                          className="focus-ring-inset p-3 text-left w-full flex-1"
                         >
                           <div className="flex items-center gap-2 mb-1">
                             <span className="text-lg">{getFoodEmoji(item.name, item.category)}</span>
@@ -296,7 +297,7 @@ function PantryPageInner() {
                             // grid doesn't reflow, but the box around it is a
                             // full 44px tap target — same trick ThemePicker uses
                             // (24px swatch inside a 44×44 button).
-                            className="border-t border-[var(--color-border)] px-3 min-h-[44px] flex items-center justify-center text-xs font-semibold text-[var(--color-primary-dark)] text-center hover:bg-[var(--color-border)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+                            className="focus-ring-inset border-t border-[var(--color-border)] px-3 min-h-[44px] flex items-center justify-center text-xs font-semibold text-[var(--color-primary-dark)] text-center hover:bg-[var(--color-border)] transition-colors"
                           >
                             🍳 Cook this
                           </Link>

--- a/nextjs/src/app/pantry/use-soon/page.tsx
+++ b/nextjs/src/app/pantry/use-soon/page.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+/**
+ * "Use Soon" triage view — issue #139.
+ *
+ * A dedicated route rather than a filtered mode of `/pantry`: the browse view
+ * groups by category in a 2-up grid with search/location chips, which is a
+ * different job (find a specific item) from this one (clear everything that's
+ * about to go bad, most urgent first). Bolting a flat urgency-sorted list
+ * into that page would mean two mutually-exclusive render paths sharing one
+ * component; a separate route keeps each page's layout single-purpose and
+ * gives the dashboard's "Use Soon" card a stable, linkable destination.
+ *
+ * This is a client component fetching client-side via React Query — nothing
+ * here awaits on the server, so the route-level fallback already provided by
+ * `app/loading.tsx` covers the initial navigation frame. A segment `loading.tsx`
+ * would only earn its keep if this page did server-side data fetching.
+ */
+
+import Link from 'next/link'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import BubblesHeader from '@/components/layout/BubblesHeader'
+import EmptyState from '@/components/ui/EmptyState'
+import FadeInView from '@/components/ui/FadeInView'
+import ResolveActions from '@/components/pantry/ResolveActions'
+import { getFoodEmoji } from '@/lib/food-emoji'
+import { titleCase } from '@/lib/format'
+import { cookThisHref } from '@/lib/chat-seed'
+import { expiryBadge } from '@/lib/expiry-badge'
+import type { EnrichedPantryItem } from '@/lib/pantry-helpers'
+
+/** Ascending: expired (most negative days) first, then soonest-to-expire. */
+function byUrgency(a: EnrichedPantryItem, b: EnrichedPantryItem): number {
+  const aDays = a.days_until_expiry ?? Number.POSITIVE_INFINITY
+  const bDays = b.days_until_expiry ?? Number.POSITIVE_INFINITY
+  return aDays - bDays
+}
+
+export default function UseSoonPage() {
+  const queryClient = useQueryClient()
+
+  // Query key shares the `'pantry'` prefix with `/pantry`'s `['pantry', {}]`
+  // so a single `invalidateQueries({ queryKey: ['pantry'] })` (partial match,
+  // the default) refetches both views after a resolve, whichever one fired it.
+  const { data, isLoading } = useQuery({
+    queryKey: ['pantry', 'expiring'],
+    queryFn: () => fetch('/api/pantry/expiring').then((r) => r.json()),
+  })
+
+  const items: EnrichedPantryItem[] = data?.items ?? []
+  const sorted = [...items].sort(byUrgency)
+
+  const handleResolved = () => {
+    queryClient.invalidateQueries({ queryKey: ['pantry'] })
+  }
+
+  return (
+    <div className="min-h-screen pb-24">
+      <BubblesHeader
+        mascotState={sorted.length > 0 ? 'surprised' : 'happy'}
+        rightSlot={
+          <div className="flex items-center gap-2">
+            <Link
+              href="/pantry"
+              className="focus-ring text-xs font-semibold text-[var(--color-muted)] px-3 py-1 rounded-full border border-[var(--color-border)]"
+            >
+              ← Pantry
+            </Link>
+            <span className="bg-[var(--color-primary)] text-white text-xs font-semibold px-3 py-1 rounded-full">
+              {sorted.length} item{sorted.length !== 1 ? 's' : ''}
+            </span>
+          </div>
+        }
+      />
+
+      <div className="px-6 pt-4">
+        <h1 className="text-lg font-extrabold text-[var(--color-text)] mb-1">🔥 Use Soon</h1>
+        <p className="text-sm text-[var(--color-muted)] mb-4">
+          Expired and expiring items, most urgent first.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center py-20 gap-3">
+          <span className="text-4xl animate-bounce">⏳</span>
+          <p className="text-sm text-[var(--color-muted)]">Checking your pantry...</p>
+        </div>
+      ) : sorted.length === 0 ? (
+        <EmptyState
+          className="mx-6"
+          headerLabel="Use Soon"
+          mascotState="happy"
+          headline="Nothing's about to expire — nice! ✨"
+          subline="Everything in your pantry is still fresh."
+        />
+      ) : (
+        <div className="px-6 space-y-3">
+          {sorted.map((item, i) => {
+            const badge = expiryBadge(item.days_until_expiry)
+            return (
+              <FadeInView key={item.id} delay={i * 0.03}>
+                <div
+                  className="rounded-2xl border border-[var(--color-border)] bg-[var(--color-surface)] p-3 flex flex-col gap-2 shadow-sm"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2 min-w-0">
+                      <span className="text-lg flex-shrink-0">
+                        {getFoodEmoji(item.name, item.category)}
+                      </span>
+                      <span className="font-semibold text-sm text-[var(--color-text)] truncate">
+                        {titleCase(item.name)}
+                      </span>
+                    </div>
+                    {badge && (
+                      <span
+                        className={`flex-shrink-0 text-xs font-semibold px-2 py-0.5 rounded-full ${badge.className}`}
+                      >
+                        {badge.label}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* One tap into a chat seeded with this ingredient (#138) —
+                      `use` carries the raw stored name, not the display copy. */}
+                  <Link
+                    href={cookThisHref(item.name, item.expiry_date)}
+                    aria-label={`Find a recipe for ${item.name}`}
+                    className="focus-ring min-h-[44px] flex items-center justify-center rounded-full text-xs font-semibold text-[var(--color-primary-dark)] border border-[var(--color-border)] hover:bg-[var(--color-border)] transition-colors"
+                  >
+                    🍳 Find a recipe
+                  </Link>
+
+                  <ResolveActions
+                    itemId={item.id}
+                    itemName={item.name}
+                    onResolved={handleResolved}
+                  />
+                </div>
+              </FadeInView>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/nextjs/src/app/recipes/[id]/page.tsx
+++ b/nextjs/src/app/recipes/[id]/page.tsx
@@ -132,9 +132,12 @@ export default function RecipeDetailPage() {
     : null
 
   // ── Loading state ──────────────────────────────────────────────────────────
+  // Neither of these two early-return states (nor the main render below) uses
+  // <main> — the root layout already supplies the page's one <main> landmark;
+  // nesting a second here would duplicate it for screen readers.
   if (loading) {
     return (
-      <main
+      <div
         className="min-h-screen flex flex-col items-center justify-center px-4 py-16 gap-6"
         style={{ background: 'var(--color-bg)' }}
       >
@@ -145,14 +148,14 @@ export default function RecipeDetailPage() {
         >
           Loading recipe...
         </p>
-      </main>
+      </div>
     )
   }
 
   // ── Error / 404 state ──────────────────────────────────────────────────────
   if (error || !recipe) {
     return (
-      <main
+      <div
         className="min-h-screen flex flex-col items-center justify-center px-4 py-16 gap-4"
         style={{ background: 'var(--color-bg)' }}
       >
@@ -173,19 +176,19 @@ export default function RecipeDetailPage() {
         </p>
         <Link
           href="/recipes"
-          className="mt-2 px-6 py-2 rounded-full font-bold text-white text-sm"
+          className="focus-ring mt-2 px-6 py-2 rounded-full font-bold text-white text-sm"
           style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
         >
           Back to Recipes
         </Link>
-      </main>
+      </div>
     )
   }
 
   // ── Recipe detail ──────────────────────────────────────────────────────────
   return (
     <>
-      <main
+      <div
         className="min-h-screen pb-24"
         style={{ background: 'var(--color-bg)', fontFamily: 'Nunito, sans-serif' }}
       >
@@ -195,8 +198,9 @@ export default function RecipeDetailPage() {
             <div className="flex items-start justify-between gap-4 mb-5">
               {/* Back button */}
               <button
+                type="button"
                 onClick={() => router.push('/recipes')}
-                className="flex items-center gap-1 text-sm font-semibold transition-opacity hover:opacity-70 active:scale-95 flex-shrink-0 mt-1"
+                className="focus-ring flex items-center gap-1 text-sm font-semibold transition-opacity hover:opacity-70 active:scale-95 flex-shrink-0 mt-1"
                 style={{ color: 'var(--color-muted)' }}
               >
                 <span aria-hidden>←</span>
@@ -331,16 +335,23 @@ export default function RecipeDetailPage() {
                         animate={{ opacity: 1, x: 0 }}
                         transition={{ delay: i * 0.03, duration: 0.25 }}
                       >
-                        {/* Custom checkbox */}
+                        {/* Custom checkbox — the real <input> is visually
+                            hidden (`sr-only`) so screen readers still get a
+                            native checkbox, but that leaves keyboard focus
+                            with nothing to show on: `peer` + `peer-focus-visible`
+                            below draws a ring on the visible box instead, using
+                            the same tokens `.focus-ring` uses (that utility
+                            itself can't apply here — it targets the focused
+                            element, which is the invisible one). */}
                         <div className="flex-shrink-0 mt-0.5">
                           <input
                             type="checkbox"
-                            className="sr-only"
+                            className="peer sr-only"
                             checked={checked}
                             onChange={() => toggleIngredient(i)}
                           />
                           <div
-                            className="w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors"
+                            className="w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors peer-focus-visible:outline peer-focus-visible:outline-[var(--focus-ring-width)] peer-focus-visible:outline-offset-[var(--focus-ring-offset)] peer-focus-visible:outline-[var(--color-focus-ring)]"
                             style={{
                               borderColor: checked ? 'var(--color-accent)' : 'var(--color-border)',
                               background: checked ? 'var(--color-accent)' : 'transparent',
@@ -465,7 +476,7 @@ export default function RecipeDetailPage() {
             </FadeInView>
           )}
         </div>
-      </main>
+      </div>
 
       {/* AI Refinement Modal */}
       <RecipeRefinementModal

--- a/nextjs/src/app/recipes/page.tsx
+++ b/nextjs/src/app/recipes/page.tsx
@@ -4,11 +4,13 @@ import ThemePicker from '@/components/ui/ThemePicker'
 
 export default function RecipesPage() {
   return (
-    <main className="min-h-screen pb-24" style={{ background: 'var(--color-bg)' }}>
+    // Not a <main> — the root layout already provides the page's one <main>
+    // landmark; nesting a second one here duplicates it for screen readers.
+    <div className="min-h-screen pb-24" style={{ background: 'var(--color-bg)' }}>
       <BubblesHeader rightSlot={<ThemePicker />} />
       <div className="max-w-3xl mx-auto px-4 pt-4">
         <RecipeBookLoader />
       </div>
-    </main>
+    </div>
   )
 }

--- a/nextjs/src/components/ThemeProvider.tsx
+++ b/nextjs/src/components/ThemeProvider.tsx
@@ -43,6 +43,14 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY)
     const resolved = stored !== null && isValidTheme(stored) ? stored : DEFAULT_THEME
+    // Deliberate: localStorage isn't readable during SSR, so the only way to
+    // correct the theme after the (mandatory) DEFAULT_THEME-on-both-passes
+    // first render is in an effect, once we know we've hydrated. There's no
+    // prop/derived-value this could be computed from during render — moving
+    // it there would either reintroduce the server/client mismatch this
+    // avoids, or read localStorage during SSR (which doesn't exist). See the
+    // WHY comment on `theme` above.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setThemeState(resolved)
     document.documentElement.setAttribute('data-theme', resolved)
   }, [])

--- a/nextjs/src/components/chat/RotatingPlaceholder.tsx
+++ b/nextjs/src/components/chat/RotatingPlaceholder.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useSyncExternalStore } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 
 const PROMPTS = [
@@ -18,21 +18,37 @@ const PROMPTS = [
 
 const INTERVAL_MS = 4000
 
+// `prefers-reduced-motion` is a browser API with no server-side equivalent, so
+// SSR always sees "not reduced" (getServerSnapshot). useSyncExternalStore is
+// the React-sanctioned way to read + subscribe to this kind of external
+// store: it renders the server snapshot on the first client pass (matching
+// hydration) and re-renders with the real client value right after, with no
+// `setState` call inside an effect body.
+function subscribeReducedMotion(callback: () => void): () => void {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  mq.addEventListener('change', callback)
+  return () => mq.removeEventListener('change', callback)
+}
+
+function getReducedMotionSnapshot(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getReducedMotionServerSnapshot(): boolean {
+  return false
+}
+
 interface RotatingPlaceholderProps {
   visible: boolean
 }
 
 export default function RotatingPlaceholder({ visible }: RotatingPlaceholderProps) {
   const [index, setIndex] = useState(0)
-  const [reducedMotion, setReducedMotion] = useState(false)
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReducedMotion(mq.matches)
-    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot
+  )
 
   useEffect(() => {
     if (!visible || reducedMotion) return

--- a/nextjs/src/components/dashboard/BubbleMessage.tsx
+++ b/nextjs/src/components/dashboard/BubbleMessage.tsx
@@ -48,11 +48,10 @@ export default function BubbleMessage({
                 <Link
                   key={action.href + action.label}
                   href={action.href}
-                  className="text-xs font-semibold px-4 py-2 rounded-full transition-opacity hover:opacity-90 active:scale-95"
+                  className="focus-ring min-h-[44px] flex items-center text-xs font-semibold px-4 py-2 rounded-full transition-opacity hover:opacity-90 active:scale-95"
                   style={{
                     background: i % 2 === 0 ? 'var(--color-primary)' : 'var(--color-accent)',
                     color: 'white',
-                    display: 'inline-block',
                   }}
                 >
                   {action.label}
@@ -62,7 +61,7 @@ export default function BubbleMessage({
                 <button
                   type="button"
                   onClick={onDismiss}
-                  className="text-xs font-semibold px-4 py-2 rounded-full transition-opacity hover:opacity-90 active:scale-95"
+                  className="focus-ring min-h-[44px] text-xs font-semibold px-4 py-2 rounded-full transition-opacity hover:opacity-90 active:scale-95"
                   style={{
                     background: 'var(--color-border)',
                     color: 'var(--color-muted)',

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -229,7 +229,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             detail: expiringCount > 0 ? `${expiringCount} item${expiringCount > 1 ? 's' : ''}` : 'All fresh!',
             // Only this card's detail depends on fetched data.
             pending: loading,
-            href: '/pantry',
+            href: '/pantry/use-soon',
             gradient: 'linear-gradient(135deg, var(--color-primary) 0%, var(--color-primary-dark) 100%)',
           },
           {

--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -209,7 +209,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
                 </p>
                 <Link
                   href={heroAction.href}
-                  className="inline-block mt-3 text-xs font-semibold px-5 py-2 rounded-full text-white"
+                  className="focus-ring min-h-[44px] inline-flex items-center mt-3 text-xs font-semibold px-5 py-2 rounded-full text-white"
                   style={{ background: 'var(--color-primary)' }}
                 >
                   {heroAction.label}
@@ -250,7 +250,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
           },
         ].map((card, i) => (
           <FadeInView key={card.href} delay={0.35 + i * 0.08}>
-            <Link href={card.href}>
+            <Link href={card.href} className="focus-ring block rounded-2xl">
               <motion.div
                 whileHover={{ scale: 1.04 }}
                 whileTap={{ scale: 0.97 }}
@@ -279,7 +279,7 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
         <Link
           href={tipChatHref(tip)}
           aria-label={`Ask Bubbles about today's tip: ${tip}`}
-          className="block max-w-sm w-full"
+          className="focus-ring block max-w-sm w-full rounded-2xl"
         >
           <div
             className="flex items-center gap-3 rounded-2xl px-4 py-3 border border-[var(--color-border)]"

--- a/nextjs/src/components/layout/BottomNav.tsx
+++ b/nextjs/src/components/layout/BottomNav.tsx
@@ -50,7 +50,7 @@ export default function BottomNav() {
             <Link
               key={tab.href}
               href={tab.href}
-              className="flex-1 relative flex flex-col items-center py-2 pb-4 gap-0.5"
+              className="focus-ring-inset flex-1 relative flex flex-col items-center py-2 pb-4 gap-0.5"
             >
               {isActive && (
                 <motion.div

--- a/nextjs/src/components/layout/BottomNav.tsx
+++ b/nextjs/src/components/layout/BottomNav.tsx
@@ -39,7 +39,10 @@ export default function BottomNav() {
   }
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-[var(--color-surface)] border-t border-[var(--color-border)] rounded-t-3xl">
+    <nav
+      aria-label="Primary"
+      className="fixed bottom-0 left-0 right-0 z-50 bg-[var(--color-surface)] border-t border-[var(--color-border)] rounded-t-3xl"
+    >
       <div className="flex items-stretch">
         {tabs.map((tab) => {
           const isActive = tab.href === '/'
@@ -50,6 +53,7 @@ export default function BottomNav() {
             <Link
               key={tab.href}
               href={tab.href}
+              aria-current={isActive ? 'page' : undefined}
               className="focus-ring-inset flex-1 relative flex flex-col items-center py-2 pb-4 gap-0.5"
             >
               {isActive && (

--- a/nextjs/src/components/pantry/AddItemModal.tsx
+++ b/nextjs/src/components/pantry/AddItemModal.tsx
@@ -207,7 +207,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                   onFocus={() => suggestions.length > 0 && setShowSuggestions(true)}
                   onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
                   placeholder="e.g., Milk, Eggs, Rice..."
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="focus-ring w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 />
                 {showSuggestions && suggestions.length > 0 && (
                   <div className="absolute left-0 right-0 top-full mt-1 bg-white border border-[var(--color-border)] rounded-xl shadow-lg z-10 overflow-hidden">
@@ -216,7 +216,9 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                         key={s.canonical_name}
                         type="button"
                         onMouseDown={() => selectSuggestion(s)}
-                        className="w-full text-left px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-primary)]/10 transition-colors"
+                        // Inset: this dropdown clips overflow, so an outward ring
+                        // would be cut off at the panel edge.
+                        className="focus-ring-inset w-full text-left px-4 py-2 text-sm text-[var(--color-text)] hover:bg-[var(--color-primary)]/10 transition-colors"
                       >
                         {s.canonical_name}
                         {s.category && (
@@ -238,7 +240,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                     step="any"
                     value={quantity}
                     onChange={(e) => setQuantity(Number(e.target.value))}
-                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                    className="focus-ring w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                   />
                 </div>
                 <div className="flex-1">
@@ -248,7 +250,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                     value={unit}
                     onChange={(e) => setUnit(e.target.value)}
                     list="unit-suggestions"
-                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                    className="focus-ring w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                   />
                   <datalist id="unit-suggestions">
                     {UNIT_SUGGESTIONS.map((u) => (
@@ -264,7 +266,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                 <select
                   value={category}
                   onChange={(e) => setCategory(e.target.value)}
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="focus-ring w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c.value} value={c.value}>{c.label}</option>
@@ -281,7 +283,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                       key={loc.value}
                       type="button"
                       onClick={() => setLocation(loc.value)}
-                      className={`flex-1 py-2 rounded-xl text-xs font-semibold transition-colors ${
+                      className={`focus-ring flex-1 py-2 rounded-xl text-xs font-semibold transition-colors ${
                         location === loc.value
                           ? 'bg-[var(--color-primary)] text-white'
                           : 'bg-[var(--color-surface)] text-[var(--color-text)] border border-[var(--color-border)]'
@@ -300,7 +302,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                   type="date"
                   value={expiryDate}
                   onChange={(e) => setExpiryDate(e.target.value)}
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="focus-ring w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 />
               </div>
 
@@ -314,14 +316,14 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                           type="button"
                           onClick={handleDelete}
                           disabled={saving}
-                          className="flex-1 py-2.5 rounded-full bg-red-400 text-white text-sm font-semibold disabled:opacity-50"
+                          className="focus-ring flex-1 py-2.5 rounded-full bg-red-400 text-white text-sm font-semibold disabled:opacity-50"
                         >
                           Confirm Delete
                         </button>
                         <button
                           type="button"
                           onClick={() => setConfirmDelete(false)}
-                          className="flex-1 py-2.5 rounded-full bg-[var(--color-surface)] text-[var(--color-text)] text-sm font-semibold border border-[var(--color-border)]"
+                          className="focus-ring flex-1 py-2.5 rounded-full bg-[var(--color-surface)] text-[var(--color-text)] text-sm font-semibold border border-[var(--color-border)]"
                         >
                           Cancel
                         </button>
@@ -330,7 +332,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                       <button
                         type="button"
                         onClick={() => setConfirmDelete(true)}
-                        className="py-2.5 px-4 rounded-full text-red-400 text-sm font-semibold border border-red-300"
+                        className="focus-ring py-2.5 px-4 rounded-full text-red-400 text-sm font-semibold border border-red-300"
                       >
                         Delete
                       </button>

--- a/nextjs/src/components/pantry/AddItemModal.tsx
+++ b/nextjs/src/components/pantry/AddItemModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import SpringButton from '@/components/ui/SpringButton'
+import { useModalFocusTrap } from '@/hooks/useModalFocusTrap'
 
 interface PantryItemData {
   id: string
@@ -61,6 +62,8 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const isEditMode = !!editItem
+  const panelRef = useRef<HTMLDivElement>(null)
+  useModalFocusTrap(isOpen, onClose, panelRef)
 
   // Populate form when editing
   useEffect(() => {
@@ -181,7 +184,12 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
 
           {/* Modal */}
           <motion.div
-            className="fixed bottom-0 left-0 right-0 z-[60] bg-white rounded-t-3xl max-h-[85vh] overflow-y-auto"
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="add-item-modal-title"
+            tabIndex={-1}
+            className="focus-ring-inset fixed bottom-0 left-0 right-0 z-[60] bg-white rounded-t-3xl max-h-[85vh] overflow-y-auto"
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
             exit={{ y: '100%' }}
@@ -193,7 +201,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
             </div>
 
             <div className="px-6 pb-8">
-              <h2 className="text-lg font-extrabold text-[var(--color-text)] mb-4">
+              <h2 id="add-item-modal-title" className="text-lg font-extrabold text-[var(--color-text)] mb-4">
                 {isEditMode ? 'Edit Item' : 'Add Item'} ✏️
               </h2>
 

--- a/nextjs/src/components/pantry/AddItemRow.tsx
+++ b/nextjs/src/components/pantry/AddItemRow.tsx
@@ -39,7 +39,7 @@ interface AddItemRowProps {
 }
 
 const inputClass =
-  'w-full rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]'
+  'focus-ring w-full rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]'
 
 export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRowProps) {
   const set = (field: keyof ManualRow, value: string | number) =>
@@ -53,7 +53,7 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
         <button
           type="button"
           onClick={onRemove}
-          className="text-xs text-[var(--color-muted)] hover:text-red-400 transition-colors px-2 py-0.5 rounded-full border border-[var(--color-border)] hover:border-red-200"
+          className="focus-ring text-xs text-[var(--color-muted)] hover:text-red-400 transition-colors px-2 py-0.5 rounded-full border border-[var(--color-border)] hover:border-red-200"
           aria-label={`Remove item ${index + 1}`}
         >
           ✕
@@ -78,13 +78,13 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
           step="any"
           value={row.quantity}
           onChange={(e) => set('quantity', Number(e.target.value))}
-          className="w-20 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="focus-ring w-20 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Quantity"
         />
         <select
           value={row.unit}
           onChange={(e) => set('unit', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="focus-ring flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Unit"
         >
           {UNITS.map((u) => (
@@ -98,7 +98,7 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
         <select
           value={row.category}
           onChange={(e) => set('category', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="focus-ring flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Category"
         >
           {CATEGORIES.map((c) => (
@@ -108,7 +108,7 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
         <select
           value={row.storage_location}
           onChange={(e) => set('storage_location', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="focus-ring flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Storage location"
         >
           {LOCATIONS.map((l) => (

--- a/nextjs/src/components/pantry/PantryAddSheet.tsx
+++ b/nextjs/src/components/pantry/PantryAddSheet.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence, useDragControls } from 'framer-motion'
 import ScanTab from './ScanTab'
 import TypeTab from './TypeTab'
+import { useModalFocusTrap } from '@/hooks/useModalFocusTrap'
 
 export interface AddItem {
   name: string
@@ -36,6 +37,8 @@ export default function PantryAddSheet({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const dragControls = useDragControls()
+  const panelRef = useRef<HTMLDivElement>(null)
+  useModalFocusTrap(isOpen, onClose, panelRef)
 
   // Update tab when prop changes (e.g. URL param triggers re-open)
   useEffect(() => {
@@ -98,7 +101,12 @@ export default function PantryAddSheet({
 
           {/* Sheet — slides up from bottom, sits above the bottom nav */}
           <motion.div
-            className="fixed bottom-16 left-0 right-0 z-[60] rounded-t-3xl flex flex-col select-none"
+            ref={panelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="pantry-add-sheet-title"
+            tabIndex={-1}
+            className="focus-ring-inset fixed bottom-16 left-0 right-0 z-[60] rounded-t-3xl flex flex-col select-none"
             style={{
               background: 'var(--color-surface)',
               maxHeight: 'calc(92vh - 64px)',
@@ -127,13 +135,13 @@ export default function PantryAddSheet({
             {/* Header */}
             <div className="px-6 pb-3 flex-shrink-0">
               <div className="flex items-center justify-between">
-                <h2 className="text-lg font-extrabold text-[var(--color-text)]">
+                <h2 id="pantry-add-sheet-title" className="text-lg font-extrabold text-[var(--color-text)]">
                   Add to Pantry
                 </h2>
                 <button
                   type="button"
                   onClick={onClose}
-                  className="text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors text-xl leading-none px-1"
+                  className="focus-ring min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-muted)] hover:text-[var(--color-text)] transition-colors text-xl leading-none"
                   aria-label="Close"
                 >
                   ✕
@@ -145,7 +153,8 @@ export default function PantryAddSheet({
                 <button
                   type="button"
                   onClick={() => setActiveTab('scan')}
-                  className={`flex-1 py-2 rounded-full text-sm font-semibold transition-colors ${
+                  aria-pressed={activeTab === 'scan'}
+                  className={`focus-ring flex-1 py-2 rounded-full text-sm font-semibold transition-colors ${
                     activeTab === 'scan'
                       ? 'bg-[var(--color-primary)] text-white'
                       : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-text)]'
@@ -156,7 +165,8 @@ export default function PantryAddSheet({
                 <button
                   type="button"
                   onClick={() => setActiveTab('type')}
-                  className={`flex-1 py-2 rounded-full text-sm font-semibold transition-colors ${
+                  aria-pressed={activeTab === 'type'}
+                  className={`focus-ring flex-1 py-2 rounded-full text-sm font-semibold transition-colors ${
                     activeTab === 'type'
                       ? 'bg-[var(--color-primary)] text-white'
                       : 'bg-[var(--color-border)] text-[var(--color-muted)] hover:text-[var(--color-text)]'
@@ -209,7 +219,7 @@ export default function PantryAddSheet({
                 whileHover={{ scale: itemCount === 0 || isSubmitting ? 1 : 1.02 }}
                 whileTap={{ scale: itemCount === 0 || isSubmitting ? 1 : 0.96 }}
                 transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-                className="w-full py-4 rounded-full font-bold text-white shadow-lg transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+                className="focus-ring w-full py-4 rounded-full font-bold text-white shadow-lg transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ background: 'var(--color-primary-dark, #FF8FAB)' }}
               >
                 {isSubmitting

--- a/nextjs/src/components/pantry/ResolveActions.tsx
+++ b/nextjs/src/components/pantry/ResolveActions.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useState } from 'react'
+import { resolvePantryItem, type ResolveOutcome } from '@/lib/api/pantry'
+
+interface ResolveActionsProps {
+  itemId: string
+  /** Raw (non-title-cased) pantry name — only used for accessible labels/copy. */
+  itemName: string
+  /** Called after a successful resolve so the caller can refetch/remove the row. */
+  onResolved: () => void
+  className?: string
+}
+
+type Status = 'idle' | 'confirm-toss' | 'resolving'
+
+/**
+ * "Used it up" / "Tossed it" — issue #140's UI half.
+ *
+ * Both outcomes delete the pantry item (`resolvePantryItem`), so a stray tap
+ * on either one loses the row. "Used it up" fires immediately: it's the
+ * outcome the whole app is nudging toward (finish food before it expires),
+ * and a false positive here costs nothing you weren't already about to
+ * do — the item was going to be consumed anyway. "Tossed it" is the one that
+ * more plausibly comes from a mis-tap (it sits right next to "Used it up",
+ * same size, same row) and is the one a user is likely to regret logging by
+ * accident (it also miscounts food waste). So only "Tossed it" gets a second,
+ * explicit tap via an inline confirm swap — same pattern as
+ * `RecipeDeleteConfirm` / `AddItemModal`'s delete-confirm toggle — rather
+ * than a swipe gesture or a modal.
+ */
+export default function ResolveActions({ itemId, itemName, onResolved, className }: ResolveActionsProps) {
+  const [status, setStatus] = useState<Status>('idle')
+  const [pendingOutcome, setPendingOutcome] = useState<ResolveOutcome | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const busy = status === 'resolving'
+
+  async function resolve(outcome: ResolveOutcome) {
+    if (busy) return // guards double-tap while a request is in flight
+    setStatus('resolving')
+    setPendingOutcome(outcome)
+    setError(null)
+    try {
+      await resolvePantryItem(itemId, outcome)
+      onResolved()
+      // No further state update on success: the parent's refetch removes
+      // this row/card entirely, so there's nothing left to render here.
+    } catch (err) {
+      // The one route-specific 500 (event recorded, delete failed) surfaces
+      // here with its own message from resolvePantryItem — the caller must
+      // not be left thinking the item quietly vanished when it didn't.
+      setStatus('idle')
+      setPendingOutcome(null)
+      setError(err instanceof Error ? err.message : 'Something went wrong — please try again.')
+    }
+  }
+
+  if (status === 'confirm-toss') {
+    return (
+      <div className={`flex items-center gap-2 ${className ?? ''}`}>
+        <span className="text-xs text-[var(--color-muted)] flex-1 min-w-0 truncate">
+          Toss {itemName}?
+        </span>
+        <button
+          type="button"
+          onClick={() => resolve('tossed')}
+          disabled={busy}
+          className="focus-ring min-h-[44px] px-3 rounded-full text-xs font-semibold bg-[var(--color-expired)] text-[var(--color-expired-text)] disabled:opacity-50"
+        >
+          {busy ? 'Tossing…' : 'Yes, toss it'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setStatus('idle')}
+          disabled={busy}
+          className="focus-ring min-h-[44px] px-3 rounded-full text-xs font-semibold border border-[var(--color-border)] text-[var(--color-muted)] disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className={className}>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={() => resolve('used')}
+          disabled={busy}
+          aria-label={`Mark ${itemName} used up`}
+          className="focus-ring flex-1 min-h-[44px] px-2 rounded-full text-xs font-semibold bg-[var(--color-fresh)] text-[var(--color-fresh-text)] disabled:opacity-50"
+        >
+          {busy && pendingOutcome === 'used' ? 'Saving…' : '✅ Used it up'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setStatus('confirm-toss')}
+          disabled={busy}
+          aria-label={`Toss ${itemName}`}
+          className="focus-ring flex-1 min-h-[44px] px-2 rounded-full text-xs font-semibold border border-[var(--color-border)] text-[var(--color-muted)] disabled:opacity-50"
+        >
+          🗑️ Tossed it
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-1.5 flex items-center justify-between gap-2 px-2 py-1.5 rounded-xl text-xs bg-[var(--color-expired)] text-[var(--color-expired-text)]"
+        >
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            aria-label="Dismiss error"
+            className="focus-ring flex-shrink-0"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/nextjs/src/components/pantry/ResolveActions.tsx
+++ b/nextjs/src/components/pantry/ResolveActions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { resolvePantryItem, type ResolveOutcome } from '@/lib/api/pantry'
 
 interface ResolveActionsProps {
@@ -34,7 +34,33 @@ export default function ResolveActions({ itemId, itemName, onResolved, className
   const [pendingOutcome, setPendingOutcome] = useState<ResolveOutcome | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  const tossButtonRef = useRef<HTMLButtonElement>(null)
+  const cancelButtonRef = useRef<HTMLButtonElement>(null)
+  const hasMountedRef = useRef(false)
+
   const busy = status === 'resolving'
+
+  // The confirm swap unmounts whichever button triggered it, which strands
+  // focus on <body> for keyboard/screen-reader users unless we move it
+  // ourselves. Skip the very first render (mount) — this effect should only
+  // react to the idle <-> confirm-toss transition, never steal focus on load.
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true
+      return
+    }
+    if (status === 'confirm-toss') {
+      // Land on "Cancel", not "Yes, toss it": this is the one destructive,
+      // hard-to-undo action in the component, and whichever control has
+      // focus is the one a bare Enter/Space keypress will hit next.
+      cancelButtonRef.current?.focus()
+    } else if (status === 'idle') {
+      // Cancelling (or a failed toss resolve) returns to idle — send focus
+      // back to the "Tossed it" button that opened the confirm view rather
+      // than dropping it.
+      tossButtonRef.current?.focus()
+    }
+  }, [status])
 
   async function resolve(outcome: ResolveOutcome) {
     if (busy) return // guards double-tap while a request is in flight
@@ -71,6 +97,7 @@ export default function ResolveActions({ itemId, itemName, onResolved, className
           {busy ? 'Tossing…' : 'Yes, toss it'}
         </button>
         <button
+          ref={cancelButtonRef}
           type="button"
           onClick={() => setStatus('idle')}
           disabled={busy}
@@ -95,6 +122,7 @@ export default function ResolveActions({ itemId, itemName, onResolved, className
           {busy && pendingOutcome === 'used' ? 'Saving…' : '✅ Used it up'}
         </button>
         <button
+          ref={tossButtonRef}
           type="button"
           onClick={() => setStatus('confirm-toss')}
           disabled={busy}
@@ -115,7 +143,7 @@ export default function ResolveActions({ itemId, itemName, onResolved, className
             type="button"
             onClick={() => setError(null)}
             aria-label="Dismiss error"
-            className="focus-ring flex-shrink-0"
+            className="focus-ring flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             ✕
           </button>

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { cookRecipe, confirmCook } from '@/lib/api/recipes'
 import type { CookProposal, IngredientMatch, DeductionItem } from '@/types/recipes'
+import { useModalFocusTrap } from '@/hooks/useModalFocusTrap'
 
 interface CookModalProps {
   recipeId: string
@@ -67,6 +68,9 @@ export default function CookModal({
   const [errorMsg, setErrorMsg] = useState<string>('')
   // Editable override quantities for unit_conflict rows (keyed by pantry_item_id)
   const [overrides, setOverrides] = useState<Record<string, string>>({})
+  const panelRef = useRef<HTMLDivElement>(null)
+  // Mounts-to-open, like RecipeEditModal — see comment there.
+  useModalFocusTrap(true, onClose, panelRef)
 
   useEffect(() => {
     let cancelled = false
@@ -163,7 +167,12 @@ export default function CookModal({
       >
         {/* Sheet */}
         <motion.div
-          className="w-full max-w-md mx-2 mb-4 sm:mb-0 rounded-2xl overflow-hidden flex flex-col"
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cook-modal-title"
+          tabIndex={-1}
+          className="focus-ring-inset w-full max-w-md mx-2 mb-4 sm:mb-0 rounded-2xl overflow-hidden flex flex-col"
           style={{
             background: 'var(--color-surface)',
             boxShadow: '0 8px 32px color-mix(in srgb, var(--color-primary) 25%, transparent)',
@@ -181,6 +190,7 @@ export default function CookModal({
           >
             <div>
               <h2
+                id="cook-modal-title"
                 className="text-base font-extrabold text-[var(--color-text)]"
                 style={{ fontFamily: 'Nunito, sans-serif' }}
               >
@@ -194,8 +204,9 @@ export default function CookModal({
               </p>
             </div>
             <button
+              type="button"
               onClick={onClose}
-              className="text-[var(--color-muted)] hover:text-[var(--color-text)] text-xl leading-none px-1"
+              className="focus-ring min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-muted)] hover:text-[var(--color-text)] text-xl leading-none"
               aria-label="Close"
             >
               ✕
@@ -288,7 +299,7 @@ export default function CookModal({
                                     [String(i)]: e.target.value,
                                   }))
                                 }
-                                className="w-16 text-right border border-[var(--color-border)] rounded px-1 py-0.5 text-xs"
+                                className="focus-ring w-16 text-right border border-[var(--color-border)] rounded px-1 py-0.5 text-xs"
                                 placeholder="qty"
                                 aria-label={`Deduct quantity for ${m.ingredient_name}`}
                               />
@@ -346,17 +357,19 @@ export default function CookModal({
               style={{ background: 'var(--color-bg)' }}
             >
               <button
+                type="button"
                 onClick={onClose}
                 disabled={state === 'confirming'}
-                className="flex-1 py-2 rounded-full text-sm font-bold border border-[var(--color-border)] text-[var(--color-muted)] active:scale-95 transition-transform disabled:opacity-50"
+                className="focus-ring flex-1 py-2 rounded-full text-sm font-bold border border-[var(--color-border)] text-[var(--color-muted)] active:scale-95 transition-transform disabled:opacity-50"
                 style={{ fontFamily: 'Nunito, sans-serif' }}
               >
                 Cancel
               </button>
               <button
+                type="button"
                 onClick={handleConfirm}
                 disabled={state === 'confirming'}
-                className="flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform disabled:opacity-50"
+                className="focus-ring flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform disabled:opacity-50"
                 style={{ background: 'var(--color-primary-dark)', fontFamily: 'Nunito, sans-serif' }}
               >
                 {state === 'confirming' ? 'Saving...' : 'Confirm'}

--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -100,6 +100,22 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
     return () => document.removeEventListener('mousedown', handleMouseDown)
   }, [menuOpen])
 
+  // Escape closes the overflow menu too — it's a popover, not a full
+  // dialog (no focus trap), but a keyboard user who opened it with Enter/
+  // Space needs a keyboard-only way to back out, and should land back on
+  // the "More options" toggle rather than losing their place.
+  useEffect(() => {
+    if (!menuOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMenuOpen(false)
+        menuRef.current?.querySelector<HTMLButtonElement>('button')?.focus()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [menuOpen])
+
   // Merge optimistic favorite overrides into the recipe list
   const recipesWithOverrides = useMemo(
     () => recipes.map((r) => r.id in favoriteOverrides ? { ...r, is_favorite: favoriteOverrides[r.id] } : r),
@@ -293,8 +309,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
           <RecipeSearchBar onSearch={handleSearch} />
         </div>
         <button
+          type="button"
           onClick={() => setImportOpen(true)}
-          className="flex-shrink-0 px-3 py-2 rounded-full text-sm font-bold text-[var(--color-text)] active:scale-95 transition-transform"
+          className="focus-ring flex-shrink-0 px-3 py-2 rounded-full text-sm font-bold text-[var(--color-text)] active:scale-95 transition-transform"
           style={{ background: 'var(--color-accent)', fontFamily: 'Nunito, sans-serif' }}
           title="Import recipe from URL"
           aria-label="Import recipe from URL"
@@ -357,8 +374,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     Recipes 🍳
                   </span>
                   <button
+                    type="button"
                     onClick={() => setSidebarOpen(false)}
-                    className="text-[var(--color-muted)] hover:text-[var(--color-text)] text-lg leading-none px-1"
+                    className="focus-ring-inset min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-muted)] hover:text-[var(--color-text)] text-lg leading-none"
                     aria-label="Close sidebar"
                   >
                     ✕
@@ -378,8 +396,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                       return (
                         <li key={r.id}>
                           <button
+                            type="button"
                             onClick={() => handleSelect(r.id)}
-                            className="w-full text-left px-4 py-3 text-sm transition-colors"
+                            aria-current={isActive ? 'true' : undefined}
+                            className="focus-ring-inset w-full text-left px-4 py-3 text-sm transition-colors min-h-[44px]"
                             style={{
                               background: isActive ? 'var(--color-bg)' : 'transparent',
                               borderLeft: `3px solid ${isActive ? 'var(--color-primary)' : 'transparent'}`,
@@ -411,8 +431,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
         {/* ─── Hamburger tab ─── */}
         {!sidebarOpen && (
           <button
+            type="button"
             onClick={() => setSidebarOpen(true)}
-            className="absolute left-0 top-4 z-10 flex items-center justify-center rounded-r-lg shadow-sm"
+            className="focus-ring-inset absolute left-0 top-4 z-10 flex items-center justify-center rounded-r-lg shadow-sm"
             style={{
               width: '28px',
               height: '40px',
@@ -480,9 +501,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   <div className="flex items-center justify-between">
                     {/* Cook it — primary-tinted to signal the main action */}
                     <button
+                      type="button"
                       onClick={() => setCookOpen(true)}
                       disabled={mutating}
-                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                       style={{ background: 'color-mix(in srgb, var(--color-primary) 18%, var(--color-bg))', border: '1.5px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border))' }}
                       aria-label="Cook this recipe"
                       title="Cook it"
@@ -493,9 +515,11 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     <div className="flex items-center gap-2">
                       {/* Heart button — 44x44 with pop animation */}
                       <motion.button
+                        type="button"
                         onClick={handleFavorite}
                         disabled={mutating}
-                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                        aria-pressed={selectedRecipe.is_favorite}
+                        className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                         style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                         aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
                         title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
@@ -512,9 +536,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                       {/* Overflow menu — Edit + Delete */}
                       <div className="relative" ref={menuRef}>
                         <button
+                          type="button"
                           onClick={() => setMenuOpen((o) => !o)}
                           disabled={mutating}
-                          className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                          className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                           style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                           aria-label="More options"
                           aria-haspopup="true"
@@ -538,15 +563,17 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                               }}
                             >
                               <button
+                                type="button"
                                 onClick={() => { setMenuOpen(false); setEditOpen(true) }}
-                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                className="focus-ring-inset w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors min-h-[44px]"
                                 style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
                               >
                                 ✏️ Edit
                               </button>
                               <button
+                                type="button"
                                 onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
-                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                className="focus-ring-inset w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors min-h-[44px]"
                                 style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
                               >
                                 🗑️ Delete
@@ -604,9 +631,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                   <div className="flex items-center justify-between w-full">
                     {/* Cook it — primary-tinted to signal the main action */}
                     <button
+                      type="button"
                       onClick={() => setCookOpen(true)}
                       disabled={mutating}
-                      className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                      className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                       style={{ background: 'color-mix(in srgb, var(--color-primary) 18%, var(--color-bg))', border: '1.5px solid color-mix(in srgb, var(--color-primary) 35%, var(--color-border))' }}
                       aria-label="Cook this recipe"
                       title="Cook it"
@@ -617,9 +645,11 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                     <div className="flex items-center gap-2">
                       {/* Heart button — 44x44 with pop animation */}
                       <motion.button
+                        type="button"
                         onClick={handleFavorite}
                         disabled={mutating}
-                        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                        aria-pressed={selectedRecipe.is_favorite}
+                        className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                         style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                         aria-label={selectedRecipe.is_favorite ? 'Unfavorite' : 'Favorite'}
                         title={selectedRecipe.is_favorite ? 'Remove from favorites' : 'Add to favorites'}
@@ -636,9 +666,10 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                       {/* Overflow menu — Edit + Delete */}
                       <div className="relative" ref={menuRef}>
                         <button
+                          type="button"
                           onClick={() => setMenuOpen((o) => !o)}
                           disabled={mutating}
-                          className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                          className="focus-ring-inset w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
                           style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
                           aria-label="More options"
                           aria-haspopup="true"
@@ -662,15 +693,17 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                               }}
                             >
                               <button
+                                type="button"
                                 onClick={() => { setMenuOpen(false); setEditOpen(true) }}
-                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                className="focus-ring-inset w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors min-h-[44px]"
                                 style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
                               >
                                 ✏️ Edit
                               </button>
                               <button
+                                type="button"
                                 onClick={() => { setMenuOpen(false); setDeleteOpen(true) }}
-                                className="w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors"
+                                className="focus-ring-inset w-full px-4 py-3 text-left text-sm font-semibold flex items-center gap-2 hover:bg-[var(--color-bg)] transition-colors min-h-[44px]"
                                 style={{ color: 'var(--color-coral)', fontFamily: 'Nunito, sans-serif' }}
                               >
                                 🗑️ Delete
@@ -707,8 +740,9 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
               >
                 <span>{errorMessage}</span>
                 <button
+                  type="button"
                   onClick={() => setErrorMessage(null)}
-                  className="ml-2 hover:opacity-70 transition-opacity"
+                  className="focus-ring-inset ml-2 min-h-[44px] min-w-[44px] flex items-center justify-center hover:opacity-70 transition-opacity"
                   style={{ color: 'var(--color-primary-dark)' }}
                   aria-label="Dismiss error"
                 >
@@ -724,20 +758,31 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
             {filteredRecipes.length > 1 && (
               <div className="flex items-center justify-between px-5 py-1.5 flex-shrink-0" style={{ borderBottom: '1px solid var(--color-border)' }}>
                 <button
+                  type="button"
                   onClick={goPrev}
                   disabled={currentIndex === 0}
-                  className="text-[var(--color-primary-dark)] text-lg px-1 disabled:opacity-30 active:scale-90 transition-transform"
+                  className="focus-ring-inset min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-primary-dark)] text-lg disabled:opacity-30 active:scale-90 transition-transform"
                   aria-label="Previous recipe"
                 >
                   ‹
                 </button>
-                <span className="text-xs text-[var(--color-muted)]" style={{ fontFamily: 'Nunito, sans-serif' }}>
+                <span className="text-xs text-[var(--color-muted)]" style={{ fontFamily: 'Nunito, sans-serif' }} aria-hidden="true">
                   {currentIndex + 1} / {filteredRecipes.length}
                 </span>
+                {/* Page-turning swaps the whole panel's content (title,
+                    ingredients, steps...) but leaves focus sitting on
+                    whichever arrow was clicked — nothing else here moves
+                    focus to the new content, so nothing else would announce
+                    the change. This is the one place in the book that needs
+                    a live region rather than relying on a focus move. */}
+                <span aria-live="polite" className="sr-only">
+                  {selectedRecipe.title}, recipe {currentIndex + 1} of {filteredRecipes.length}
+                </span>
                 <button
+                  type="button"
                   onClick={goNext}
                   disabled={currentIndex === filteredRecipes.length - 1}
-                  className="text-[var(--color-primary-dark)] text-lg px-1 disabled:opacity-30 active:scale-90 transition-transform"
+                  className="focus-ring-inset min-h-[44px] min-w-[44px] flex items-center justify-center text-[var(--color-primary-dark)] text-lg disabled:opacity-30 active:scale-90 transition-transform"
                   aria-label="Next recipe"
                 >
                   ›

--- a/nextjs/src/components/recipes/RecipeBookLoader.tsx
+++ b/nextjs/src/components/recipes/RecipeBookLoader.tsx
@@ -9,8 +9,17 @@ export default function RecipeBookLoader() {
   const [loading, setLoading] = useState(true)
   const [refreshKey, setRefreshKey] = useState(0)
 
-  useEffect(() => {
+  // Reset `loading` for a refetch during render rather than in the effect
+  // below (React docs: "Adjusting state when a prop changes"). `loading`
+  // already starts `true` for the initial mount fetch, so this only fires on
+  // a genuine `refreshKey` bump from `onMutate` — no setState-in-effect needed.
+  const [trackedRefreshKey, setTrackedRefreshKey] = useState(refreshKey)
+  if (refreshKey !== trackedRefreshKey) {
+    setTrackedRefreshKey(refreshKey)
     setLoading(true)
+  }
+
+  useEffect(() => {
     fetch('/api/recipes')
       .then((r) => r.json())
       .then((data) => {

--- a/nextjs/src/components/recipes/RecipeDeleteConfirm.tsx
+++ b/nextjs/src/components/recipes/RecipeDeleteConfirm.tsx
@@ -29,9 +29,10 @@ export default function RecipeDeleteConfirm({
         Delete &ldquo;{recipeTitle}&rdquo;?
       </span>
       <button
+        type="button"
         onClick={onConfirm}
         disabled={deleting}
-        className="px-3 py-1 rounded-full text-xs font-bold disabled:opacity-50 active:scale-95 transition-transform"
+        className="focus-ring min-h-[44px] px-3 py-1 rounded-full text-xs font-bold disabled:opacity-50 active:scale-95 transition-transform"
         style={{
           color: 'var(--color-coral, #ff9aa2)',
           border: '1.5px solid var(--color-coral, #ff9aa2)',
@@ -42,9 +43,10 @@ export default function RecipeDeleteConfirm({
         {deleting ? 'Deleting...' : 'Delete'}
       </button>
       <button
+        type="button"
         onClick={onCancel}
         disabled={deleting}
-        className="px-3 py-1 rounded-full text-xs font-bold disabled:opacity-50 active:scale-95 transition-transform"
+        className="focus-ring min-h-[44px] px-3 py-1 rounded-full text-xs font-bold disabled:opacity-50 active:scale-95 transition-transform"
         style={{
           color: 'var(--color-muted)',
           border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeEditModal.tsx
+++ b/nextjs/src/components/recipes/RecipeEditModal.tsx
@@ -102,7 +102,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
             </h2>
             <button
               onClick={onClose}
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
+              className="focus-ring w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
               style={{ background: 'var(--color-bg)', color: 'var(--color-muted)' }}
               aria-label="Close"
             >
@@ -124,7 +124,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)]"
+                className="focus-ring w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -146,7 +146,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none resize-none border focus:border-[var(--color-primary)]"
+                className="focus-ring w-full rounded-xl px-4 py-2.5 text-sm resize-none border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -169,7 +169,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
                 placeholder="comma-separated"
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)]"
+                className="focus-ring w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -194,7 +194,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                       type="text"
                       value={item}
                       onChange={(e) => updateItem(setIngredients, i, e.target.value)}
-                      className="flex-1 rounded-xl px-3 py-2 text-sm outline-none border focus:border-[var(--color-primary)]"
+                      className="focus-ring flex-1 rounded-xl px-3 py-2 text-sm border focus:border-[var(--color-primary)]"
                       style={{
                         background: 'var(--color-bg)',
                         border: '1.5px solid var(--color-border)',
@@ -204,7 +204,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                     />
                     <button
                       onClick={() => removeItem(setIngredients, i)}
-                      className="w-7 h-7 rounded-full flex items-center justify-center text-xs hover:opacity-70 flex-shrink-0"
+                      className="focus-ring w-7 h-7 rounded-full flex items-center justify-center text-xs hover:opacity-70 flex-shrink-0"
                       style={{ background: 'var(--color-bg)', color: 'var(--color-muted)', border: '1.5px solid var(--color-border)' }}
                       aria-label="Remove ingredient"
                     >
@@ -214,7 +214,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 ))}
                 <button
                   onClick={() => addItem(setIngredients)}
-                  className="text-xs font-bold px-3 py-1.5 rounded-full"
+                  className="focus-ring text-xs font-bold px-3 py-1.5 rounded-full"
                   style={{ color: 'var(--color-primary)', background: 'var(--color-bg)', border: '1.5px solid var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
                 >
                   + Add ingredient
@@ -243,7 +243,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                       value={step}
                       onChange={(e) => updateItem(setInstructions, i, e.target.value)}
                       rows={2}
-                      className="flex-1 rounded-xl px-3 py-2 text-sm outline-none resize-none border focus:border-[var(--color-primary)]"
+                      className="focus-ring flex-1 rounded-xl px-3 py-2 text-sm resize-none border focus:border-[var(--color-primary)]"
                       style={{
                         background: 'var(--color-bg)',
                         border: '1.5px solid var(--color-border)',
@@ -253,7 +253,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                     />
                     <button
                       onClick={() => removeItem(setInstructions, i)}
-                      className="w-7 h-7 rounded-full flex items-center justify-center text-xs hover:opacity-70 flex-shrink-0 mt-1"
+                      className="focus-ring w-7 h-7 rounded-full flex items-center justify-center text-xs hover:opacity-70 flex-shrink-0 mt-1"
                       style={{ background: 'var(--color-bg)', color: 'var(--color-muted)', border: '1.5px solid var(--color-border)' }}
                       aria-label="Remove step"
                     >
@@ -263,7 +263,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 ))}
                 <button
                   onClick={() => addItem(setInstructions)}
-                  className="text-xs font-bold px-3 py-1.5 rounded-full"
+                  className="focus-ring text-xs font-bold px-3 py-1.5 rounded-full"
                   style={{ color: 'var(--color-primary)', background: 'var(--color-bg)', border: '1.5px solid var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
                 >
                   + Add step
@@ -280,7 +280,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
             <button
               onClick={handleSave}
               disabled={saving || !title.trim()}
-              className="flex-1 py-2.5 rounded-full text-sm font-bold text-white disabled:opacity-50 active:scale-95 transition-transform"
+              className="focus-ring flex-1 py-2.5 rounded-full text-sm font-bold text-white disabled:opacity-50 active:scale-95 transition-transform"
               style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
             >
               {saving ? 'Saving...' : 'Save'}
@@ -288,7 +288,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
             <button
               onClick={onClose}
               disabled={saving}
-              className="flex-1 py-2.5 rounded-full text-sm font-bold disabled:opacity-50 active:scale-95 transition-transform"
+              className="focus-ring flex-1 py-2.5 rounded-full text-sm font-bold disabled:opacity-50 active:scale-95 transition-transform"
               style={{
                 background: 'var(--color-bg)',
                 border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeEditModal.tsx
+++ b/nextjs/src/components/recipes/RecipeEditModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { type Recipe, type Ingredient } from './RecipePage'
+import { useModalFocusTrap } from '@/hooks/useModalFocusTrap'
 
 const toIngStr = (i: string | Ingredient): string =>
   typeof i === 'string' ? i : [i.quantity, i.unit, i.name].filter(Boolean).join(' ')
@@ -27,6 +28,11 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
     (recipe.instructions ?? []).map(toStepStr)
   )
   const [saving, setSaving] = useState(false)
+  const panelRef = useRef<HTMLDivElement>(null)
+  // This modal only exists in the tree while open — its parent mounts it
+  // conditionally rather than passing an `isOpen` prop — so `true` is fixed:
+  // the trap arms once on mount and tears down (returning focus) on unmount.
+  useModalFocusTrap(true, onClose, panelRef)
 
   const updateItem = (
     setter: React.Dispatch<React.SetStateAction<string[]>>,
@@ -75,7 +81,12 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
         {/* Modal panel */}
         <motion.div
           key="edit-panel"
-          className="fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="recipe-edit-modal-title"
+          tabIndex={-1}
+          className="focus-ring-inset fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
           style={{
             background: 'var(--color-surface)',
             border: '1px solid var(--color-border)',
@@ -95,6 +106,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
             style={{ borderColor: 'var(--color-border)' }}
           >
             <h2
+              id="recipe-edit-modal-title"
               className="text-base font-extrabold"
               style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
             >

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { type Recipe } from './RecipePage'
+import { useModalFocusTrap } from '@/hooks/useModalFocusTrap'
 
 interface RecipeImportModalProps {
   onImported: (recipe: Partial<Recipe>, sourceUrl: string) => void
@@ -22,6 +23,9 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
   const [url, setUrl] = useState('')
   const [state, setState] = useState<ImportState>('idle')
   const [errorMsg, setErrorMsg] = useState('')
+  const panelRef = useRef<HTMLDivElement>(null)
+  // Mounts-to-open, like RecipeEditModal — see comment there.
+  useModalFocusTrap(true, onClose, panelRef)
 
   const isValidUrl = (s: string) => {
     try {
@@ -93,7 +97,12 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
 
         <motion.div
           key="import-panel"
-          className="fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
+          ref={panelRef}
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="recipe-import-modal-title"
+          tabIndex={-1}
+          className="focus-ring-inset fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
           style={{
             background: 'var(--color-surface)',
             border: '1px solid var(--color-border)',
@@ -113,6 +122,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
             style={{ borderColor: 'var(--color-border)' }}
           >
             <h2
+              id="recipe-import-modal-title"
               className="text-base font-extrabold"
               style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
             >

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -120,7 +120,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
             </h2>
             <button
               onClick={onClose}
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
+              className="focus-ring w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
               style={{ background: 'var(--color-bg)', color: 'var(--color-muted)' }}
               aria-label="Close"
             >
@@ -150,7 +150,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
                   target="_blank"
                   rel="noopener noreferrer"
                   title={noImage ? 'Images may not be available for this site' : undefined}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold no-underline hover:opacity-80 active:scale-95 transition-all"
+                  className="focus-ring inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold no-underline hover:opacity-80 active:scale-95 transition-all"
                   style={{
                     background: 'var(--color-bg)',
                     border: '1.5px solid var(--color-border)',
@@ -176,7 +176,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
               placeholder="https://www.allrecipes.com/recipe/..."
               disabled={state === 'loading'}
               autoFocus
-              className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)] disabled:opacity-50"
+              className="focus-ring w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)] disabled:opacity-50"
               style={{
                 background: 'var(--color-bg)',
                 border: `1.5px solid ${state === 'error' ? 'var(--color-coral)' : 'var(--color-border)'}`,
@@ -213,7 +213,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
             <button
               onClick={handleImport}
               disabled={state === 'loading' || !url.trim()}
-              className="flex-1 py-2.5 rounded-full text-sm font-bold text-white disabled:opacity-50 active:scale-95 transition-transform"
+              className="focus-ring flex-1 py-2.5 rounded-full text-sm font-bold text-white disabled:opacity-50 active:scale-95 transition-transform"
               style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
             >
               {state === 'loading' ? 'Importing…' : 'Import'}
@@ -221,7 +221,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
             <button
               onClick={onClose}
               disabled={state === 'loading'}
-              className="flex-1 py-2.5 rounded-full text-sm font-bold disabled:opacity-50 active:scale-95 transition-transform"
+              className="focus-ring flex-1 py-2.5 rounded-full text-sm font-bold disabled:opacity-50 active:scale-95 transition-transform"
               style={{
                 background: 'var(--color-bg)',
                 border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeRefinementModal.tsx
+++ b/nextjs/src/components/recipes/RecipeRefinementModal.tsx
@@ -249,7 +249,7 @@ export default function RecipeRefinementModal({
                   className="text-sm text-center py-4"
                   style={{ color: 'var(--color-muted)', fontFamily: 'Nunito, sans-serif' }}
                 >
-                  Type a refinement below — e.g. "make it vegetarian" or "reduce cook time"
+                  Type a refinement below — e.g. &ldquo;make it vegetarian&rdquo; or &ldquo;reduce cook time&rdquo;
                 </p>
               )}
             </div>

--- a/nextjs/src/components/recipes/RecipeRefinementModal.tsx
+++ b/nextjs/src/components/recipes/RecipeRefinementModal.tsx
@@ -143,7 +143,7 @@ export default function RecipeRefinementModal({
               </h2>
               <button
                 onClick={onClose}
-                className="w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
+                className="focus-ring w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
                 style={{ background: 'var(--color-surface)', color: 'var(--color-muted)' }}
                 aria-label="Close"
               >
@@ -293,7 +293,7 @@ export default function RecipeRefinementModal({
                   onKeyDown={handleKeyDown}
                   placeholder="e.g. make it vegan, less spicy..."
                   disabled={refining}
-                  className="flex-1 rounded-full px-4 py-2.5 text-sm outline-none disabled:opacity-50"
+                  className="focus-ring flex-1 rounded-full px-4 py-2.5 text-sm disabled:opacity-50"
                   style={{
                     background: 'var(--color-bg)',
                     border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeSearchBar.tsx
+++ b/nextjs/src/components/recipes/RecipeSearchBar.tsx
@@ -29,7 +29,7 @@ export default function RecipeSearchBar({ onSearch }: RecipeSearchBarProps) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="Search your recipes..."
-        className="w-full py-2.5 pl-4 pr-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-colors text-sm font-[Nunito,sans-serif]"
+        className="focus-ring w-full py-2.5 pl-4 pr-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-muted)] focus:border-[var(--color-accent)] transition-colors text-sm font-[Nunito,sans-serif]"
       />
 
       <AnimatePresence mode="wait">
@@ -41,7 +41,7 @@ export default function RecipeSearchBar({ onSearch }: RecipeSearchBarProps) {
             exit={{ opacity: 0, scale: 0.7 }}
             transition={{ duration: 0.15 }}
             onClick={() => setValue('')}
-            className="absolute right-3 text-[var(--color-muted)] hover:text-[var(--color-text)] text-lg leading-none"
+            className="focus-ring absolute right-3 text-[var(--color-muted)] hover:text-[var(--color-text)] text-lg leading-none rounded-full"
             aria-label="Clear search"
           >
             ×

--- a/nextjs/src/components/scan/ScannedItemCard.tsx
+++ b/nextjs/src/components/scan/ScannedItemCard.tsx
@@ -60,7 +60,7 @@ export default function ScannedItemCard({
         type="button"
         aria-label={`Dismiss ${item.name}`}
         onClick={onDismiss}
-        className="absolute top-3 right-3 w-6 h-6 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors text-sm font-bold"
+        className="focus-ring absolute top-3 right-3 w-6 h-6 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors text-sm font-bold"
       >
         ×
       </button>
@@ -80,7 +80,7 @@ export default function ScannedItemCard({
           aria-label="Item name"
           value={item.name}
           onChange={(e) => update('name', e.target.value)}
-          className="flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] outline-none pb-1 transition-colors"
+          className="focus-ring flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] pb-1 transition-colors"
           placeholder="Item name"
         />
       </div>
@@ -96,7 +96,7 @@ export default function ScannedItemCard({
             min={0}
             step={0.1}
             onChange={(e) => update('quantity', parseFloat(e.target.value) || 0)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="focus-ring w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           />
         </div>
         <div className="flex-1">
@@ -106,7 +106,7 @@ export default function ScannedItemCard({
             aria-label="Unit"
             value={item.unit}
             onChange={(e) => update('unit', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="focus-ring w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
             placeholder="pcs, g, ml…"
           />
         </div>
@@ -120,7 +120,7 @@ export default function ScannedItemCard({
             aria-label="Category"
             value={item.category}
             onChange={(e) => update('category', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="focus-ring w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           >
             {CATEGORIES.map((c) => (
               <option key={c} value={c}>
@@ -135,7 +135,7 @@ export default function ScannedItemCard({
             aria-label="Location"
             value={item.location}
             onChange={(e) => update('location', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="focus-ring w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           >
             {LOCATIONS.map((l) => (
               <option key={l} value={l}>

--- a/nextjs/src/components/ui/Chip.tsx
+++ b/nextjs/src/components/ui/Chip.tsx
@@ -56,7 +56,7 @@ export default function Chip({
   ariaLabel,
   className,
 }: ChipProps) {
-  const baseClass = `inline-flex items-center gap-1 ${SIZE_CLASS[size]} rounded-full font-semibold whitespace-nowrap transition-colors border border-[var(--color-border)]`
+  const baseClass = `focus-ring inline-flex items-center gap-1 ${SIZE_CLASS[size]} rounded-full font-semibold whitespace-nowrap transition-colors border border-[var(--color-border)]`
   const merged = className ? `${baseClass} ${className}` : baseClass
 
   const style = {

--- a/nextjs/src/components/ui/SpringButton.tsx
+++ b/nextjs/src/components/ui/SpringButton.tsx
@@ -28,10 +28,13 @@ export default function SpringButton({
       whileHover={{ scale: disabled ? 1 : 1.03 }}
       whileTap={{ scale: disabled ? 1 : 0.95 }}
       transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-      className={
+      // `focus-ring` is prepended unconditionally (not folded into the default
+      // string below) so every caller gets it — including ones that pass a
+      // fully custom `className`, which replaces the default entirely.
+      className={`focus-ring ${
         className ??
         'bg-[var(--color-primary)] text-white font-semibold py-3 px-6 rounded-full disabled:opacity-50 disabled:cursor-not-allowed'
-      }
+      }`}
     >
       {children}
     </motion.button>

--- a/nextjs/src/components/ui/ThemePicker.tsx
+++ b/nextjs/src/components/ui/ThemePicker.tsx
@@ -70,7 +70,7 @@ export default function ThemePicker() {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform"
+        className="focus-ring w-11 h-11 rounded-full flex items-center justify-center active:scale-95 transition-transform"
         style={{ background: 'var(--color-bg)', border: '1px solid var(--color-border)' }}
         aria-label={`Change theme, current theme ${active.name}`}
         aria-haspopup="true"
@@ -123,8 +123,9 @@ export default function ThemePicker() {
                     if (!isActive) setTheme(key)
                     setOpen(false)
                   }}
-                  // py-3 + 20px swatch puts each row at 44px tall.
-                  className="w-full px-4 py-3 flex items-center gap-3 text-left text-sm font-semibold hover:bg-[var(--color-bg)] transition-colors"
+                  // py-3 + 20px swatch puts each row at 44px tall. Inset ring:
+                  // the popover panel above is `overflow-hidden`.
+                  className="focus-ring-inset w-full px-4 py-3 flex items-center gap-3 text-left text-sm font-semibold hover:bg-[var(--color-bg)] transition-colors"
                   style={{ color: 'var(--color-text)', fontFamily: 'Nunito, sans-serif' }}
                 >
                   <span

--- a/nextjs/src/hooks/useModalFocusTrap.ts
+++ b/nextjs/src/hooks/useModalFocusTrap.ts
@@ -1,0 +1,116 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+/**
+ * Modal keyboard/focus behaviour — issue #10.
+ *
+ * Every bottom-sheet/dialog in the app (`AddItemModal`, `PantryAddSheet`,
+ * `RecipeEditModal`, `RecipeImportModal`, `CookModal`) rolled its own
+ * backdrop + `motion.div` but none of them moved focus in on open, trapped
+ * Tab inside the panel, closed on Escape, or gave focus back to whatever
+ * opened them. Rather than duplicate that logic five times, it lives here
+ * once; callers still own their own `role="dialog"` / `aria-modal` /
+ * `aria-labelledby` markup since that's tied to their own heading ids.
+ *
+ * Two call shapes, matching the two ways modals exist in this codebase:
+ *  - Stays-mounted sheets (`AddItemModal`, `PantryAddSheet`) pass their own
+ *    `isOpen` prop through — the effect re-arms every time it flips to true.
+ *  - Mounts-to-open modals (`RecipeEditModal`, `RecipeImportModal`,
+ *    `CookModal`) have no `isOpen` prop; their presence in the tree *is* the
+ *    signal, so callers pass a fixed `true` and the effect runs once on
+ *    mount, cleaning up (returning focus) on unmount.
+ */
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+function getFocusable(panel: HTMLElement): HTMLElement[] {
+  // Deliberately not filtering by `offsetParent`/layout visibility: every
+  // modal in this codebase hides sections by not rendering them (conditional
+  // JSX per state), not by CSS-hiding a focusable element that's still in the
+  // DOM, so there's nothing here that would actually need it — and
+  // `offsetParent` is always null under jsdom (no layout engine), which would
+  // silently empty this list in tests.
+  return Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+}
+
+export function useModalFocusTrap(
+  isOpen: boolean,
+  onClose: () => void,
+  panelRef: React.RefObject<HTMLElement | null>,
+) {
+  // Latest `onClose` in a ref, not the effect's dependency array — these
+  // callbacks are re-created every parent render (they're rarely wrapped in
+  // useCallback), and re-running setup/teardown on every keystroke inside the
+  // modal would steal focus back out of whatever field the user is typing in.
+  // Synced in its own effect (not written during render) per the
+  // react-hooks/refs rule — refs are only safe to read/write outside render.
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  })
+
+  const triggerRef = useRef<HTMLElement | null>(null)
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    // Whatever had focus when the modal opened — almost always the button
+    // that triggered it — gets it back on close.
+    triggerRef.current = document.activeElement as HTMLElement | null
+
+    const panel = panelRef.current
+    if (panel) {
+      // Respect a field's own `autoFocus` (e.g. RecipeImportModal's URL
+      // input) instead of always jumping to the first focusable element.
+      const alreadyFocusedInside =
+        document.activeElement !== document.body && panel.contains(document.activeElement)
+      if (!alreadyFocusedInside) {
+        const focusable = getFocusable(panel)
+        ;(focusable[0] ?? panel).focus()
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCloseRef.current()
+        return
+      }
+
+      if (e.key !== 'Tab' || !panel) return
+
+      // Recomputed on every Tab press, not cached at mount — several of
+      // these modals swap their own content mid-flight (confirm-delete
+      // swaps, loading -> review -> success), which changes what's focusable.
+      const focusables = getFocusable(panel)
+      if (focusables.length === 0) {
+        e.preventDefault()
+        return
+      }
+
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement
+
+      if (e.shiftKey) {
+        if (active === first || !panel.contains(active)) {
+          e.preventDefault()
+          last.focus()
+        }
+      } else if (active === last || !panel.contains(active)) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      // Guard against the trigger having been removed from the DOM while the
+      // modal was open (e.g. the pantry card that opened it got deleted).
+      triggerRef.current?.focus?.()
+    }
+  }, [isOpen, panelRef])
+}

--- a/nextjs/src/lib/api/pantry.ts
+++ b/nextjs/src/lib/api/pantry.ts
@@ -1,0 +1,34 @@
+/**
+ * Pantry client — calls the Next.js CRUD routes (not the AI service).
+ */
+
+export type ResolveOutcome = 'used' | 'tossed'
+
+export interface ResolveResponse {
+  resolved: true
+  id: string
+  outcome: ResolveOutcome
+  event_id: string
+}
+
+/**
+ * Resolve an expiring pantry item: record what happened to it (used it up /
+ * tossed it) and remove it from the pantry. Issue #140.
+ */
+export async function resolvePantryItem(
+  itemId: string,
+  outcome: ResolveOutcome,
+): Promise<ResolveResponse> {
+  const res = await fetch(`/api/pantry/${itemId}/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ outcome }),
+  })
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Resolve failed' }))
+    throw new Error(err.error ?? `Resolve failed: ${res.status}`)
+  }
+
+  return res.json()
+}

--- a/nextjs/src/lib/expiry-badge.ts
+++ b/nextjs/src/lib/expiry-badge.ts
@@ -1,0 +1,21 @@
+/**
+ * Days-left tier badge — shared by the pantry grid (`app/pantry/page.tsx`) and
+ * the Use Soon triage view (`app/pantry/use-soon/page.tsx`), issue #139.
+ *
+ * Kept as a single source of truth so the two views can't drift on where the
+ * expired/expiring/fresh boundaries sit (they used to live as a copy-pasted
+ * local function in the pantry page alone).
+ */
+export interface ExpiryBadge {
+  label: string
+  /** Tailwind utility classes resolving entirely through `--color-*` tokens. */
+  className: string
+}
+
+export function expiryBadge(days: number | null): ExpiryBadge | null {
+  if (days === null) return null
+  if (days <= 0) return { label: 'Expired', className: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
+  if (days <= 2) return { label: `${days}d left`, className: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]' }
+  if (days <= 5) return { label: `${days}d left`, className: 'bg-[var(--color-expiring)] text-[var(--color-expiring-text)]' }
+  return { label: `${days}d left`, className: 'bg-[var(--color-fresh)] text-[var(--color-fresh-text)]' }
+}

--- a/nextjs/src/lib/pantry-helpers.ts
+++ b/nextjs/src/lib/pantry-helpers.ts
@@ -25,20 +25,26 @@ export interface EnrichedPantryItem extends PantryItemRow {
   is_expiring_soon: boolean
 }
 
-export function enrichPantryItem(row: PantryItemRow): EnrichedPantryItem {
-  let days_until_expiry: number | null = null
-  let is_expired = false
-  let is_expiring_soon = false
+/**
+ * Days between today and an expiry date (negative when already past).
+ * Null when there is no expiry date. Shared by `enrichPantryItem` and the
+ * resolve route, which records this at the moment an item is used/tossed.
+ */
+export function daysUntilExpiry(expiryDate: string | null): number | null {
+  if (!expiryDate) return null
 
-  if (row.expiry_date) {
-    const expiry = new Date(row.expiry_date)
-    const today = new Date()
-    today.setHours(0, 0, 0, 0)
-    const diffMs = expiry.getTime() - today.getTime()
-    days_until_expiry = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
-    is_expired = days_until_expiry < 0
-    is_expiring_soon = days_until_expiry >= 0 && days_until_expiry <= 3
-  }
+  const expiry = new Date(expiryDate)
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffMs = expiry.getTime() - today.getTime()
+  return Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+}
+
+export function enrichPantryItem(row: PantryItemRow): EnrichedPantryItem {
+  const days_until_expiry = daysUntilExpiry(row.expiry_date)
+  const is_expired = days_until_expiry !== null && days_until_expiry < 0
+  const is_expiring_soon =
+    days_until_expiry !== null && days_until_expiry >= 0 && days_until_expiry <= 3
 
   return {
     ...row,

--- a/supabase/migrations/00007_add_pantry_events.sql
+++ b/supabase/migrations/00007_add_pantry_events.sql
@@ -1,0 +1,47 @@
+-- Migration: Add pantry_events table
+-- Records what actually happened when an expiring pantry item was resolved
+-- (used, tossed, or cooked) so the app can eventually report "you saved N
+-- items this week" instead of just watching items expire silently.
+--
+-- pantry_item_id is nullable on purpose: resolving an item deletes its row
+-- from pantry_items, so by the time anyone reads this table the FK target
+-- may already be gone. item_name is denormalised alongside it so the event
+-- stays meaningful on its own after the pantry_items row disappears. For
+-- that same reason this column intentionally has no foreign key constraint.
+--
+-- Append-only: no updated_at column, and no UPDATE/DELETE policy below
+-- (see RLS section) -- rows are written once and never changed.
+
+CREATE TABLE pantry_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  pantry_item_id UUID,
+  item_name TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN ('used', 'tossed', 'cooked')),
+  quantity NUMERIC,
+  unit TEXT,
+  days_until_expiry INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Serves "this user's events, most recent first"; a future weekly-stats
+-- screen will filter this same table on created_at.
+CREATE INDEX idx_pantry_events_user_created ON pantry_events(user_id, created_at DESC);
+
+-- ============================================================================
+-- RLS
+-- ============================================================================
+ALTER TABLE pantry_events ENABLE ROW LEVEL SECURITY;
+
+-- Users may only insert events for themselves.
+CREATE POLICY "Users insert own pantry events"
+  ON pantry_events FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+-- Users may only read their own events.
+CREATE POLICY "Users view own pantry events"
+  ON pantry_events FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- No UPDATE or DELETE policy: intentional. pantry_events is append-only,
+-- so rows are never modified or removed once written.


### PR DESCRIPTION
## Summary

Three strands, all landing on `main`:

1. **The expiry loop closes.** #138 gave expiring items a way *out* (one tap into a seeded recipe); this adds the way to *close* — saying what actually happened to an item — and a single place to triage everything.
2. **The app becomes keyboard-operable.** Focus visibility (#147) plus focus management, landmarks and real labels (#10).
3. **The verification gates become trustworthy** (#149) — eslint had 8 errors and wasn't in CI at all.

Synced with `main` (includes #153's modal z-index fix; no conflict — that touched overlay wrappers, this touches the controls inside them).

## What lands

**#140 / #139 — resolve actions + Use Soon.** Append-only `pantry_events` table (migration `00007`), `POST /api/pantry/[id]/resolve`, "Used it up" / "Tossed it" on urgent cards, and `/pantry/use-soon` — an urgency-sorted triage list where each row carries both "Find a recipe" and resolve.

**#147 / #10 — accessibility.** `.focus-ring` / `.focus-ring-inset` utilities applied app-wide, then: a shared `useModalFocusTrap` wired into all five modals, `aria-current` and a named landmark on the bottom nav, edit buttons that say *which* item, a live region for page-turn, and the removal of a nested `<main>` that gave three routes two landmarks each.

**#149 — gates.** eslint backlog cleared and eslint added to the `nextjs` CI job.

### Decisions worth a reviewer's attention

- **Every modal had zero focus management.** No `role="dialog"`, no trap, no Escape, no focus restored. A keyboard user could tab straight through a panel into the page behind an opaque backdrop — the add-item and cook-it flows were effectively unusable by keyboard. One shared hook, not five implementations; it recomputes the focusable set per Tab because several panels swap content mid-flight.
- **Only "Tossed it" takes a second tap.** Both outcomes delete the item, but "Used it up" is what the product nudges toward and a false positive costs nothing, while "Tossed it" is the more plausible mis-tap *and* the one a user regrets logging, since it silently inflates their waste record. Friction on the accident.
- **The focus ring aliases `--color-text`, not the accent tokens.** `--color-primary-dark` measures **1.70–3.18:1** against `--color-surface` — under WCAG 1.4.11's 3:1 floor on four of five themes. `--color-text` measures 7.36–9.72:1 on all five. Independently recomputed during review.
- **The four `set-state-in-effect` errors were triaged individually, not blanket-fixed.** `ThemeProvider`'s is deliberate — `localStorage` is unreadable during SSR, so the neutral-render-then-correct convention needs the effect, and "fixing" it reintroduces the theme flash. It carries a documented suppression; the other three were real and fixed properly (one via `useSyncExternalStore`, two via render-time state adjustment).
- **`pantry_events` is append-only** — INSERT + SELECT only, deliberately no UPDATE/DELETE. First such table here. The event is written *before* the item is deleted so a crash can't lose the record; if the delete then fails the route returns 500 rather than `resolved: true`, surfaced in a `role="alert"` with the control reset.

### Correction to a carried-forward note
Previous handoffs recorded "5 pre-existing `tsc` errors in `e2e/*` — filter them out." **They don't exist.** Reproduced, then fixed by a clean `npm ci`: `@playwright/test` is correctly declared and resolves; the errors came from a stale local `node_modules` predating #59. CI runs `npm ci` first, so `tsc` was always a real gate. No repo change was needed and none was made — worth striking from the next handoff.

## Tests

```
pytest   131 passed, 10 skipped
ruff     All checks passed
tsc      exit 0, no filtering
eslint   0 errors (2 pre-existing warnings)
jest     110 passed        (main: 78)
```

`qa-reviewer` pass run against #139/#140/#147. Findings and resolution:

| Finding | Resolution |
|---|---|
| Focus stranded on `<body>` when the toss-confirm swaps in | **fixed** — moves to Cancel, returns to Toss, regression test added |
| Alert dismiss button missed the 44px target | **fixed** |
| eslint reports 8 errors, not the 2 briefed | **fixed here** — cleared and gated in CI |
| No test pinning the null-expiry comparator | won't fix — unreachable, the API filters null-expiry rows |

⚠️ `/code-review` and `/interrogate` remain uninstalled in this environment; `qa-reviewer` is the only review layer that ran. The #10 work landed after that pass and has **not** been through review.

## Demo

**Not captured here.** No `.env.local` in this environment — authed routes 307 to `/login` and the migration can't be applied to a real database. PR #154's recordings cover adjacent flows but predate this work.

Unverified: the migration against real Postgres (RLS confirmed only at the "no code attempts UPDATE/DELETE" level, not engine-enforced); the resolve round-trip; rendering across five themes; and — importantly for #10 — **no real screen-reader pass**. jsdom asserts focus transitions and accessible names; it cannot tell you what NVDA announces.

## Linked issues

Closes #139
Closes #140
Closes #147
Closes #10
Closes #149

## Out of scope

- **Migration `00007` must be applied** to production Supabase when this merges. Nothing in the resolve flow works without it.
- No optimistic row removal — resolve invalidates and refetches.
- `'cooked'` is permitted by the CHECK but nothing writes it; the cook-confirm flow can adopt it without a second migration.
- Left in `#10`: full `role="menu"` semantics on the recipe overflow menu, the 28×40px hamburger tab, and the repeated generic `<h1>Bubbles</h1>` from `BubblesHeader` on every route — that last one is a heading-structure smell but changing it site-wide touches a branding decision.
- The waste-stats payoff UI the event log exists to enable.

---

- [ ] `/code-review` run — skill not available here
- [ ] `/interrogate` run (feature-level PRs only) — skill not available here
- [ ] CI green
- [ ] Demo captured (blocked on env)
