### PR TITLE
fix: inherit recipe constraints across the brainstorm follow-up turn (#144)

### DIFF
--- a/ai-service/bubbly_chef/workflows/recipe/nodes.py
+++ b/ai-service/bubbly_chef/workflows/recipe/nodes.py
@@ -381,8 +381,66 @@ def _default_meal_type() -> str:
         return "late-night snack"
 
 
+def _merge_constraints(
+    prior: dict[str, Any],
+    fresh: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge freshly-extracted constraints with the prior turn's constraints.
+
+    Rules (implement "inherit + override"):
+    - Scalar fields (cuisine, mood, meal_type, max_time_minutes, servings,
+      skill_level): fresh value wins when non-None/non-empty; otherwise
+      inherit prior.
+    - List fields (dietary, preferred_ingredients, excluded_ingredients):
+      fresh list wins when non-empty; otherwise inherit prior.
+    - must_use_ingredients: fresh list wins when non-empty; otherwise inherit
+      prior. This ensures dietary restrictions AND must-use ingredients both
+      survive a follow-up turn that doesn't repeat them.
+    """
+    merged: dict[str, Any] = dict(prior)
+
+    scalar_keys = ("cuisine", "mood", "meal_type", "max_time_minutes", "servings", "skill_level")
+    list_keys = (
+        "dietary",
+        "preferred_ingredients",
+        "excluded_ingredients",
+        "must_use_ingredients",
+    )
+
+    for key in scalar_keys:
+        fresh_val = fresh.get(key)
+        if fresh_val is not None and fresh_val != "":
+            merged[key] = fresh_val
+
+    for key in list_keys:
+        fresh_list = fresh.get(key) or []
+        if fresh_list:
+            merged[key] = fresh_list
+        # else: keep prior value (already in merged)
+
+    return merged
+
+
+def _prior_constraints_from_state(state: WorkflowState) -> dict[str, Any] | None:
+    """Return recipe_constraints stored in the session metadata, if any."""
+    session = state.get("session")
+    if not isinstance(session, dict):
+        return None
+    metadata = session.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    prior = metadata.get("recipe_constraints")
+    return prior if isinstance(prior, dict) else None
+
+
 async def extract_recipe_constraints(state: WorkflowState) -> WorkflowState:
-    """Node: Extract recipe constraints from user message via structured LLM call."""
+    """Node: Extract recipe constraints from user message via structured LLM call.
+
+    On follow-up turns (e.g. user selects a brainstorm idea or refines a recipe),
+    the newly-extracted constraints are merged with any constraints persisted in
+    the session from the previous turn.  Fresh values override; fields that the
+    user didn't re-mention inherit from the prior turn (#144).
+    """
     input_text = state.get("input_text", "")
     ai_manager = get_ai_manager()
     logger.info("Extracting recipe constraints", extra={"message_preview": input_text[:80]})
@@ -394,12 +452,23 @@ async def extract_recipe_constraints(state: WorkflowState) -> WorkflowState:
             temperature=0.1,
         )
         if isinstance(result, RecipeConstraints):
-            constraints = result.model_dump()
+            constraints: dict[str, Any] = result.model_dump()
         else:
             constraints = {}
     except Exception as e:
         logger.warning("Constraint extraction failed (using empty constraints): %s", e)
         constraints = {}
+
+    # Merge with prior constraints from the session (inherit + override).
+    prior = _prior_constraints_from_state(state)
+    if prior:
+        constraints = _merge_constraints(prior, constraints)
+        logger.info(
+            "Merged prior session constraints into fresh extraction "
+            "(dietary=%s, must_use=%s)",
+            constraints.get("dietary"),
+            constraints.get("must_use_ingredients"),
+        )
 
     # Default meal_type from time of day when user didn't specify
     if not constraints.get("meal_type"):
@@ -571,15 +640,35 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
 
 
 async def research_recipe(state: WorkflowState) -> WorkflowState:
-    """Node: Search DuckDuckGo for the selected recipe, store grounding context."""
-    recipe_name: str = state.get("selected_recipe_name") or state.get("input_text", "")
-    constraints: dict[str, Any] = state.get("recipe_constraints") or {}
-    cuisine_tag = constraints.get("cuisine")
+    """Node: Search DuckDuckGo for the selected recipe, store grounding context.
 
+    This node runs on the brainstorm follow-up path which bypasses
+    extract_recipe_constraints.  We load prior constraints from the session
+    here so that generate_grounded_recipe always has them available (#144).
+    """
+    recipe_name: str = state.get("selected_recipe_name") or state.get("input_text", "")
+
+    # Rehydrate constraints from the session when the brainstorm follow-up path
+    # skipped extract_recipe_constraints.  Without this the constraints from
+    # turn 1 (cuisine, dietary, must_use_ingredients, …) are silently dropped.
+    constraints: dict[str, Any] = state.get("recipe_constraints") or {}
+    if not constraints:
+        prior = _prior_constraints_from_state(state)
+        if prior:
+            constraints = prior
+            logger.info(
+                "research_recipe: inherited constraints from session "
+                "(dietary=%s, must_use=%s)",
+                constraints.get("dietary"),
+                constraints.get("must_use_ingredients"),
+            )
+
+    cuisine_tag = constraints.get("cuisine")
     search_result = await search_recipe(recipe_name, cuisine_tag=cuisine_tag)
 
     return {
         **state,
+        "recipe_constraints": constraints,
         "web_search_result": search_result.model_dump() if search_result else None,
     }
 

--- a/ai-service/bubbly_chef/workflows/router.py
+++ b/ai-service/bubbly_chef/workflows/router.py
@@ -624,6 +624,14 @@ async def update_session_node(state: WorkflowState) -> WorkflowState:
         if intent in (Intent.RECIPE_BRAINSTORM.value, Intent.RECIPE_GENERATION.value):
             session.active_mode = SessionMode.RECIPE_EXPLORING
             session.metadata["brainstorm_ideas"] = state.get("brainstorm_ideas", [])
+            # Persist constraints so the follow-up turn (research_recipe) can inherit
+            # them even though it bypasses extract_recipe_constraints (#144).
+            constraints = state.get("recipe_constraints")
+            if constraints:
+                session.metadata["recipe_constraints"] = constraints
+                logger.debug(
+                    "Session: persisted recipe_constraints for follow-up inheritance"
+                )
 
         elif intent == Intent.RECIPE_CARD.value:
             proposal = state.get("proposal")
@@ -637,6 +645,10 @@ async def update_session_node(state: WorkflowState) -> WorkflowState:
                 session.metadata["last_recipe_title"] = getattr(
                     getattr(proposal, "recipe", None), "title", None
                 )
+                # Keep constraints alive across further refinement turns.
+                constraints = state.get("recipe_constraints")
+                if constraints:
+                    session.metadata["recipe_constraints"] = constraints
             # else: stay in current mode
 
         elif intent == Intent.PANTRY_UPDATE.value:
@@ -653,6 +665,9 @@ async def update_session_node(state: WorkflowState) -> WorkflowState:
             if state.get("brainstorm_ideas"):
                 session.active_mode = SessionMode.RECIPE_EXPLORING
                 session.metadata["brainstorm_ideas"] = state.get("brainstorm_ideas", [])
+                constraints = state.get("recipe_constraints")
+                if constraints:
+                    session.metadata["recipe_constraints"] = constraints
                 logger.info(
                     f"Session transition (brainstorm fallback): "
                     f"{old_mode} → recipe_exploring "

--- a/ai-service/tests/test_constraint_inheritance.py
+++ b/ai-service/tests/test_constraint_inheritance.py
@@ -1,0 +1,384 @@
+"""Issue #144: Recipe constraints must survive the brainstorm → follow-up turn boundary.
+
+When the user establishes constraints on turn 1 (e.g. "vegetarian pasta, under 30 min")
+and then selects an idea on turn 2 ("make me the first one"), the routing goes directly
+to research_recipe, bypassing extract_recipe_constraints.  Without the fix the
+constraints are silently dropped — this file covers the two-turn sequence end-to-end
+and validates every constraint that must survive.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bubbly_chef.models.recipe import RecipeConstraints
+from bubbly_chef.workflows.recipe.nodes import (
+    _merge_constraints,
+    _prior_constraints_from_state,
+    extract_recipe_constraints,
+    research_recipe,
+)
+from bubbly_chef.workflows.state import LLMRecipeResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_recipe_nodes_ai(return_value: Any) -> Any:
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value=return_value)
+    return patch(
+        "bubbly_chef.workflows.recipe.nodes.get_ai_manager",
+        MagicMock(return_value=ai),
+    )
+
+
+def _state_with_session_constraints(
+    input_text: str,
+    prior_constraints: dict[str, Any],
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build a minimal WorkflowState whose session metadata carries prior constraints."""
+    return {
+        "input_text": input_text,
+        "errors": [],
+        "warnings": [],
+        "session": {
+            "conversation_id": "conv-1",
+            "active_mode": "recipe_exploring",
+            "metadata": {"recipe_constraints": prior_constraints},
+        },
+        **extra,
+    }
+
+
+def _llm_recipe() -> LLMRecipeResult:
+    return LLMRecipeResult(
+        title="Veggie Pasta",
+        ingredients=[{"name": "pasta", "quantity": 200, "unit": "g"}],
+        instructions=["Cook pasta."],
+        confidence=0.9,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit: _merge_constraints
+# ---------------------------------------------------------------------------
+
+
+def test_merge_inherits_dietary_when_fresh_is_empty() -> None:
+    prior = {"dietary": ["vegetarian"], "cuisine": "italian"}
+    fresh: dict[str, Any] = {"dietary": [], "cuisine": None}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["dietary"] == ["vegetarian"]
+    assert merged["cuisine"] == "italian"  # also inherited (fresh is None)
+
+
+def test_merge_fresh_dietary_overrides_prior() -> None:
+    prior = {"dietary": ["vegetarian"]}
+    fresh: dict[str, Any] = {"dietary": ["vegan"]}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["dietary"] == ["vegan"]
+
+
+def test_merge_inherits_must_use_when_fresh_is_empty() -> None:
+    prior = {"must_use_ingredients": ["eggs", "spinach"]}
+    fresh: dict[str, Any] = {"must_use_ingredients": []}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["must_use_ingredients"] == ["eggs", "spinach"]
+
+
+def test_merge_fresh_must_use_overrides_prior() -> None:
+    prior = {"must_use_ingredients": ["eggs"]}
+    fresh: dict[str, Any] = {"must_use_ingredients": ["chicken"]}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["must_use_ingredients"] == ["chicken"]
+
+
+def test_merge_inherits_max_time_when_fresh_is_none() -> None:
+    prior = {"max_time_minutes": 30}
+    fresh: dict[str, Any] = {"max_time_minutes": None}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["max_time_minutes"] == 30
+
+
+def test_merge_fresh_max_time_overrides_prior() -> None:
+    prior = {"max_time_minutes": 30}
+    fresh: dict[str, Any] = {"max_time_minutes": 45}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["max_time_minutes"] == 45
+
+
+def test_merge_preserves_unmentioned_cuisine() -> None:
+    prior = {"cuisine": "italian", "dietary": ["vegetarian"]}
+    # Fresh extraction says nothing about cuisine
+    fresh: dict[str, Any] = {"cuisine": None, "dietary": []}
+    merged = _merge_constraints(prior, fresh)
+    assert merged["cuisine"] == "italian"
+    assert merged["dietary"] == ["vegetarian"]
+
+
+def test_merge_with_no_prior_returns_fresh() -> None:
+    fresh = {"dietary": ["vegan"], "cuisine": "thai", "must_use_ingredients": ["tofu"]}
+    merged = _merge_constraints({}, fresh)
+    assert merged == fresh
+
+
+# ---------------------------------------------------------------------------
+# Unit: _prior_constraints_from_state
+# ---------------------------------------------------------------------------
+
+
+def test_prior_constraints_from_state_returns_dict() -> None:
+    state = _state_with_session_constraints("hi", {"dietary": ["vegetarian"]})
+    result = _prior_constraints_from_state(state)
+    assert result == {"dietary": ["vegetarian"]}
+
+
+def test_prior_constraints_from_state_returns_none_when_no_session() -> None:
+    state = {"input_text": "hi", "session": None}
+    assert _prior_constraints_from_state(state) is None
+
+
+def test_prior_constraints_from_state_returns_none_when_no_metadata_key() -> None:
+    state = {"session": {"metadata": {}}}
+    assert _prior_constraints_from_state(state) is None
+
+
+# ---------------------------------------------------------------------------
+# extract_recipe_constraints: merges session constraints on follow-up turns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_merges_dietary_from_session_on_followup() -> None:
+    """Turn-2 extraction keeps dietary from turn 1 when user doesn't repeat it."""
+    prior = {
+        "dietary": ["vegetarian"],
+        "cuisine": "italian",
+        "must_use_ingredients": [],
+        "max_time_minutes": 30,
+    }
+    # Fresh LLM result: user just says "make me the pasta one" — no dietary mentioned
+    fresh_llm = RecipeConstraints(meal_type="dinner")
+
+    with _mock_recipe_nodes_ai(fresh_llm):
+        result = await extract_recipe_constraints(
+            _state_with_session_constraints(
+                "make me the pasta one", prior
+            )
+        )
+
+    constraints = result["recipe_constraints"]
+    assert constraints["dietary"] == ["vegetarian"], (
+        "Dietary restriction from turn 1 must survive the follow-up turn"
+    )
+    assert constraints["cuisine"] == "italian", "Cuisine must also be inherited"
+    assert constraints["max_time_minutes"] == 30, "Time limit must be inherited"
+
+
+@pytest.mark.asyncio
+async def test_extract_merges_must_use_from_session_on_followup() -> None:
+    """Turn-2 extraction keeps must_use_ingredients from turn 1."""
+    prior = {"must_use_ingredients": ["spinach", "eggs"], "dietary": []}
+
+    fresh_llm = RecipeConstraints(meal_type="lunch")
+
+    with _mock_recipe_nodes_ai(fresh_llm):
+        result = await extract_recipe_constraints(
+            _state_with_session_constraints("give me the first one", prior)
+        )
+
+    assert result["recipe_constraints"]["must_use_ingredients"] == ["spinach", "eggs"]
+
+
+@pytest.mark.asyncio
+async def test_extract_fresh_dietary_overrides_session_dietary() -> None:
+    """If the user explicitly specifies a new dietary restriction, it wins."""
+    prior = {"dietary": ["vegetarian"]}
+    fresh_llm = RecipeConstraints(meal_type="dinner", dietary=["vegan"])
+
+    with _mock_recipe_nodes_ai(fresh_llm):
+        result = await extract_recipe_constraints(
+            _state_with_session_constraints("actually make it vegan", prior)
+        )
+
+    assert result["recipe_constraints"]["dietary"] == ["vegan"]
+
+
+@pytest.mark.asyncio
+async def test_extract_without_prior_session_is_unchanged() -> None:
+    """When there is no session, behaviour is identical to the original code."""
+    fresh_llm = RecipeConstraints(meal_type="dinner", dietary=["gluten-free"])
+
+    state = {"input_text": "quick gluten-free dinner", "session": None, "errors": [], "warnings": []}
+
+    with _mock_recipe_nodes_ai(fresh_llm):
+        result = await extract_recipe_constraints(state)
+
+    assert result["recipe_constraints"]["dietary"] == ["gluten-free"]
+
+
+# ---------------------------------------------------------------------------
+# research_recipe: loads constraints from session when state has none (#144)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_research_recipe_inherits_constraints_from_session() -> None:
+    """The brainstorm follow-up path bypasses extract_recipe_constraints.
+
+    research_recipe must load constraints from the session so that
+    generate_grounded_recipe has them for cuisine tagging and must-use
+    ingredient binding.
+    """
+    prior = {
+        "dietary": ["vegetarian"],
+        "cuisine": "italian",
+        "must_use_ingredients": ["spinach"],
+        "max_time_minutes": 30,
+    }
+    state = _state_with_session_constraints(
+        "make me the first one",
+        prior,
+        selected_recipe_name="Spinach Pasta",
+        # No recipe_constraints in state — this is the bug scenario
+    )
+
+    with patch(
+        "bubbly_chef.workflows.recipe.nodes.search_recipe",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await research_recipe(state)
+
+    # Constraints must now be present on the state for generate_grounded_recipe
+    constraints = result.get("recipe_constraints") or {}
+    assert constraints.get("dietary") == ["vegetarian"], (
+        "Dietary restriction must be loaded from session on the brainstorm follow-up path"
+    )
+    assert constraints.get("cuisine") == "italian"
+    assert constraints.get("must_use_ingredients") == ["spinach"]
+    assert constraints.get("max_time_minutes") == 30
+
+
+@pytest.mark.asyncio
+async def test_research_recipe_keeps_existing_constraints_when_present() -> None:
+    """If constraints are already on the state (non-brainstorm path), keep them."""
+    existing = {"dietary": ["vegan"], "cuisine": "thai"}
+    session_prior = {"dietary": ["vegetarian"], "cuisine": "italian"}
+
+    state = {
+        "input_text": "Pad Thai",
+        "selected_recipe_name": "Pad Thai",
+        "recipe_constraints": existing,
+        "session": {
+            "metadata": {"recipe_constraints": session_prior},
+        },
+        "errors": [],
+        "warnings": [],
+    }
+
+    with patch(
+        "bubbly_chef.workflows.recipe.nodes.search_recipe",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await research_recipe(state)
+
+    # Existing constraints win — session prior must NOT overwrite them
+    assert result["recipe_constraints"]["dietary"] == ["vegan"]
+    assert result["recipe_constraints"]["cuisine"] == "thai"
+
+
+@pytest.mark.asyncio
+async def test_research_recipe_without_session_works_normally() -> None:
+    """No session → constraints stay empty, no crash."""
+    state = {
+        "input_text": "make me pasta",
+        "selected_recipe_name": "Pasta",
+        "session": None,
+        "errors": [],
+        "warnings": [],
+    }
+
+    with patch(
+        "bubbly_chef.workflows.recipe.nodes.search_recipe",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await research_recipe(state)
+
+    # No session → empty constraints, no crash
+    assert result.get("recipe_constraints") == {}
+
+
+# ---------------------------------------------------------------------------
+# End-to-end two-turn simulation: constraint set turn 1 → idea selected turn 2
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_turn_constraint_inheritance_end_to_end() -> None:
+    """Simulate the full two-turn sequence described in issue #144.
+
+    Turn 1: User asks for a vegetarian pasta recipe (brainstorm) — constraints
+            are extracted and persisted to session metadata via update_session_node.
+    Turn 2: User selects an idea ("make me the first one") — routing bypasses
+            extract_recipe_constraints and goes straight to research_recipe.
+            Constraints must still reach generate_grounded_recipe.
+
+    This test exercises research_recipe (the node that runs on turn 2) and verifies
+    that the constraints from turn 1 are present in state when it returns, ready
+    for generate_grounded_recipe to consume.
+    """
+    # --- Simulate what update_session_node would have stored after turn 1 ---
+    turn1_constraints = {
+        "dietary": ["vegetarian"],
+        "cuisine": "italian",
+        "must_use_ingredients": [],
+        "max_time_minutes": 30,
+        "meal_type": "dinner",
+        "mood": None,
+        "servings": None,
+        "skill_level": None,
+        "preferred_ingredients": [],
+        "excluded_ingredients": [],
+    }
+
+    # --- Turn 2 state: brainstorm follow-up, no recipe_constraints in state ---
+    turn2_state = {
+        "input_text": "make me the first one",
+        "selected_recipe_name": "Spinach and Ricotta Pasta",
+        # recipe_constraints is absent — this is the pre-fix bug state
+        "session": {
+            "conversation_id": "conv-1",
+            "active_mode": "recipe_exploring",
+            "metadata": {"recipe_constraints": turn1_constraints},
+        },
+        "errors": [],
+        "warnings": [],
+    }
+
+    with patch(
+        "bubbly_chef.workflows.recipe.nodes.search_recipe",
+        new_callable=AsyncMock,
+        return_value=None,
+    ):
+        result = await research_recipe(turn2_state)
+
+    constraints = result.get("recipe_constraints") or {}
+
+    # Core regression assertions
+    assert "vegetarian" in (constraints.get("dietary") or []), (
+        "#144: Dietary restriction from turn 1 must not be dropped on turn 2"
+    )
+    assert constraints.get("cuisine") == "italian", (
+        "#144: Cuisine from turn 1 must not be dropped on turn 2"
+    )
+    assert constraints.get("max_time_minutes") == 30, (
+        "#144: Time constraint from turn 1 must not be dropped on turn 2"
+    )


### PR DESCRIPTION
## Summary

Fixes #144 — recipe constraints were silently dropped when a user picked an idea from a brainstorm list on the follow-up turn ("make me the first one"). That path routes `classify_intent → research_recipe`, bypassing `extract_recipe_constraints`, so cuisine, dietary restrictions, time limits, and `must_use_ingredients` established on the prior turn were all discarded. Dropping dietary restrictions on turn two is a correctness bug, not just a quality one.

## What lands

- **Inherit + merge semantics** for `RecipeConstraints` across turns (`workflows/recipe/nodes.py`):
  - `_merge_constraints(prior, fresh)` — scalars: fresh non-empty value wins, else inherit; lists (`dietary`, `must_use_ingredients`, preferred/excluded): fresh non-empty list replaces, else the prior list survives. Supports "actually make it vegetarian" on turn two while preserving everything else.
  - `research_recipe` now rehydrates prior constraints from the session when they're absent from state (the brainstorm-follow-up path), and always passes `recipe_constraints` downstream so generation is never handed an empty dict.
- **Write side** (`workflows/router.py`): `update_session_node` persists `recipe_constraints` into the session's existing `metadata` JSONB on recipe-exploring transitions, so turn two can read them back.

No DB migration — constraints live in the `conversation_sessions.metadata` column that already exists.

## Tests

- New `tests/test_constraint_inheritance.py` (19 tests): merge unit cases, state-reader guards, async `extract_recipe_constraints` / `research_recipe` behavior, and a two-turn end-to-end simulation that reproduces the reported bug and asserts dietary + cuisine + time all survive the handoff.
- Full suite green: **170 passed, 10 skipped**, `ruff check` clean.

## Linked

Closes #144. Also lets the stale `CLAUDE.md` "Known Limitations" line (constraint modifications ignored on chat follow-up) be removed once merged.

## Out of scope

- Appending/union of constraints across turns (current semantics are replace-or-inherit per field, which matches the issue's decision).
- The broader recipe-generation quality work; this only fixes constraint propagation.
