### PR TITLE
fix: add visible focus indicators across all interactive elements (#147)

### DIFF
--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -403,7 +403,7 @@ function ChatSurface() {
             // button is replaced by Stop below — so typing cannot interleave two
             // requests.
             aria-label="Message Bubbles"
-            className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] text-sm"
+            className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] focus:border-[var(--color-accent)] text-sm"
           />
           {/* Placeholder hides once anything is typed; no longer tied to streaming,
               since the field is now usable mid-stream. */}

--- a/nextjs/src/app/globals.css
+++ b/nextjs/src/app/globals.css
@@ -145,6 +145,54 @@
   }
 }
 
+/*
+ * Global focus-visible treatment (WCAG 2.4.7)
+ *
+ * Applied to ALL interactive elements via the universal selector so new
+ * components get correct focus handling by default without any extra class.
+ * :focus-visible fires only for keyboard / programmatic focus — mouse clicks
+ * do NOT trigger it — so the ring is never shown for pointer interactions.
+ *
+ * --focus-ring uses --color-text (rather than a primary hue) to guarantee
+ * legibility across all five themes:
+ *
+ *   sakura   —  #5C4A5A on #FFF0F5  ≈ 7 : 1  ✓
+ *   mint     —  #3A5C4A on #F0FBF5  ≈ 8 : 1  ✓
+ *   lavender —  #4A3A5C on #F5F0FF  ≈ 8 : 1  ✓
+ *   yuzu     —  #5C4A3A on #FFFBF0  ≈ 8 : 1  ✓
+ *   bluebell —  #3A4A5C on #F0F5FF  ≈ 8 : 1  ✓
+ *
+ * The amber yuzu primary (#FFB830) would fail against near-white (~1.8 : 1)
+ * so it is deliberately excluded.  --color-text is dark on every theme's
+ * near-white background, giving a comfortable ≥ 7 : 1 ratio.
+ *
+ * The 2 px transparent offset creates a two-tone "white gap + dark ring"
+ * effect — visible but soft — while meeting WCAG 2.4.7 Non-text Contrast.
+ */
+*:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: 2px;
+  border-radius: inherit; /* follow the element's own corner radius */
+}
+
+/*
+ * Inset variant — for interactive elements inside overflow:hidden containers
+ * (pantry cards, recipe modals).  A positive outline-offset is clipped by the
+ * parent; negative offset draws the ring inside the border box instead.
+ *
+ * Usage: add class="focus-ring-inset" to the element (not the container).
+ *
+ * The pantry card buttons already set focus-visible:outline-offset-[-2px]
+ * via Tailwind utilities (which override the global offset via specificity).
+ * This utility centralises the same pattern for future overflow-clipping
+ * containers where adding Tailwind utilities would be verbose.
+ */
+.focus-ring-inset:focus-visible {
+  outline: 2px solid var(--color-text);
+  outline-offset: -3px;
+  border-radius: inherit;
+}
+
 /* Chowder-style textile/fabric panel — subtle woven crosshatch texture */
 .chowder-panel {
   background-color: var(--color-primary);

--- a/nextjs/src/app/login/page.tsx
+++ b/nextjs/src/app/login/page.tsx
@@ -77,7 +77,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
                 required
-                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
+                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
                 placeholder="you@email.com"
               />
             </div>
@@ -93,7 +93,7 @@ export default function LoginPage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:outline-none focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
+                className="w-full px-4 py-3 rounded-2xl border border-[var(--color-border)] bg-white text-[var(--color-text)] focus:border-[var(--color-accent)] transition-colors placeholder:text-[var(--color-muted)]"
                 placeholder="Min 6 characters"
               />
             </div>

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -196,7 +196,7 @@ function PantryPageInner() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search items..."
-          className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)] placeholder:text-[var(--color-muted)]"
+          className="w-full rounded-full px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)] placeholder:text-[var(--color-muted)]"
         />
       </div>
 

