### PR TITLE
fix: resolve cook→chat recipe context server-side from id (#155)

### DIFF
--- a/ai-service/bubbly_chef/models/requests.py
+++ b/ai-service/bubbly_chef/models/requests.py
@@ -95,9 +95,11 @@ class ChatRequest(BaseModel):
     context: dict[str, Any] | None = Field(
         default=None,
         description=(
-            "Additional context forwarded to the workflow. Recognised key: "
-            '"cooking_recipe" ({id, title, ingredients}) — pins the conversation '
-            "to the recipe the user just started cooking."
+            "Additional context forwarded to the workflow. Recognised keys: "
+            '"cooking_recipe_id" (<str>) — the recipe the user just started '
+            "cooking; the recipe is resolved server-side from this id and the "
+            "conversation is pinned to it. Legacy: \"cooking_recipe\" "
+            "({id, title, ingredients}) — still accepted, same effect."
         ),
     )
 

--- a/ai-service/bubbly_chef/workflows/chat/nodes.py
+++ b/ai-service/bubbly_chef/workflows/chat/nodes.py
@@ -97,6 +97,9 @@ def detect_mode_suggestion(text: str, current_mode: str) -> str | None:
 # ─── Cook handoff: recipe the user is actively cooking ───────────────────────
 
 COOKING_RECIPE_KEY = "cooking_recipe"
+# Preferred cook-handoff payload: just the recipe id, resolved server-side from
+# the DB. Avoids the client fetch/send race that could pin an empty context.
+COOKING_RECIPE_ID_KEY = "cooking_recipe_id"
 
 # Ingredient lines kept out of the prompt beyond this — long imported recipes
 # would otherwise crowd out the pantry and history context.
@@ -121,15 +124,30 @@ def get_cooking_recipe(state: WorkflowState) -> dict[str, Any] | None:
     return recipe if isinstance(recipe, dict) else None
 
 
+def _flatten_ingredient(raw: Any) -> str:
+    """Render one ingredient as a display string.
+
+    Client payloads send ingredients already flattened to strings, but a
+    server-resolved DB recipe stores them as objects
+    ({name, quantity, unit, ...}). Mirror the frontend's `ingredientLines`
+    ("<quantity> <unit> <name>", skipping empty parts) so both shapes yield the
+    same prompt text.
+    """
+    if isinstance(raw, dict):
+        parts = [raw.get("quantity"), raw.get("unit"), raw.get("name")]
+        return " ".join(str(part).strip() for part in parts if str(part or "").strip())
+    return str(raw).strip()
+
+
 def normalize_cooking_recipe(raw: dict[str, Any]) -> dict[str, Any]:
     """Trim a client-supplied cooking recipe down to what prompts/sessions need."""
     raw_ingredients = raw.get("ingredients")
     ingredients: list[str] = []
     if isinstance(raw_ingredients, list):
         ingredients = [
-            str(item).strip()
+            line
             for item in raw_ingredients[: MAX_PROMPT_INGREDIENTS * 2]
-            if str(item).strip()
+            if (line := _flatten_ingredient(item))
         ]
     recipe_id = raw.get("id")
     return {

--- a/ai-service/bubbly_chef/workflows/router.py
+++ b/ai-service/bubbly_chef/workflows/router.py
@@ -37,8 +37,9 @@ from bubbly_chef.models.pantry import (
 from bubbly_chef.models.proposals import HandoffKind
 from bubbly_chef.models.recipe import RecipeCardProposal
 from bubbly_chef.models.session import SessionMode
-from bubbly_chef.repository.supabase_repo import get_repository
+from bubbly_chef.repository.supabase_repo import SupabaseRepository, get_repository
 from bubbly_chef.workflows.chat.nodes import (
+    COOKING_RECIPE_ID_KEY,
     COOKING_RECIPE_KEY,
     GENERAL_CHAT_SYSTEM_PROMPT,
     GENERAL_CHAT_USER_PROMPT,
@@ -529,6 +530,48 @@ def build_handoff_recipe(state: WorkflowState) -> WorkflowState:
     }
 
 
+async def _resolve_cook_context(
+    context: dict[str, Any],
+    user_id: str,
+    repo: SupabaseRepository,
+) -> dict[str, Any] | None:
+    """Return the raw cooking-recipe dict to pin, resolving by id when needed.
+
+    Three accepted shapes, in priority order:
+    1. `cooking_recipe_id`: <str> — the preferred payload. Resolved server-side
+       via the repository so pinning never depends on a client-side fetch (#155).
+    2. `cooking_recipe`: {id, title, ingredients, ...} — legacy full dict; used
+       as-is (non-breaking).
+    3. `cooking_recipe`: {id} — a thin dict carrying only an id; also resolved
+       server-side.
+
+    Returns None when there is no cook context, or when the id resolves to no
+    recipe (deleted / wrong user) — the caller then leaves the session un-pinned
+    rather than crashing the turn.
+    """
+    recipe_id = context.get(COOKING_RECIPE_ID_KEY)
+
+    raw = context.get(COOKING_RECIPE_KEY)
+    if recipe_id is None and isinstance(raw, dict):
+        # Legacy full dict already carries what we need.
+        if str(raw.get("title") or "").strip() or raw.get("ingredients"):
+            return raw
+        # Thin dict with only an id → resolve like the id-only payload.
+        recipe_id = raw.get("id")
+
+    if recipe_id is None:
+        return None
+
+    resolved = await repo.get_recipe(user_id, str(recipe_id))
+    if not resolved:
+        logger.warning(
+            f"Cook handoff: recipe {recipe_id!r} not found for user "
+            f"{user_id!r}; leaving session un-pinned"
+        )
+        return None
+    return dict(resolved)
+
+
 async def update_session_node(state: WorkflowState) -> WorkflowState:
     """
     Node: Update session mode based on workflow outcome.
@@ -556,14 +599,21 @@ async def update_session_node(state: WorkflowState) -> WorkflowState:
         # Cook handoff: the client pins the recipe the user just started cooking.
         # Only the request context triggers this (not the pinned copy in session
         # metadata), so a later brainstorm can still move the session on.
+        #
+        # Preferred payload is just the recipe id, which we resolve from the DB
+        # here — this removes the client fetch/send race that could otherwise pin
+        # an empty context (#155). The legacy full `cooking_recipe` dict is still
+        # accepted for non-breaking rollout; a dict carrying only an `id` is also
+        # routed through the server-side resolve.
         context = state.get("context") or {}
-        raw_cooking_recipe = context.get(COOKING_RECIPE_KEY)
+        user_id = state.get("user_id") or ""
+        raw_cooking_recipe = await _resolve_cook_context(context, user_id, repo)
         if isinstance(raw_cooking_recipe, dict):
             cooking_recipe = normalize_cooking_recipe(raw_cooking_recipe)
             session.active_mode = SessionMode.COOKING
             session.pinned_recipe_id = cooking_recipe["id"]
             session.metadata[COOKING_RECIPE_KEY] = cooking_recipe
-            await repo.update_session(state.get("user_id") or "", session)
+            await repo.update_session(user_id, session)
             logger.info(
                 f"Session pinned to cooking recipe: {old_mode} → cooking "
                 f"(recipe_id={cooking_recipe['id']})"

--- a/ai-service/tests/test_chat_router.py
+++ b/ai-service/tests/test_chat_router.py
@@ -10,7 +10,11 @@ import pytest
 
 from bubbly_chef.models.base import Intent
 from bubbly_chef.models.session import ConversationSession, SessionMode
-from bubbly_chef.workflows.chat.nodes import format_cooking_recipe_context
+from bubbly_chef.workflows.chat.nodes import (
+    _flatten_ingredient,
+    format_cooking_recipe_context,
+    normalize_cooking_recipe,
+)
 from bubbly_chef.workflows.router import classify_intent, update_session_node
 from bubbly_chef.workflows.state import LLMIntentResult
 
@@ -217,13 +221,32 @@ def _cooking_context(recipe_id: str = "recipe-42") -> dict:
 
 
 def _session_repo(mode: SessionMode = SessionMode.DEFAULT) -> MagicMock:
-    """Mock repository whose session starts in `mode`."""
+    """Mock repository whose session starts in `mode`.
+
+    `get_recipe` returns a fake DB row (object-shaped ingredients, as stored in
+    the `recipes` JSONB column) so the id-only cook-handoff path can resolve
+    server-side. Legacy full-dict tests never call it.
+    """
     repo = MagicMock()
     repo.get_or_create_session = AsyncMock(
         return_value=ConversationSession(conversation_id="conv-1", active_mode=mode)
     )
     repo.update_session = AsyncMock(return_value=None)
+    repo.get_recipe = AsyncMock(return_value=_fake_recipe_row())
     return repo
+
+
+def _fake_recipe_row(recipe_id: str = "recipe-42") -> dict:
+    """A raw `recipes` row as `get_recipe` returns it (ingredients are objects)."""
+    return {
+        "id": recipe_id,
+        "title": "Lemon Garlic Pasta",
+        "ingredients": [
+            {"name": "spaghetti", "quantity": 200, "unit": "g"},
+            {"name": "lemon", "quantity": 1, "unit": None},
+            {"name": "garlic", "quantity": 3, "unit": "cloves"},
+        ],
+    }
 
 
 def _patch_repo(repo: MagicMock):
@@ -327,6 +350,142 @@ async def test_no_context_leaves_session_mode_alone():
     saved = repo.update_session.await_args.args[1]
     assert saved.active_mode == SessionMode.DEFAULT
     assert saved.pinned_recipe_id is None
+
+
+# ---------------------------------------------------------------------------
+# Cook handoff — server-side recipe resolution from id (issue #155)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cooking_recipe_id_resolves_server_side_and_pins():
+    """The id-only payload resolves the recipe via the repo and pins it.
+
+    No title/ingredients are sent by the client — proving the pin no longer
+    depends on a client-side fetch winning a race (#155).
+    """
+    repo = _session_repo()
+    state = _state(
+        input_text="what temperature for the pasta water?",
+        conversation_id="conv-1",
+        user_id="user-1",
+        intent=Intent.COOKING_HELP.value,
+        context={"cooking_recipe_id": "recipe-42"},
+    )
+
+    with _patch_repo(repo):
+        await update_session_node(state)
+
+    repo.get_recipe.assert_awaited_once_with("user-1", "recipe-42")
+    saved = repo.update_session.await_args.args[1]
+    assert saved.active_mode == SessionMode.COOKING
+    assert saved.pinned_recipe_id == "recipe-42"
+    assert saved.metadata["cooking_recipe"]["title"] == "Lemon Garlic Pasta"
+    # DB rows store ingredient objects; they must arrive flattened to strings.
+    assert saved.metadata["cooking_recipe"]["ingredients"] == [
+        "200 g spaghetti",
+        "1 lemon",
+        "3 cloves garlic",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_thin_cooking_recipe_dict_resolves_server_side():
+    """A `cooking_recipe` dict carrying only an id is resolved like the id-only form."""
+    repo = _session_repo()
+    state = _state(
+        input_text="how long do I cook it?",
+        conversation_id="conv-1",
+        user_id="user-1",
+        intent=Intent.COOKING_HELP.value,
+        context={"cooking_recipe": {"id": "recipe-42"}},
+    )
+
+    with _patch_repo(repo):
+        await update_session_node(state)
+
+    repo.get_recipe.assert_awaited_once_with("user-1", "recipe-42")
+    saved = repo.update_session.await_args.args[1]
+    assert saved.pinned_recipe_id == "recipe-42"
+    assert saved.metadata["cooking_recipe"]["title"] == "Lemon Garlic Pasta"
+
+
+@pytest.mark.asyncio
+async def test_cooking_recipe_id_missing_recipe_leaves_session_unpinned():
+    """A deleted/unauthorised recipe id resolves to None — no pin, no crash."""
+    repo = _session_repo()
+    repo.get_recipe = AsyncMock(return_value=None)
+    state = _state(
+        input_text="what temp?",
+        conversation_id="conv-1",
+        user_id="user-1",
+        intent=Intent.COOKING_HELP.value,
+        context={"cooking_recipe_id": "recipe-gone"},
+    )
+
+    with _patch_repo(repo):
+        await update_session_node(state)
+
+    repo.get_recipe.assert_awaited_once_with("user-1", "recipe-gone")
+    saved = repo.update_session.await_args.args[1]
+    assert saved.active_mode == SessionMode.DEFAULT
+    assert saved.pinned_recipe_id is None
+
+
+@pytest.mark.asyncio
+async def test_legacy_full_dict_does_not_call_get_recipe():
+    """The legacy full `cooking_recipe` dict is used as-is — no server resolve."""
+    repo = _session_repo()
+    state = _state(
+        input_text="how do I julienne the carrots?",
+        conversation_id="conv-1",
+        user_id="user-1",
+        intent=Intent.COOKING_HELP.value,
+        context=_cooking_context(),
+    )
+
+    with _patch_repo(repo):
+        await update_session_node(state)
+
+    repo.get_recipe.assert_not_awaited()
+    saved = repo.update_session.await_args.args[1]
+    assert saved.pinned_recipe_id == "recipe-42"
+    assert saved.metadata["cooking_recipe"]["ingredients"] == [
+        "spaghetti",
+        "lemon",
+        "garlic",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Ingredient flattening (str passthrough + object flatten)
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_ingredient_passes_strings_through():
+    assert _flatten_ingredient("2 cups flour") == "2 cups flour"
+    assert _flatten_ingredient("  salt  ") == "salt"
+
+
+def test_flatten_ingredient_joins_object_parts():
+    assert (
+        _flatten_ingredient({"name": "spaghetti", "quantity": 200, "unit": "g"})
+        == "200 g spaghetti"
+    )
+    # Missing/None parts are skipped, not rendered as "None".
+    assert _flatten_ingredient({"name": "lemon", "quantity": 1, "unit": None}) == "1 lemon"
+    assert _flatten_ingredient({"name": "salt"}) == "salt"
+
+
+def test_normalize_cooking_recipe_handles_object_ingredients():
+    normalized = normalize_cooking_recipe(
+        {
+            "id": "r1",
+            "title": "Test",
+            "ingredients": [{"name": "egg", "quantity": 2, "unit": None}, "salt"],
+        }
+    )
+    assert normalized["ingredients"] == ["2 egg", "salt"]
 
 
 # ---------------------------------------------------------------------------

--- a/docs/plans/2026-07-28-fix-155-cook-chat-context.md
+++ b/docs/plans/2026-07-28-fix-155-cook-chat-context.md
@@ -1,0 +1,146 @@
+# Fix #155 — cook→chat handoff can land with no recipe context
+
+## Context
+
+When a user cooks a recipe, the Cook flow hands off to `/chat?cooking=<id>` and the
+chat is supposed to be pinned to that recipe so Bubbles answers "what temp?" /
+"substitute for X?" specifically about the dish being cooked.
+
+The end-to-end plumbing is correct, but there's a **race**: the recipe context the
+frontend attaches to the first chat message depends on an async
+`fetchRecipe(cookingRecipeId)` resolving first (`chat/page.tsx:114-150`). The
+quick-prompt chips and Send are tappable *before* that fetch resolves. If the user
+sends message #1 first, it goes out with **no `cooking_recipe`**, the backend never
+pins the session, and because the context is one-shot (`contextSentRef`), **every
+later turn is also context-free**. The "COOKING NOW" card renders regardless, so it
+*looks* pinned but isn't. A silent fetch failure is a second, rarer path to the same
+state.
+
+**Intended outcome:** the pin happens deterministically on message #1, independent of
+any client-side fetch — because the recipe id (`?cooking=<id>`) is known
+synchronously and the backend can resolve the full recipe itself from the DB.
+
+## Approach — resolve the recipe server-side from the id
+
+Move the source of truth from a client-held recipe snapshot (that must win a race) to
+the id in the URL + the DB. The frontend sends only the id synchronously; the backend
+resolves title + ingredients via the repository before pinning. The `fetchRecipe`
+call stays purely to render the cosmetic card.
+
+### Backend
+
+**`ai-service/bubbly_chef/workflows/router.py` (pin block, `update_session_node`, ~L556-571)**
+- `repo` and `user_id` are already in scope here (`repo` at L543, `state.get("user_id")`).
+- Read the cook context and branch on shape:
+  - **New id-only form:** `context["cooking_recipe_id"]` (a string) → resolve via
+    `await repo.get_recipe(user_id, recipe_id)` (`supabase_repo.py:294`, returns the
+    raw `recipes` row dict or `None`). Build the normalized
+    `{id, title, ingredients}` dict from the row, then pin exactly as today.
+  - **Legacy form (non-breaking):** `context["cooking_recipe"]` is a `dict` with
+    `title`/`ingredients` already present → keep the current path unchanged.
+  - Also accept `context["cooking_recipe"]` being a dict with only an `id` (defensive)
+    by routing it through the same server-side resolve.
+- If `get_recipe` returns `None` (deleted recipe / wrong user), log a warning and skip
+  pinning — do **not** crash the turn (chat still works, just un-pinned). This makes
+  failure-mode 2 explicit on the server instead of silent on the client.
+
+**Ingredient shape gotcha (critical):** the DB `recipes.ingredients` column is `JSONB`
+storing **objects** `{name, quantity, unit, preparation, optional, substitutes}`
+(migration `00001_initial_schema.sql:56`; `RecipeCard.ingredients: list[Ingredient]`
+in `models/recipe.py:10-43`). `normalize_cooking_recipe` (`chat/nodes.py:124`) does
+`str(item).strip()` — that would stringify a dict badly. The frontend already flattens
+these to `"2 cups flour"` strings via `ingredientLines()` (`chat/page.tsx:46-52`:
+`[quantity, unit, name].filter(Boolean).join(' ')`).
+- **Mirror that flatten server-side.** Add a small helper in `chat/nodes.py` (next to
+  `normalize_cooking_recipe`), e.g. `_flatten_ingredient(raw)` that accepts a str
+  (pass through) or a dict (`{quantity} {unit} {name}` joined, non-empty parts) and
+  returns a display string. Extend `normalize_cooking_recipe` to run each ingredient
+  through it, so the same normalizer safely handles both string lists (legacy client
+  payload + existing tests) and object lists (server-resolved DB rows). This keeps a
+  single normalization point and doesn't break the existing string-based tests.
+
+**`ai-service/bubbly_chef/models/requests.py` (L95-102)** — update the `context`
+field description to document the new recognised key `cooking_recipe_id` alongside the
+legacy `cooking_recipe`.
+
+### Frontend
+
+**`nextjs/src/app/chat/page.tsx`**
+- `takeCookingContext()` (L153-157): return the id-only payload synchronously from
+  `cookingRecipeId` (known at L82 on mount) instead of depending on `cookingContext`
+  (which requires `loadedRecipe`). New payload: `{ cooking_recipe_id: cookingRecipeId }`.
+  Keep the `contextSentRef` / `isStreaming` one-shot guard.
+- `cookingContext` / `ingredientLines()` (L142-150, L46-52) are now only needed for the
+  legacy payload; the id-only path no longer needs them for context. Keep
+  `cookingRecipe` (L135-140) — it still drives the cosmetic `CookingContextCard`
+  (L308-314). `fetchRecipe` stays as-is; its failure now affects only the card.
+- The seed auto-send effect (L165-171) sets `contextSentRef.current = true` before
+  `sendMessage(seed.message)` — a seeded chat has no cook context, so leave as-is.
+
+**`nextjs/src/types/chat.ts` (L114-119)** — add the id-only context shape (e.g. a
+`cooking_recipe_id: string` field on the chat request context, or a new
+`CookingRecipeIdContext`), keeping `CookingRecipeContext` for back-compat.
+
+### Tests
+
+**`ai-service/tests/test_chat_router.py`** (mirror the existing cook-handoff tests at
+L205-289; fixtures `_session_repo`, `_cooking_context`, `_patch_repo`, `_state`):
+- Add `repo.get_recipe = AsyncMock(return_value=<fake row dict>)` to `_session_repo`
+  (or a variant) so the new path can resolve.
+- **New test:** context carries only `{cooking_recipe_id: "recipe-42"}` → `get_recipe`
+  is awaited with `(user_id, "recipe-42")` → session pinned, `pinned_recipe_id`
+  set, `metadata["cooking_recipe"]` has the resolved title + flattened ingredient
+  strings (fake row uses object ingredients like
+  `[{"name":"spaghetti","quantity":200,"unit":"g"}]` → assert `["200 g spaghetti", ...]`).
+- **New test:** `get_recipe` returns `None` → no pin, no crash, mode unchanged.
+- **Keep** the existing legacy-dict tests passing unchanged (proves non-breaking).
+- Add a unit test for the ingredient-flatten helper (str passthrough + dict flatten).
+
+**Frontend** — scaffold a test (even if no harness for this component exists yet)
+asserting the core race fix: `takeCookingContext()` returns `{cooking_recipe_id: <id>}`
+synchronously on mount from `?cooking=<id>`, **without** waiting on `fetchRecipe` /
+`loadedRecipe`. Since `takeCookingContext` is currently an inner closure of
+`ChatSurface`, the cleanest testable unit is the pure derivation — extract the
+"id → context payload" logic into a tiny exported pure helper (e.g.
+`cookingContextForId(id): {cooking_recipe_id} | undefined`) and unit-test that, then
+have the component call it. This avoids standing up a full React render harness while
+still locking in the synchronous-on-mount guarantee. Place under
+`nextjs/src/__tests__/` (existing Jest location per CLAUDE.md). Mirror the legacy path
+too if kept.
+
+## Verification
+
+```bash
+# Backend
+cd ai-service && BUBBLY_RUN_LIVE_TESTS=0 pytest tests/test_chat_router.py -q
+cd ai-service && ruff check bubbly_chef/
+
+# Frontend
+cd nextjs && npx tsc --noEmit   # expect the 5 pre-existing e2e/* + playwright.config.ts
+                                 # errors ONLY (from the #59 harness) — not regressions
+```
+
+**Manual (the acceptance repro, #155):** with both servers up (frontend `-p 3100`, AI
+`:8888`), cook a recipe → Confirm → land on `/chat?cooking=<id>`. On a throttled
+connection, immediately tap a quick-prompt chip (before the card fills in). Confirm the
+AI-service log shows `Session pinned to cooking recipe (recipe_id=...)` on that first
+turn, and Bubbles' answer to "what temp / substitute" is recipe-specific. Then delete
+the recipe and repeat → chat still works un-pinned, no crash.
+
+## Acceptance criteria (from #155)
+- First message (typed or chip) always pins the session, even sent immediately on a
+  throttled connection — verified by the "Session pinned" log on that turn.
+- Pin does not depend on the client finishing the fetch (server resolves from id).
+- A failed/missing recipe affects only the cosmetic card, not context, and is not a
+  silent crash.
+- Backend still accepts the legacy full `cooking_recipe` dict (non-breaking).
+- `pytest` + `npx tsc --noEmit` clean (modulo the 5 known e2e tsc errors).
+
+## Out of scope
+- #144 (constraints dropped on brainstorm follow-up) — distinct bug.
+- Re-recording demo `02` / updating PR #154 — a follow-up once this lands.
+- The `RecipeCard.dietary_tags` vs DB `tags` inconsistency the exploration flagged —
+  unrelated to context resolution; note as a separate issue if worth tracking.
+
+## Branch
+`fix/issue-155-cook-chat-context-server-resolve` off `main`.

--- a/nextjs/src/__tests__/cooking-context.test.ts
+++ b/nextjs/src/__tests__/cooking-context.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Issue #155 — the cook→chat handoff must pin the session on the first message
+ * regardless of whether the client has finished fetching the recipe.
+ *
+ * `takeCookingContext` in `chat/page.tsx` builds its payload from
+ * `cookingContextForId(cookingRecipeId)`, where `cookingRecipeId` is the
+ * `?cooking=<id>` param — known synchronously on mount. These assertions lock
+ * in that the payload is available immediately (no `loadedRecipe` dependency),
+ * which is what closes the fetch/send race. The AI service resolves the full
+ * recipe from this id server-side.
+ */
+import { cookingContextForId } from '@/lib/chat-seed'
+
+describe('cookingContextForId (#155)', () => {
+  it('returns the id-only context payload synchronously from the URL param', () => {
+    expect(cookingContextForId('recipe-42')).toEqual({ cooking_recipe_id: 'recipe-42' })
+  })
+
+  it('does not include title/ingredients — the backend resolves those', () => {
+    const context = cookingContextForId('recipe-42')
+    expect(Object.keys(context ?? {})).toEqual(['cooking_recipe_id'])
+  })
+
+  it('returns undefined for a bare /chat (no ?cooking= param)', () => {
+    expect(cookingContextForId(null)).toBeUndefined()
+    expect(cookingContextForId(undefined)).toBeUndefined()
+  })
+
+  it('ignores a blank or whitespace-only id so no empty pin is sent', () => {
+    expect(cookingContextForId('')).toBeUndefined()
+    expect(cookingContextForId('   ')).toBeUndefined()
+  })
+
+  it('trims surrounding whitespace off the id', () => {
+    expect(cookingContextForId('  recipe-42  ')).toEqual({ cooking_recipe_id: 'recipe-42' })
+  })
+})

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -20,12 +20,11 @@ import EmptyState from '@/components/ui/EmptyState'
 import { useChat } from '@/hooks/useChat'
 import { checkAIHealth } from '@/lib/api/chat'
 import { fetchRecipe } from '@/lib/api/recipes'
-import { deriveChatSeed } from '@/lib/chat-seed'
+import { cookingContextForId, deriveChatSeed } from '@/lib/chat-seed'
 import type { Recipe } from '@/components/recipes/RecipePage'
 import type {
   ChatMessage,
   ChatRecipeData,
-  CookingRecipeContext,
   PantryProposalData,
 } from '@/types/chat'
 
@@ -41,15 +40,6 @@ const COOKING_SUGGESTIONS = [
   'How do I prep this? 🔪',
   'How long does this take? ⏱️',
 ]
-
-/** Flatten a saved recipe's ingredients to plain strings for the AI context. */
-function ingredientLines(recipe: Recipe): string[] {
-  return recipe.ingredients.map((ing) =>
-    typeof ing === 'string'
-      ? ing
-      : [ing.quantity, ing.unit, ing.name].filter(Boolean).join(' '),
-  )
-}
 
 /**
  * `useSearchParams` opts the tree into client-side rendering, so the page shell
@@ -139,21 +129,22 @@ function ChatSurface() {
       ? loadedRecipe
       : null
 
-  const cookingContext = useMemo(() => {
-    if (!cookingRecipe) return null
-    const payload: CookingRecipeContext = {
-      id: cookingRecipe.id,
-      title: cookingRecipe.title,
-      ingredients: ingredientLines(cookingRecipe),
-    }
-    return { cooking_recipe: payload } as Record<string, unknown>
-  }, [cookingRecipe])
-
-  /** Attach the cook context to the first message of the conversation only. */
+  /**
+   * Attach the cook context to the first message of the conversation only.
+   *
+   * The payload is derived from `cookingRecipeId` — the `?cooking=<id>` param,
+   * known synchronously on mount — NOT from `loadedRecipe`. The AI service
+   * resolves the full recipe from this id server-side, so the pin no longer
+   * races the client's `fetchRecipe` (#155): a message sent before the card
+   * fills in still pins the session. `loadedRecipe` drives only the cosmetic
+   * card below.
+   */
   const takeCookingContext = (): Record<string, unknown> | undefined => {
-    if (!cookingContext || contextSentRef.current || isStreaming) return undefined
+    if (contextSentRef.current || isStreaming) return undefined
+    const context = cookingContextForId(cookingRecipeId)
+    if (!context) return undefined
     contextSentRef.current = true
-    return cookingContext
+    return { ...context }
   }
 
   // Auto-send the seeded question so a tap on the dashboard tip / an expiring

--- a/nextjs/src/lib/chat-seed.ts
+++ b/nextjs/src/lib/chat-seed.ts
@@ -10,13 +10,29 @@
  * dismissible context card above the thread, and prime the conversation.
  *
  * IMPORTANT — the seed lives in the *message text*, not in a context payload.
- * The AI service only recognises one client-supplied context key
- * (`cooking_recipe`); anything else is ignored, and the must-use ingredient is
- * recovered by an LLM structured-output call over the message itself. So the
- * ingredient name and the tip text have to appear verbatim in `message`, and
- * the `"with my <name>"` phrasing below is the one the backend prompt was
- * tuned against. Don't reword it without re-tuning `recipe/nodes.py`.
+ * The AI service recognises two client-supplied context keys — `cooking_recipe`
+ * and `cooking_recipe_id` (the cook handoff, see `cookingContextForId` below);
+ * anything else is ignored, and the must-use ingredient is recovered by an LLM
+ * structured-output call over the message itself. So the ingredient name and
+ * the tip text have to appear verbatim in `message`, and the `"with my <name>"`
+ * phrasing below is the one the backend prompt was tuned against. Don't reword
+ * it without re-tuning `recipe/nodes.py`.
  */
+
+import type { CookingRecipeIdContext } from '@/types/chat'
+
+/**
+ * Cook-handoff context for the first chat message, built from the `?cooking=<id>`
+ * param alone. Returns the id-only payload the AI service resolves server-side,
+ * so pinning never waits on a client-side recipe fetch (#155). Returns
+ * `undefined` for a bare/blank id so callers can spread it conditionally.
+ */
+export function cookingContextForId(
+  recipeId: string | null | undefined,
+): CookingRecipeIdContext | undefined {
+  const id = recipeId?.trim()
+  return id ? { cooking_recipe_id: id } : undefined
+}
 
 /** Minimal read surface shared by `URLSearchParams` and Next's readonly variant. */
 export interface ReadableSearchParams {

--- a/nextjs/src/types/chat.ts
+++ b/nextjs/src/types/chat.ts
@@ -104,14 +104,25 @@ export interface ChatRequest {
   mode?: string
   pantry_snapshot?: Record<string, unknown>[]
   /**
-   * Extra context forwarded to the AI workflow. Recognised key:
-   * `cooking_recipe` ({ id, title, ingredients }) — pins the conversation to
-   * the recipe the user just started cooking.
+   * Extra context forwarded to the AI workflow. Recognised keys:
+   * `cooking_recipe_id` (string) — the recipe the user just started cooking;
+   * the AI service resolves the full recipe from the DB and pins the
+   * conversation to it. Legacy `cooking_recipe` ({ id, title, ingredients })
+   * is still accepted, same effect.
    */
   context?: Record<string, unknown> | null
 }
 
-/** Shape of `context.cooking_recipe` sent after the Cook flow hands off to chat. */
+/**
+ * Preferred cook-handoff context: just the recipe id, resolved server-side.
+ * Known synchronously from `?cooking=<id>`, so it never has to wait on a fetch
+ * (the client fetch/send race that #155 fixed).
+ */
+export interface CookingRecipeIdContext {
+  cooking_recipe_id: string
+}
+
+/** Legacy shape of `context.cooking_recipe` — still accepted by the AI service. */
 export interface CookingRecipeContext {
   id: string
   title: string


### PR DESCRIPTION
## Summary

The cook→chat handoff could land in chat with **no recipe context**, so Bubbles answered "what temp?" / "substitute for X?" generically instead of about the dish being cooked. The plumbing was correct but raced: the context payload was built only after an async `fetchRecipe` resolved, yet the quick-prompt chips and Send were tappable before then. A first message sent early went out with no `cooking_recipe`; the backend never pinned the session; and because the context is one-shot, every later turn stayed context-free. The "COOKING NOW" card rendered regardless, masking the failure. A silent fetch failure was a second path to the same state.

This moves the source of truth to the recipe id already in the URL (`/chat?cooking=<id>`), which is known synchronously — killing the race by construction.

## What lands

- **Frontend** sends `{ cooking_recipe_id }` synchronously from `?cooking=<id>` (new `cookingContextForId` helper), with no dependency on `loadedRecipe`. `fetchRecipe` now feeds only the cosmetic context card; its failure no longer affects context.
- **Backend** resolves the recipe via `repo.get_recipe(user_id, id)` before pinning (`router._resolve_cook_context`). A missing/deleted recipe leaves the session un-pinned instead of crashing the turn — the previously-silent failure is now a server-side warning log.
- DB stores ingredients as objects; `normalize_cooking_recipe` now flattens them to display strings (mirrors the frontend's old `ingredientLines`), so both client and server payloads yield the same prompt text.
- Legacy full `cooking_recipe` dict still accepted (non-breaking rollout); a thin dict carrying only an `id` is routed through the same server-side resolve.

## Tests

- Backend (`test_chat_router.py`): id-only payload resolves + pins with flattened object ingredients; thin-dict resolve; missing recipe → no pin, no crash; legacy full dict does **not** call `get_recipe` (proves non-breaking); unit tests for the ingredient-flatten helper. `pytest tests/test_chat_router.py tests/test_chat_routes.py` → 41 passed.
- Frontend (`cooking-context.test.ts`): `cookingContextForId` returns the id-only payload synchronously, is `undefined` for a bare/blank id, and trims whitespace. 5 passed.
- `npx tsc --noEmit` clean apart from 5 pre-existing `e2e/*` + `playwright.config.ts` errors (missing `@playwright/test` types, from the existing e2e harness — not from this change).

## Linked

Closes #155.

## Out of scope

- Re-recording the `02-cook-chat-handoff` demo to show working context — a follow-up now that the fix has landed.
- Recipe-constraint drop on brainstorm follow-up turns — a distinct bug.
- A pre-existing timezone/date bug surfaced in `chat-seed.test.ts`'s `expiryPhrase` cases (they fail non-deterministically on clean `main`, independent of this change) — worth a separate issue.