### PR TITLE
fix: modal overlays covered by bottom nav on mobile (z-index collision)

### DIFF
--- a/nextjs/src/components/pantry/AddItemModal.tsx
+++ b/nextjs/src/components/pantry/AddItemModal.tsx
@@ -172,7 +172,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
         <>
           {/* Backdrop */}
           <motion.div
-            className="fixed inset-0 bg-black/40 z-50"
+            className="fixed inset-0 bg-black/40 z-[60]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -181,7 +181,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
 
           {/* Modal */}
           <motion.div
-            className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-3xl max-h-[85vh] overflow-y-auto"
+            className="fixed bottom-0 left-0 right-0 z-[60] bg-white rounded-t-3xl max-h-[85vh] overflow-y-auto"
             initial={{ y: '100%' }}
             animate={{ y: 0 }}
             exit={{ y: '100%' }}

--- a/nextjs/src/components/pantry/PantryAddSheet.tsx
+++ b/nextjs/src/components/pantry/PantryAddSheet.tsx
@@ -89,7 +89,7 @@ export default function PantryAddSheet({
         <>
           {/* Backdrop */}
           <motion.div
-            className="fixed inset-0 bg-black/40 z-50"
+            className="fixed inset-0 bg-black/40 z-[60]"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
@@ -98,7 +98,7 @@ export default function PantryAddSheet({
 
           {/* Sheet — slides up from bottom, sits above the bottom nav */}
           <motion.div
-            className="fixed bottom-16 left-0 right-0 z-50 rounded-t-3xl flex flex-col select-none"
+            className="fixed bottom-16 left-0 right-0 z-[60] rounded-t-3xl flex flex-col select-none"
             style={{
               background: 'var(--color-surface)',
               maxHeight: 'calc(92vh - 64px)',

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -152,7 +152,7 @@ export default function CookModal({
     <AnimatePresence>
       {/* Backdrop */}
       <motion.div
-        className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+        className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center"
         style={{ background: 'rgba(0,0,0,0.4)' }}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}

--- a/nextjs/src/components/recipes/RecipeEditModal.tsx
+++ b/nextjs/src/components/recipes/RecipeEditModal.tsx
@@ -63,7 +63,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
         {/* Backdrop */}
         <motion.div
           key="edit-backdrop"
-          className="fixed inset-0 z-50"
+          className="fixed inset-0 z-[60]"
           style={{ background: 'rgba(0,0,0,0.4)' }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -75,7 +75,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
         {/* Modal panel */}
         <motion.div
           key="edit-panel"
-          className="fixed inset-x-4 top-1/2 z-50 rounded-2xl overflow-hidden"
+          className="fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
           style={{
             background: 'var(--color-surface)',
             border: '1px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -82,7 +82,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
       <>
         <motion.div
           key="import-backdrop"
-          className="fixed inset-0 z-50"
+          className="fixed inset-0 z-[60]"
           style={{ background: 'rgba(0,0,0,0.4)' }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -93,7 +93,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
 
         <motion.div
           key="import-panel"
-          className="fixed inset-x-4 top-1/2 z-50 rounded-2xl overflow-hidden"
+          className="fixed inset-x-4 top-1/2 z-[60] rounded-2xl overflow-hidden"
           style={{
             background: 'var(--color-surface)',
             border: '1px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeRefinementModal.tsx
+++ b/nextjs/src/components/recipes/RecipeRefinementModal.tsx
@@ -99,7 +99,7 @@ export default function RecipeRefinementModal({
           {/* Backdrop */}
           <motion.div
             key="backdrop"
-            className="fixed inset-0 z-40"
+            className="fixed inset-0 z-[60]"
             style={{ background: 'rgba(92,74,90,0.35)', backdropFilter: 'blur(2px)' }}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -111,7 +111,7 @@ export default function RecipeRefinementModal({
           {/* Modal — slide up from bottom */}
           <motion.div
             key="modal"
-            className="fixed inset-x-0 bottom-0 z-50 flex flex-col rounded-t-3xl overflow-hidden"
+            className="fixed inset-x-0 bottom-0 z-[60] flex flex-col rounded-t-3xl overflow-hidden"
             style={{
               background: 'var(--color-bg)',
               maxHeight: '92dvh',


### PR DESCRIPTION
## Summary

On mobile, the CookModal's Confirm/Cancel buttons rendered **underneath** the fixed bottom nav — tapping Confirm hit the Chat nav tab instead, so a cook could never be confirmed. Root cause: the modal overlay and `BottomNav` both used `z-50`; with equal z-index, DOM order wins, and `<BottomNav />` renders after `{children}` in `layout.tsx`. Found while recording a demo of the cook→chat flow (a screenshot wouldn't have caught it).

## What lands

Raises every modal overlay + panel from `z-50`/`z-40` to `z-[60]`, above the `z-50` nav. Same latent bug existed in 5 other modals — all fixed in one pass:
- `CookModal` (the reported one)
- `AddItemModal`, `PantryAddSheet` (bottom sheets)
- `RecipeEditModal`, `RecipeImportModal`
- `RecipeRefinementModal` (overlay was `z-40`, *below* the nav — worse)

Establishes the convention: nav = 50, modals/overlays = 60.

## Tests

- `npx tsc --noEmit` — clean on all 6 changed files (the only tsc errors are pre-existing `e2e/*` / `playwright.config.ts` missing-types, present on main before this change).
- Verified live at 430×932: before, `document.elementFromPoint()` at the Confirm button center returned the `<a>Chat</a>` nav tab; after, it returns the `Confirm` button. Playwright can now click it.

## Linked

Closes #152

## Out of scope

Introducing a formal z-index scale/token set (chrome/nav/modal/toast) — worth doing but larger; this PR just lifts modals above the nav consistently.