--- a/nextjs/src/components/pantry/AddItemModal.tsx
+++ b/nextjs/src/components/pantry/AddItemModal.tsx
@@ -207,7 +207,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                   onFocus={() => suggestions.length > 0 && setShowSuggestions(true)}
                   onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
                   placeholder="e.g., Milk, Eggs, Rice..."
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 />
                 {showSuggestions && suggestions.length > 0 && (
                   <div className="absolute left-0 right-0 top-full mt-1 bg-white border border-[var(--color-border)] rounded-xl shadow-lg z-10 overflow-hidden">
@@ -238,7 +238,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                     step="any"
                     value={quantity}
                     onChange={(e) => setQuantity(Number(e.target.value))}
-                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                   />
                 </div>
                 <div className="flex-1">
@@ -248,7 +248,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                     value={unit}
                     onChange={(e) => setUnit(e.target.value)}
                     list="unit-suggestions"
-                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                    className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                   />
                   <datalist id="unit-suggestions">
                     {UNIT_SUGGESTIONS.map((u) => (
@@ -264,7 +264,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                 <select
                   value={category}
                   onChange={(e) => setCategory(e.target.value)}
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 >
                   {CATEGORIES.map((c) => (
                     <option key={c.value} value={c.value}>{c.label}</option>
@@ -300,7 +300,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                   type="date"
                   value={expiryDate}
                   onChange={(e) => setExpiryDate(e.target.value)}
-                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+                  className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 />
               </div>
 

--- a/nextjs/src/components/pantry/AddItemRow.tsx
+++ b/nextjs/src/components/pantry/AddItemRow.tsx
@@ -39,7 +39,7 @@ interface AddItemRowProps {
 }
 
 const inputClass =
-  'w-full rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]'
+  'w-full rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]'
 
 export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRowProps) {
   const set = (field: keyof ManualRow, value: string | number) =>
@@ -78,13 +78,13 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
           step="any"
           value={row.quantity}
           onChange={(e) => set('quantity', Number(e.target.value))}
-          className="w-20 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="w-20 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Quantity"
         />
         <select
           value={row.unit}
           onChange={(e) => set('unit', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Unit"
         >
           {UNITS.map((u) => (
@@ -98,7 +98,7 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
         <select
           value={row.category}
           onChange={(e) => set('category', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Category"
         >
           {CATEGORIES.map((c) => (
@@ -108,7 +108,7 @@ export default function AddItemRow({ row, onChange, onRemove, index }: AddItemRo
         <select
           value={row.storage_location}
           onChange={(e) => set('storage_location', e.target.value)}
-          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:outline-none focus:border-[var(--color-primary)]"
+          className="flex-1 rounded-xl px-3 py-2 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
           aria-label="Storage location"
         >
           {LOCATIONS.map((l) => (

--- a/nextjs/src/components/recipes/RecipeEditModal.tsx
+++ b/nextjs/src/components/recipes/RecipeEditModal.tsx
@@ -124,7 +124,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)]"
+                className="w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -146,7 +146,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none resize-none border focus:border-[var(--color-primary)]"
+                className="w-full rounded-xl px-4 py-2.5 text-sm resize-none border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -169,7 +169,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
                 placeholder="comma-separated"
-                className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)]"
+                className="w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)]"
                 style={{
                   background: 'var(--color-bg)',
                   border: '1.5px solid var(--color-border)',
@@ -194,7 +194,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                       type="text"
                       value={item}
                       onChange={(e) => updateItem(setIngredients, i, e.target.value)}
-                      className="flex-1 rounded-xl px-3 py-2 text-sm outline-none border focus:border-[var(--color-primary)]"
+                      className="flex-1 rounded-xl px-3 py-2 text-sm border focus:border-[var(--color-primary)]"
                       style={{
                         background: 'var(--color-bg)',
                         border: '1.5px solid var(--color-border)',
@@ -243,7 +243,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
                       value={step}
                       onChange={(e) => updateItem(setInstructions, i, e.target.value)}
                       rows={2}
-                      className="flex-1 rounded-xl px-3 py-2 text-sm outline-none resize-none border focus:border-[var(--color-primary)]"
+                      className="flex-1 rounded-xl px-3 py-2 text-sm resize-none border focus:border-[var(--color-primary)]"
                       style={{
                         background: 'var(--color-bg)',
                         border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -176,7 +176,7 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
               placeholder="https://www.allrecipes.com/recipe/..."
               disabled={state === 'loading'}
               autoFocus
-              className="w-full rounded-xl px-4 py-2.5 text-sm outline-none border focus:border-[var(--color-primary)] disabled:opacity-50"
+              className="w-full rounded-xl px-4 py-2.5 text-sm border focus:border-[var(--color-primary)] disabled:opacity-50"
               style={{
                 background: 'var(--color-bg)',
                 border: `1.5px solid ${state === 'error' ? 'var(--color-coral)' : 'var(--color-border)'}`,

--- a/nextjs/src/components/recipes/RecipeRefinementModal.tsx
+++ b/nextjs/src/components/recipes/RecipeRefinementModal.tsx
@@ -293,7 +293,7 @@ export default function RecipeRefinementModal({
                   onKeyDown={handleKeyDown}
                   placeholder="e.g. make it vegan, less spicy..."
                   disabled={refining}
-                  className="flex-1 rounded-full px-4 py-2.5 text-sm outline-none disabled:opacity-50"
+                  className="flex-1 rounded-full px-4 py-2.5 text-sm disabled:opacity-50"
                   style={{
                     background: 'var(--color-bg)',
                     border: '1.5px solid var(--color-border)',

--- a/nextjs/src/components/recipes/RecipeSearchBar.tsx
+++ b/nextjs/src/components/recipes/RecipeSearchBar.tsx
@@ -29,7 +29,7 @@ export default function RecipeSearchBar({ onSearch }: RecipeSearchBarProps) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="Search your recipes..."
-        className="w-full py-2.5 pl-4 pr-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-colors text-sm font-[Nunito,sans-serif]"
+        className="w-full py-2.5 pl-4 pr-10 rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] placeholder:text-[var(--color-muted)] focus:border-[var(--color-accent)] transition-colors text-sm font-[Nunito,sans-serif]"
       />
 
       <AnimatePresence mode="wait">

--- a/nextjs/src/components/scan/ScannedItemCard.tsx
+++ b/nextjs/src/components/scan/ScannedItemCard.tsx
@@ -80,7 +80,7 @@ export default function ScannedItemCard({
           aria-label="Item name"
           value={item.name}
           onChange={(e) => update('name', e.target.value)}
-          className="flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] outline-none pb-1 transition-colors"
+          className="flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] pb-1 transition-colors"
           placeholder="Item name"
         />
       </div>
@@ -96,7 +96,7 @@ export default function ScannedItemCard({
             min={0}
             step={0.1}
             onChange={(e) => update('quantity', parseFloat(e.target.value) || 0)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           />
         </div>
         <div className="flex-1">
@@ -106,7 +106,7 @@ export default function ScannedItemCard({
             aria-label="Unit"
             value={item.unit}
             onChange={(e) => update('unit', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
             placeholder="pcs, g, ml…"
           />
         </div>
@@ -120,7 +120,7 @@ export default function ScannedItemCard({
             aria-label="Category"
             value={item.category}
             onChange={(e) => update('category', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           >
             {CATEGORIES.map((c) => (
               <option key={c} value={c}>
@@ -135,7 +135,7 @@ export default function ScannedItemCard({
             aria-label="Location"
             value={item.location}
             onChange={(e) => update('location', e.target.value)}
-            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:outline-none focus:border-[var(--color-primary)] transition-colors"
+            className="w-full text-sm text-[var(--color-text)] bg-[var(--color-bg,#FFF0F5)] border border-[var(--color-border)] rounded-xl px-2 py-1.5 focus:border-[var(--color-primary)] transition-colors"
           >
             {LOCATIONS.map((l) => (
               <option key={l} value={l}>


### PR DESCRIPTION
## Summary

Fixes #147 — the app had no `focus-visible` treatment anywhere, and the house input style (`focus:outline-none focus:border-...`) removed the browser default without an adequate replacement. Keyboard users couldn't see where they were (WCAG 2.4.7, Level AA).

## What lands

- **One design-system rule** in `globals.css`: a global `*:focus-visible` outline (`2px solid var(--color-text)`, `outline-offset: 2px`, `border-radius: inherit`). Using `--color-text` gives a ~7–8:1 ring against every theme's near-white surface — deliberately not `--color-primary`, whose yuzu amber (`#FFB830`) reads at only ~1.8:1.
- **`.focus-ring-inset`** utility (`outline-offset: -3px`) for `overflow-hidden` containers that would clip an outward ring. The existing pantry-card button/link keep their hand-authored inset utilities (higher specificity than `*`), so they're unchanged.
- **11 files de-suppressed**: removed bare `outline-none` / `focus:outline-none` from RecipeSearchBar, AddItemRow, AddItemModal, ScannedItemCard, RecipeEditModal, RecipeImportModal, RecipeRefinementModal, login, chat, and pantry inputs. The supplemental `focus:border-[var(--color-accent)]` accents are kept; the ring is now the primary affordance.
- `:focus-visible` (not `:focus`) so mouse clicks don't draw rings.

## Tests

- `npx tsc --noEmit`: clean (only the 5 pre-existing e2e/playwright module-resolution errors remain).
- `npx eslint` on all changed files: no new findings. Verified the pre-existing `set-state-in-effect` / unescaped-quote errors are untouched by this change.
- Manual: Tab through login → dashboard → pantry → chat → recipes on all five themes; ring visible at every stop (yuzu especially — dark ring, not invisible amber), no clipping on pantry cards.

## Linked

Closes #147. #10 was already folded into this issue as a duplicate.

## Out of scope

- The 2 remaining `set-state-in-effect` eslint errors and the `<img>` warning (tracked under #149).
- ARIA-label / keyboard-trap work beyond focus visibility.

## Note for merge

Touches `RecipeRefinementModal.tsx` and `pantry/page.tsx`, which #149 (PR #166) also edits on different lines. Whichever merges second may need a trivial rebase — no logical conflict.
