### PR TITLE
feat: auto-categorize manual pantry adds via catalog (yogurt → dairy)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/pantry.py
+++ b/ai-service/bubbly_chef/api/routes/pantry.py
@@ -1,12 +1,14 @@
 """Pantry helper HTTP routes for the BubblyChef AI microservice.
 
 Exposes:
-- POST /v1/pantry/estimate-expiry — estimate an expiry date for an item
+- POST /v1/pantry/estimate-expiry   — estimate an expiry date for an item
+- POST /v1/pantry/estimate-category — categorize an item name via the catalog
 
-The expiry heuristic (`tools/expiry`) is Python-only and is the single source of
-truth shared by the AI ingest paths. This endpoint lets the Next.js CRUD routes
-(manual add, bulk add) reuse it instead of forking the table into TypeScript, so
-items added by hand or via receipt-confirm get the same default expiries (#158).
+The expiry heuristic (`tools/expiry`) and catalog categorizer
+(`domain/catalog`) are Python-only and are the single source of truth shared by
+the AI ingest paths. These endpoints let the Next.js CRUD routes (manual add,
+bulk add) reuse them instead of forking the logic into TypeScript, so items
+added by hand get the same defaults as AI-parsed items (#158, #159).
 """
 
 import logging
@@ -15,6 +17,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from bubbly_chef.api.auth import get_current_user_id
+from bubbly_chef.domain.catalog import categorize
 from bubbly_chef.models.pantry import FoodCategory, StorageLocation
 from bubbly_chef.tools.expiry import get_expiry_heuristics
 
@@ -32,6 +35,17 @@ class EstimateExpiryRequest(BaseModel):
 class EstimateExpiryResponse(BaseModel):
     expiry_date: str = Field(..., description="Estimated expiry date (ISO YYYY-MM-DD)")
     is_estimated: bool = Field(..., description="Always true — this is a heuristic")
+
+
+class EstimateCategoryRequest(BaseModel):
+    name: str = Field(..., description="Item name to categorize")
+
+
+class EstimateCategoryResponse(BaseModel):
+    category: str | None = Field(
+        ...,
+        description="Matched food category string, or null if the catalog has no confident match",
+    )
 
 
 def _coerce_category(value: str) -> FoodCategory:
@@ -76,3 +90,25 @@ async def estimate_expiry(
         expiry_date=expiry_date.isoformat(),
         is_estimated=is_estimated,
     )
+
+
+@router.post(
+    "/estimate-category",
+    summary="Categorize a pantry item by name",
+    response_model=EstimateCategoryResponse,
+    responses={
+        200: {"description": "Category string, or null if no confident match"},
+        401: {"description": "Missing or invalid JWT"},
+    },
+)
+async def estimate_category(
+    request: EstimateCategoryRequest,
+    user_id: str = Depends(get_current_user_id),
+) -> EstimateCategoryResponse:
+    """Infer a food category from an item name using the catalog fuzzy matcher.
+
+    Deterministic — no LLM call. Returns null when the catalog has no match
+    above the confidence threshold (95). Callers should fall back to 'other'
+    on null so that a failed or absent estimate never blocks the add.
+    """
+    return EstimateCategoryResponse(category=categorize(request.name))

--- a/ai-service/tests/test_pantry_estimate_category.py
+++ b/ai-service/tests/test_pantry_estimate_category.py
@@ -1,0 +1,49 @@
+"""Tests for the pantry category-estimation endpoint helpers.
+
+The endpoint itself requires JWT auth + wires FastAPI, but the interesting
+behaviour is the catalog lookup and that known items resolve to the right
+category while unknown items return None. These test that layer directly.
+"""
+
+from bubbly_chef.api.routes.pantry import (
+    EstimateCategoryRequest,
+    EstimateCategoryResponse,
+)
+from bubbly_chef.domain.catalog import categorize
+
+
+def test_request_model_accepts_name() -> None:
+    req = EstimateCategoryRequest(name="greek yogurt")
+    assert req.name == "greek yogurt"
+
+
+def test_response_model_allows_null_category() -> None:
+    resp = EstimateCategoryResponse(category=None)
+    assert resp.category is None
+
+
+def test_response_model_allows_string_category() -> None:
+    resp = EstimateCategoryResponse(category="dairy")
+    assert resp.category == "dairy"
+
+
+def test_greek_yogurt_resolves_to_dairy() -> None:
+    """Catalog entry for yogurt should return 'dairy' at threshold=95."""
+    result = categorize("greek yogurt")
+    assert result == "dairy"
+
+
+def test_banana_resolves_to_produce() -> None:
+    result = categorize("banana")
+    assert result == "produce"
+
+
+def test_unknown_item_returns_none() -> None:
+    """No catalog match for a nonsense name — caller falls back to 'other'."""
+    result = categorize("xyzunknownitem123")
+    assert result is None
+
+
+def test_empty_string_returns_none() -> None:
+    result = categorize("")
+    assert result is None

--- a/ai-service/tests/test_pantry_estimate_expiry.py
+++ b/ai-service/tests/test_pantry_estimate_expiry.py
@@ -16,32 +16,32 @@ from bubbly_chef.models.pantry import FoodCategory, StorageLocation
 from bubbly_chef.tools.expiry import get_expiry_heuristics
 
 
