### PR TITLE
fix: resolve 4 eslint errors (quote escapes, unused var, 2 set-state-in-effect) (#149)

### DIFF
--- a/nextjs/src/components/chat/RotatingPlaceholder.tsx
+++ b/nextjs/src/components/chat/RotatingPlaceholder.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useSyncExternalStore } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 
 const PROMPTS = [
@@ -22,17 +22,27 @@ interface RotatingPlaceholderProps {
   visible: boolean
 }
 
+function subscribeReducedMotion(callback: () => void): () => void {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+  mq.addEventListener('change', callback)
+  return () => mq.removeEventListener('change', callback)
+}
+
+function getReducedMotionSnapshot(): boolean {
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+function getReducedMotionServerSnapshot(): boolean {
+  return false
+}
+
 export default function RotatingPlaceholder({ visible }: RotatingPlaceholderProps) {
   const [index, setIndex] = useState(0)
-  const [reducedMotion, setReducedMotion] = useState(false)
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
-    setReducedMotion(mq.matches)
-    const handler = (e: MediaQueryListEvent) => setReducedMotion(e.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, [])
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  )
 
   useEffect(() => {
     if (!visible || reducedMotion) return

--- a/nextjs/src/components/pantry/PantryAddSheet.tsx
+++ b/nextjs/src/components/pantry/PantryAddSheet.tsx
@@ -65,7 +65,11 @@ export default function PantryAddSheet({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          items: allItems.map(({ source: _source, ...item }) => item),
+          items: allItems.map((item) => {
+            const { source, ...rest } = item
+            void source
+            return rest
+          }),
         }),
       })
 

--- a/nextjs/src/components/recipes/RecipeBookLoader.tsx
+++ b/nextjs/src/components/recipes/RecipeBookLoader.tsx
@@ -10,7 +10,6 @@ export default function RecipeBookLoader() {
   const [refreshKey, setRefreshKey] = useState(0)
 
   useEffect(() => {
-    setLoading(true)
     fetch('/api/recipes')
       .then((r) => r.json())
       .then((data) => {
@@ -33,5 +32,5 @@ export default function RecipeBookLoader() {
     )
   }
 
-  return <RecipeBook recipes={recipes} onMutate={() => setRefreshKey(k => k + 1)} />
+  return <RecipeBook recipes={recipes} onMutate={() => { setLoading(true); setRefreshKey(k => k + 1) }} />
 }

--- a/nextjs/src/components/recipes/RecipeRefinementModal.tsx
+++ b/nextjs/src/components/recipes/RecipeRefinementModal.tsx
@@ -249,7 +249,7 @@ export default function RecipeRefinementModal({
                   className="text-sm text-center py-4"
                   style={{ color: 'var(--color-muted)', fontFamily: 'Nunito, sans-serif' }}
                 >
-                  Type a refinement below — e.g. "make it vegetarian" or "reduce cook time"
+                  Type a refinement below — e.g. &ldquo;make it vegetarian&rdquo; or &ldquo;reduce cook time&rdquo;
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary

Partial fix for #149 — resolves 4 of the eslint errors that were safe to fix without behavior risk. The issue's original "8 errors across 5 files" count had drifted; the accurate current state and the two deliberately-deferred errors are documented on the issue.

## What lands

- **`RecipeRefinementModal.tsx`** — escape straight quotes with `&ldquo;`/`&rdquo;` (`react/no-unescaped-entities`).
- **`PantryAddSheet.tsx`** — replace the unused `_source` destructure binding with an explicit key strip (`@typescript-eslint/no-unused-vars`).
- **`RotatingPlaceholder.tsx`** — migrate the `matchMedia` read from a `useState` + synchronous-`setState`-in-effect pattern to `useSyncExternalStore` (`react-hooks/set-state-in-effect`). SSR-safe; reduced-motion preference is still read on mount and updates live.
- **`RecipeBookLoader.tsx`** — initialize `loading` to `true` and move the refresh-path `setLoading(true)` into the `onMutate` event handler, out of the effect body. The parent/child `refreshKey` + `onMutate` contract is unchanged.

## Tests

- `npx eslint` on all four files: **0 errors, 0 warnings**.
- `npx tsc --noEmit`: no new errors (only the 5 pre-existing e2e/playwright module-resolution errors remain, unrelated to this change).

## Linked

Partial for #149 (kept open). Two `set-state-in-effect` errors remain and are deferred deliberately because they carry behavior risk — `ThemeProvider.tsx` (documented hydration-mismatch avoidance) and `pantry/page.tsx` (reacts to live `?add=` deep-link param). Both want their own change with a visual/deep-link check. The `RecipeBook.tsx` `<img>` → `next/image` warning is also out of scope (LCP/layout change, not a lint tidy).

## Out of scope

- The 2 deferred `set-state-in-effect` refactors and the `<img>` warning above.