-def test_coerce_category_valid():
+def test_coerce_category_valid() -> None:
     assert _coerce_category("dairy") == FoodCategory.DAIRY
     assert _coerce_category("produce") == FoodCategory.PRODUCE
 
 
-def test_coerce_category_unknown_falls_back_to_other():
+def test_coerce_category_unknown_falls_back_to_other() -> None:
     assert _coerce_category("not-a-category") == FoodCategory.OTHER
     assert _coerce_category("") == FoodCategory.OTHER
 
 
-def test_coerce_location_valid():
+def test_coerce_location_valid() -> None:
     assert _coerce_location("fridge") == StorageLocation.FRIDGE
     assert _coerce_location("freezer") == StorageLocation.FREEZER
 
 
-def test_coerce_location_unknown_falls_back_to_pantry():
+def test_coerce_location_unknown_falls_back_to_pantry() -> None:
     assert _coerce_location("garage") == StorageLocation.PANTRY
 
 
-def test_request_defaults():
+def test_request_defaults() -> None:
     req = EstimateExpiryRequest(name="milk")
     assert req.category == "other"
     assert req.location == "pantry"
 
 
-def test_heuristic_returns_future_date_for_known_item():
+def test_heuristic_returns_future_date_for_known_item() -> None:
     """The estimator the endpoint wraps returns a plausible future expiry."""
     expiry, is_estimated = get_expiry_heuristics().estimate_expiry(
         category=FoodCategory.DAIRY,

--- a/nextjs/src/app/api/pantry/route.ts
+++ b/nextjs/src/app/api/pantry/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireAuth, errorResponse } from '@/lib/response-helpers'
 import { enrichPantryItem, buildPantryListResponse } from '@/lib/pantry-helpers'
-import { estimateExpiry } from '@/lib/api/ai-proxy'
+import { estimateExpiry, estimateCategory } from '@/lib/api/ai-proxy'
 import type { PantryItemRow } from '@/lib/pantry-helpers'
 
 export async function GET(request: Request) {
@@ -40,13 +40,18 @@ export async function POST(request: Request) {
 
   const body = await request.json()
 
+  // Resolve category: use the supplied value, else ask the catalog, else 'other'
+  // (#159 — same Python catalog as the AI ingest paths; best-effort, never blocks).
+  const category =
+    body.category || (await estimateCategory(body.name as string)) || 'other'
+
   // Estimate an expiry when the user didn't supply one (#158) — same Python
   // heuristic as the AI paths, via the AI service. Falls back to null on error.
   const expiry =
     body.expiry_date ||
     (await estimateExpiry({
       name: body.name,
-      category: body.category,
+      category,
       location: body.storage_location || body.location,
     }))
 
@@ -56,7 +61,7 @@ export async function POST(request: Request) {
       user_id: user.id,
       name: body.name,
       name_normalized: (body.name as string).toLowerCase().trim(),
-      category: body.category || 'other',
+      category,
       location: body.storage_location || body.location || 'pantry',
       quantity: body.quantity || 1.0,
       unit: body.unit || 'item',

--- a/nextjs/src/lib/api/ai-proxy.ts
+++ b/nextjs/src/lib/api/ai-proxy.ts
@@ -103,3 +103,25 @@ export async function estimateExpiry(item: {
     return null
   }
 }
+
+/**
+ * Infer a food category for a pantry item name via the AI service's catalog
+ * fuzzy matcher (the single source of truth — see #159). Returns a category
+ * string (e.g. "dairy"), or `null` when the catalog has no confident match.
+ * Callers should fall back to 'other' on null so the add is never blocked.
+ */
+export async function estimateCategory(name: string): Promise<string | null> {
+  try {
+    const res = await aiProxyFetch('/v1/pantry/estimate-category', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    })
+    if (res instanceof NextResponse || !res.ok) return null
+    const data = (await res.json()) as { category?: string | null }
+    return data.category ?? null
+  } catch {
+    // Categorization is best-effort — never let it block adding the item.
+    return null
+  }
+}


### PR DESCRIPTION
## Summary
A manually added item with no category was landing as `other` (e.g. "greek yogurt" → other, not dairy). This wires the existing food catalog categorizer into the manual-add path, so hand-added items are classified the same way AI-ingested items are.

## What lands
- New AI-service endpoint `POST /v1/pantry/estimate-category`, wrapping `catalog.categorize` (deterministic, no LLM). Sits alongside the `estimate-expiry` endpoint and shares the same auth.
- `estimateCategory()` in `lib/api/ai-proxy.ts`, best-effort with graceful null fallback — never blocks an add.
- The manual-add route resolves category first (`body.category || estimateCategory(name) || "other"`), then feeds the resolved category into the expiry estimate, so a categorized item also gets a sharper default expiry.

## Tests
- `test_pantry_estimate_category.py`: "greek yogurt" → dairy, unknown → null. Existing estimate-expiry tests still green (13/13 total). ruff clean.
- `npx tsc --noEmit` clean (bar the known e2e/playwright errors).

## Linked
Follow-up to the default-expiry work (#158).

## Out of scope
- Categorization of receipt-scanned items already flows through the AI ingest paths; this PR only covers the manual "+ Add Item" route.