### PR TITLE
feat: dev SAP-proxy AI provider + brainstorm follow-up fix + clickable recipe cards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ NEXT_PUBLIC_AI_SERVICE_URL=http://localhost:8888   # → Railway URL in producti
 # =============================================================================
 
 BUBBLY_SUPABASE_URL=https://your-project.supabase.co
-BUBBLY_SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+BUBBLY_SUPABASE_SECRET_KEY=your-service-role-key
 BUBBLY_SUPABASE_JWT_SECRET=your-jwt-secret
 
 BUBBLY_GEMINI_API_KEY=your-gemini-api-key
@@ -26,6 +26,13 @@ BUBBLY_GEMINI_MODEL=gemini-2.5-flash
 
 BUBBLY_OLLAMA_BASE_URL=http://localhost:11434   # optional
 BUBBLY_OLLAMA_MODEL=llama3.2:3b                 # optional
+
+# dev only — routes LLM calls through local SAP proxy; leave false in prod
+BUBBLY_ANTHROPIC_BASE_URL=http://localhost:6655/anthropic
+BUBBLY_ANTHROPIC_API_KEY=                        # leave blank for SAP proxy (no key needed)
+BUBBLY_ANTHROPIC_MODEL=anthropic--claude-4.6-sonnet
+BUBBLY_ANTHROPIC_MAX_TOKENS=4096
+BUBBLY_USE_ANTHROPIC_PROXY=false
 
 BUBBLY_CORS_ORIGINS=["http://localhost:3000"]   # → add Vercel URL in production
 
@@ -38,5 +45,5 @@ BUBBLY_REVIEW_CONFIDENCE_THRESHOLD=0.5
 # supabase.com → your project → Settings → API:
 #   Project URL        → NEXT_PUBLIC_SUPABASE_URL / BUBBLY_SUPABASE_URL
 #   anon key           → NEXT_PUBLIC_SUPABASE_ANON_KEY
-#   service_role key   → SUPABASE_SERVICE_ROLE_KEY / BUBBLY_SUPABASE_SERVICE_ROLE_KEY
+#   service_role key   → SUPABASE_SERVICE_ROLE_KEY / BUBBLY_SUPABASE_SECRET_KEY
 #   JWT Secret         → BUBBLY_SUPABASE_JWT_SECRET (under JWT Settings)

--- a/ai-service/bubbly_chef/ai/__init__.py
+++ b/ai-service/bubbly_chef/ai/__init__.py
@@ -2,9 +2,10 @@
 """
 AI provider abstraction layer.
 
-Supports multiple providers (Gemini, Ollama) with automatic fallback.
+Supports multiple providers (Gemini, Ollama, Anthropic/SAP proxy) with automatic fallback.
 """
 
+from .anthropic import AnthropicProvider
 from .gemini import GeminiProvider
 from .manager import AIManager, NoProviderAvailableError
 from .ollama import OllamaProvider
@@ -20,6 +21,7 @@ __all__ = [
     "AIManager",
     "NoProviderAvailableError",
     # Providers
+    "AnthropicProvider",
     "GeminiProvider",
     "OllamaProvider",
 ]

--- a/ai-service/bubbly_chef/ai/anthropic.py
+++ b/ai-service/bubbly_chef/ai/anthropic.py
@@ -1,0 +1,331 @@
+# Anthropic AI Provider (SAP proxy / dev only)
+"""
+Anthropic Messages API provider, designed for the SAP proxy at
+http://localhost:6655/anthropic/ (no API key) or direct Anthropic endpoints.
+
+IMPORTANT: This provider is dev-only and is only activated when
+BUBBLY_USE_ANTHROPIC_PROXY=true.  Do NOT enable it in production.
+"""
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any, TypeVar
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+class AnthropicProvider(AIProvider):
+    """Anthropic Messages API provider (SAP proxy or direct)."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str = "",
+        model: str = "anthropic--claude-4.6-sonnet",
+        max_tokens: int = 4096,
+        timeout: float = 60.0,
+    ) -> None:
+        """
+        Initialize AnthropicProvider.
+
+        Args:
+            base_url: Base URL of the proxy or Anthropic endpoint
+                      (trailing slash stripped automatically).
+            api_key: Optional API key — omit for the SAP proxy (no key needed).
+            model: Anthropic/proxy model ID.
+            max_tokens: Maximum tokens to generate (required by Anthropic API).
+            timeout: Request timeout in seconds.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.model = model
+        self.max_tokens = max_tokens
+        self.timeout = timeout
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    @property
+    def name(self) -> str:
+        return f"anthropic/{self.model}"
+
+    def _headers(self) -> dict[str, str]:
+        """Build request headers, including x-api-key only when configured."""
+        headers = {
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+        return headers
+
+    def _build_prompt(
+        self, prompt: str, response_schema: type[T] | None
+    ) -> str:
+        """Append JSON-schema instruction when structured output is requested."""
+        if not response_schema:
+            return prompt
+        schema_json = json.dumps(response_schema.model_json_schema(), indent=2)
+        return f"""{prompt}
+
+Respond with valid JSON matching this schema:
+```json
+{schema_json}
+```
+
+Return ONLY the JSON, no markdown formatting or extra text."""
+
+    @staticmethod
+    def _strip_fences(text: str) -> str:
+        """Remove ```json / ``` fences from the response text."""
+        cleaned = text.strip()
+        if cleaned.startswith("```json"):
+            cleaned = cleaned[7:]
+        if cleaned.startswith("```"):
+            cleaned = cleaned[3:]
+        if cleaned.endswith("```"):
+            cleaned = cleaned[:-3]
+        return cleaned.strip()
+
+    def _parse_structured(self, text: str, response_schema: type[T]) -> T:
+        """Parse fence-stripped text into the given Pydantic schema."""
+        cleaned = self._strip_fences(text)
+        try:
+            parsed = json.loads(cleaned)
+            result: T = response_schema.model_validate(parsed)
+            return result
+        except json.JSONDecodeError as e:
+            raise StructuredOutputError(f"Failed to parse JSON: {text}") from e
+        except ValidationError as e:
+            raise StructuredOutputError(f"Schema validation failed: {e}") from e
+
+    def _extract_text(self, data: dict[str, Any]) -> str:
+        """Extract the text payload from an Anthropic Messages API response."""
+        try:
+            return str(data["content"][0]["text"])
+        except (KeyError, IndexError) as e:
+            raise StructuredOutputError(
+                f"Unexpected Anthropic response format: {data}"
+            ) from e
+
+    async def complete(
+        self,
+        prompt: str,
+        response_schema: type[T] | None = None,
+        temperature: float = 0.7,
+    ) -> T | str:
+        """Generate a completion using the Anthropic Messages API."""
+        url = f"{self.base_url}/v1/messages"
+        full_prompt = self._build_prompt(prompt, response_schema)
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "temperature": temperature,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": full_prompt}],
+                }
+            ],
+        }
+
+        try:
+            response = await self._client.post(
+                url, json=payload, headers=self._headers()
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if hasattr(e.response, "text") else str(e)
+            if e.response.status_code == 429:
+                raise ProviderUnavailableError(
+                    f"Anthropic [{self.model}] rate limit 429: {error_body}"
+                ) from e
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] API error {e.response.status_code}: {error_body}"
+            ) from e
+        except httpx.RequestError as e:
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] connection error: {e}"
+            ) from e
+
+        data = response.json()
+        text = self._extract_text(data)
+
+        if not response_schema:
+            return str(text)
+
+        return self._parse_structured(text, response_schema)
+
+    @property
+    def supports_vision(self) -> bool:
+        return True
+
+    async def vision_complete(
+        self,
+        prompt: str,
+        image_bytes: bytes,
+        mime_type: str = "image/jpeg",
+        response_schema: type[T] | None = None,
+        temperature: float = 0.3,
+    ) -> T | str:
+        """Generate a completion from an image + text prompt."""
+        import base64
+
+        url = f"{self.base_url}/v1/messages"
+        full_prompt = self._build_prompt(prompt, response_schema)
+        b64 = base64.b64encode(image_bytes).decode("utf-8")
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "temperature": temperature,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": mime_type,
+                                "data": b64,
+                            },
+                        },
+                        {"type": "text", "text": full_prompt},
+                    ],
+                }
+            ],
+        }
+
+        try:
+            response = await self._client.post(
+                url, json=payload, headers=self._headers()
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if hasattr(e.response, "text") else str(e)
+            if e.response.status_code == 429:
+                raise ProviderUnavailableError(
+                    f"Anthropic [{self.model}] vision rate limit 429: {error_body}"
+                ) from e
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] vision API error {e.response.status_code}: "
+                f"{error_body}"
+            ) from e
+        except httpx.RequestError as e:
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] vision connection error: {e}"
+            ) from e
+
+        data = response.json()
+        text = self._extract_text(data)
+
+        if not response_schema:
+            return str(text)
+
+        return self._parse_structured(text, response_schema)
+
+    async def stream_complete(
+        self,
+        prompt: str,
+        temperature: float = 0.7,
+    ) -> AsyncIterator[str]:
+        """Stream tokens using Anthropic SSE (content_block_delta events)."""
+        url = f"{self.base_url}/v1/messages"
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "temperature": temperature,
+            "stream": True,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": prompt}],
+                }
+            ],
+        }
+
+        try:
+            async with self._client.stream(
+                "POST", url, json=payload, headers=self._headers()
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line.startswith("data: "):
+                        continue
+                    json_str = line[6:]  # strip 'data: ' prefix
+                    if not json_str.strip():
+                        continue
+                    try:
+                        chunk = json.loads(json_str)
+                        if chunk.get("type") == "content_block_delta":
+                            delta_text = chunk.get("delta", {}).get("text", "")
+                            if delta_text:
+                                yield delta_text
+                    except (json.JSONDecodeError, KeyError):
+                        continue
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 429:
+                error_body = e.response.text[:500] if hasattr(e.response, "text") else str(e)
+                logger.warning(
+                    f"Anthropic [{self.model}] stream hit 429 rate limit, cascading: "
+                    f"{error_body[:200]}"
+                )
+                raise ProviderUnavailableError(
+                    f"Anthropic stream rate limit exceeded: {error_body}"
+                ) from e
+            # Non-429 HTTP errors: fall back to non-streaming
+            logger.warning(
+                f"Anthropic [{self.model}] stream failed "
+                f"(status={e.response.status_code}), falling back to non-streaming"
+            )
+            result = await self.complete(prompt=prompt, temperature=temperature)
+            text = result if isinstance(result, str) else str(result)
+            yield text
+        except httpx.RequestError as e:
+            logger.warning(
+                f"Anthropic [{self.model}] stream connection error, "
+                f"falling back to non-streaming: {e}"
+            )
+            result = await self.complete(prompt=prompt, temperature=temperature)
+            text = result if isinstance(result, str) else str(result)
+            yield text
+
+    async def is_available(self) -> bool:
+        """Check if the proxy/endpoint is reachable.
+
+        Returns True if the host responds at all (any HTTP status or 200/429),
+        False only on httpx.RequestError (unreachable host).  This mirrors
+        GeminiProvider.is_available() semantics so the manager cascade works.
+        """
+        try:
+            response = await self._client.get(
+                self.base_url,
+                headers=self._headers(),
+                follow_redirects=True,
+            )
+            # Any HTTP response (even 404) means the host is up
+            _ = response.status_code
+            if response.status_code == 429:
+                logger.info(
+                    f"Anthropic [{self.model}] availability check got 429 "
+                    "(rate-limited), treating as available for cascade"
+                )
+            return True
+        except httpx.RequestError as e:
+            logger.warning(
+                f"Anthropic [{self.model}] availability check connection error: {e}"
+            )
+            return False
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()

--- a/ai-service/bubbly_chef/api/deps.py
+++ b/ai-service/bubbly_chef/api/deps.py
@@ -16,10 +16,29 @@ def get_ai_manager() -> AIManager:
     if _ai_manager is not None:
         return _ai_manager
 
+    manager = AIManager()
+
+    # Dev-only: route all LLM calls through the local SAP proxy.
+    # When this flag is set, only AnthropicProvider is registered (no Gemini/Ollama).
+    if settings.use_anthropic_proxy:
+        from bubbly_chef.ai.anthropic import AnthropicProvider
+
+        provider = AnthropicProvider(
+            base_url=settings.anthropic_base_url,
+            api_key=settings.anthropic_api_key,
+            model=settings.anthropic_model,
+            max_tokens=settings.anthropic_max_tokens,
+        )
+        manager.add_provider(provider)
+        logger.info(
+            f"Registered Anthropic/SAP-proxy provider (model={settings.anthropic_model}, "
+            f"base_url={settings.anthropic_base_url})"
+        )
+        _ai_manager = manager
+        return _ai_manager
+
     from bubbly_chef.ai.gemini import GeminiProvider
     from bubbly_chef.ai.ollama import OllamaProvider
-
-    manager = AIManager()
 
     if settings.gemini_api_key:
         manager.add_provider(

--- a/ai-service/bubbly_chef/config.py
+++ b/ai-service/bubbly_chef/config.py
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     ollama_timeout_seconds: int = 120
     ollama_max_retries: int = 2
 
+    # Anthropic / SAP proxy (dev only — leave use_anthropic_proxy=false in prod/CI)
+    anthropic_base_url: str = "http://localhost:6655/anthropic"
+    anthropic_api_key: str = ""
+    anthropic_model: str = "anthropic--claude-4.6-sonnet"
+    anthropic_max_tokens: int = 4096
+    use_anthropic_proxy: bool = False
+
     # CORS
     cors_origins: list[str] = ["http://localhost:3000", "capacitor://localhost"]
 

--- a/ai-service/bubbly_chef/main.py
+++ b/ai-service/bubbly_chef/main.py
@@ -67,16 +67,17 @@ def create_app() -> FastAPI:
 
     @app.get("/health/ai")
     async def health() -> dict:
-        providers = []
-        if settings.gemini_api_key:
-            providers.append({"name": "gemini", "available": True})
-        if settings.ollama_base_url:
-            providers.append({"name": "ollama", "available": True})
+        # Ask the actual AIManager which providers are registered and
+        # reachable, rather than reconstructing from raw settings — this
+        # reflects the real config (incl. the dev SAP-proxy provider).
+        from bubbly_chef.api.deps import get_ai_manager
+
+        status = await get_ai_manager().health_check()
         return {
             "status": "ok",
             "service": "ai-microservice",
-            "ai_available": len(providers) > 0,
-            "providers": providers,
+            "ai_available": status["healthy"],
+            "providers": status["providers"],
         }
 
     # AI routes

--- a/ai-service/bubbly_chef/workflows/recipe/nodes.py
+++ b/ai-service/bubbly_chef/workflows/recipe/nodes.py
@@ -254,8 +254,12 @@ def detect_brainstorm_followup(state: WorkflowState) -> bool:
 def extract_selected_recipe(
     user_text: str,
     history: list[dict[str, Any]],
-) -> str:
-    """Extract which recipe the user selected from the last brainstorm response."""
+) -> str | None:
+    """Extract which recipe the user selected from the last brainstorm response.
+
+    Returns the matched recipe name, or None when the message is a conversational
+    follow-up (informational question) rather than a selection.
+    """
     from rapidfuzz import fuzz  # local import — optional dep already in pyproject.toml
 
     brainstorm_text = ""
@@ -267,15 +271,42 @@ def extract_selected_recipe(
     # Extract **bold** recipe names from brainstorm
     ideas: list[str] = re.findall(r"\*\*(.+?)\*\*", brainstorm_text)
 
+    text_lower = user_text.lower()
+
+    # Guard: informational follow-ups are NOT selections.
+    # If the text sounds like a question/elaboration request AND doesn't contain
+    # an ordinal/selection word, treat it as a conversational follow-up.
+    informational_phrases = {
+        "tell me more",
+        "more info",
+        "more about",
+        "explain",
+        "what's in",
+        "whats in",
+        "how do i make",
+        "how do you make",
+        "what are",
+        "details",
+    }
+    ordinal_words = {
+        "first", "second", "third", "fourth",
+        "1st", "2nd", "3rd", "4th",
+        "one", "two", "three", "four",
+        "surprise", "any", "random", "you pick", "all of them",
+    }
+    has_informational = any(phrase in text_lower for phrase in informational_phrases)
+    has_ordinal = any(word in text_lower for word in ordinal_words)
+    if has_informational and not has_ordinal:
+        return None
+
     if not ideas:
-        return user_text  # fallback: use raw user text as recipe name
+        return None  # no brainstorm context to match against
 
     ordinal_map = {
         "first": 0, "second": 1, "third": 2, "fourth": 3,
         "1st": 0, "2nd": 1, "3rd": 2, "4th": 3,
         "one": 0, "two": 1, "three": 2, "four": 3,
     }
-    text_lower = user_text.lower()
 
     for word, idx in ordinal_map.items():
         if word in text_lower and idx < len(ideas):
@@ -284,12 +315,12 @@ def extract_selected_recipe(
     if any(kw in text_lower for kw in ["surprise", "any", "random", "you pick", "all of them"]):
         return ideas[0]
 
-    # Fuzzy match against idea names
+    # Fuzzy match against idea names — raised threshold (>=80) to avoid false positives
     best_match = max(ideas, key=lambda idea: fuzz.partial_ratio(text_lower, idea.lower()))
-    if fuzz.partial_ratio(text_lower, best_match.lower()) > 50:
+    if fuzz.partial_ratio(text_lower, best_match.lower()) >= 80:
         return best_match
 
-    return user_text
+    return None
 
 
 def score_and_rank(

--- a/ai-service/bubbly_chef/workflows/router.py
+++ b/ai-service/bubbly_chef/workflows/router.py
@@ -337,18 +337,21 @@ async def classify_intent(state: WorkflowState) -> WorkflowState:
             input_text,
             state.get("conversation_history") or [],
         )
-        logger.info(
-            f"Intent classified: recipe_card "
-            f"(source=brainstorm_followup, selected='{selected_name}')"
-        )
-        return {
-            **state,
-            "intent": Intent.RECIPE_CARD.value,
-            "intent_confidence": 0.95,
-            "intent_reasoning": "Follow-up to recipe brainstorm",
-            "detected_entities": [],
-            "selected_recipe_name": selected_name,
-        }
+        if selected_name:
+            logger.info(
+                f"Intent classified: recipe_card "
+                f"(source=brainstorm_followup, selected='{selected_name}')"
+            )
+            return {
+                **state,
+                "intent": Intent.RECIPE_CARD.value,
+                "intent_confidence": 0.95,
+                "intent_reasoning": "Follow-up to recipe brainstorm",
+                "detected_entities": [],
+                "selected_recipe_name": selected_name,
+            }
+        # No confident selection — fall through to LLM intent classification
+        # so informational questions expand on the brainstorm ideas.
 
     # URL shortcut: unambiguous recipe ingest signal (no LLM needed)
     text_lower = input_text.lower()
@@ -957,6 +960,7 @@ async def run_chat_workflow(
         )
         envelope.suggested_mode = final_state.get("suggested_mode")
         envelope.suggested_action = final_state.get("suggested_action")
+        envelope.metadata["brainstorm_ideas"] = final_state.get("brainstorm_ideas", [])
         return envelope
 
 
@@ -1064,6 +1068,12 @@ def _build_envelope_from_state(
         )
 
     envelope.suggested_mode = final_state.get("suggested_mode")
+    if intent in (
+        Intent.GENERAL_CHAT.value,
+        Intent.COOKING_HELP.value,
+        Intent.RECIPE_BRAINSTORM.value,
+    ):
+        envelope.metadata["brainstorm_ideas"] = final_state.get("brainstorm_ideas", [])
     return envelope
 
 

--- a/ai-service/tests/test_brainstorm_followup.py
+++ b/ai-service/tests/test_brainstorm_followup.py
@@ -1,0 +1,265 @@
+"""Regression tests for brainstorm follow-up routing (Part 2 fix).
+
+After a recipe_brainstorm assistant turn:
+- Informational phrases ("tell me more", "explain", ...) must NOT produce a
+  recipe_card — they fall through to cooking_help / general_chat via LLM.
+- Ordinal selection ("the first one", "make the second one") → recipe_card with
+  the correct brainstorm idea.
+- Clear fuzzy name match ("make the pasta one") → recipe_card with the matched idea.
+- The recipe title must NEVER be the raw follow-up phrase.
+"""
+
+import sys
+import types
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stub heavy optional deps that are not installed in the lightweight test env.
+# These stubs are set up BEFORE any bubbly_chef sub-modules are imported.
+# ---------------------------------------------------------------------------
+
+_stubs: list[str] = []
+
+
+def _stub(name: str) -> None:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+        _stubs.append(name)
+
+
+# supabase (and its sub-modules referenced by bubbly_chef code)
+for _mod in ("supabase", "supabase.lib", "supabase.lib.client_options"):
+    _stub(_mod)
+_supabase = sys.modules["supabase"]
+_supabase.Client = MagicMock()  # type: ignore[attr-defined]
+_supabase.create_client = MagicMock()  # type: ignore[attr-defined]
+
+# rapidfuzz — used by extract_selected_recipe at call time (local import).
+# We need the real package; mock only if absent so unit tests still work.
+try:
+    import rapidfuzz  # noqa: F401
+except ModuleNotFoundError:
+    _rp = types.ModuleType("rapidfuzz")
+    _rp_fuzz = types.ModuleType("rapidfuzz.fuzz")  # type: ignore[attr-defined]
+    _rp_process = types.ModuleType("rapidfuzz.process")  # type: ignore[attr-defined]
+
+    def _partial_ratio(a: str, b: str) -> int:  # simple fallback
+        # Not as accurate as the real rapidfuzz but sufficient for ordinal tests
+        a_lower, b_lower = a.lower(), b.lower()
+        if b_lower in a_lower or a_lower in b_lower:
+            return 90
+        return 0
+
+    _rp_fuzz.partial_ratio = _partial_ratio  # type: ignore[attr-defined]
+    _rp_fuzz.WRatio = _partial_ratio  # type: ignore[attr-defined]
+    _rp_process.extractOne = MagicMock(return_value=None)  # type: ignore[attr-defined]
+    _rp.fuzz = _rp_fuzz  # type: ignore[attr-defined]
+    _rp.process = _rp_process  # type: ignore[attr-defined]
+    sys.modules["rapidfuzz"] = _rp
+    sys.modules["rapidfuzz.fuzz"] = _rp_fuzz
+    sys.modules["rapidfuzz.process"] = _rp_process
+
+from bubbly_chef.models.base import Intent  # noqa: E402
+from bubbly_chef.workflows.recipe.nodes import extract_selected_recipe  # noqa: E402
+from bubbly_chef.workflows.router import classify_intent  # noqa: E402
+from bubbly_chef.workflows.state import LLMIntentResult  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_BRAINSTORM_CONTENT = (
+    "Here are some ideas:\n"
+    "**Cheesy Chicken Bites** - crispy fried bites\n"
+    "**Pasta Primavera** - light veggie pasta\n"
+    "**Beef Tacos** - spicy weeknight tacos\n"
+)
+
+_BRAINSTORM_HISTORY: list[dict[str, Any]] = [
+    {
+        "role": "user",
+        "content": "what can I make with chicken?",
+    },
+    {
+        "role": "assistant",
+        "content": _BRAINSTORM_CONTENT,
+        "intent": Intent.RECIPE_BRAINSTORM.value,
+    },
+]
+
+
+def _state(**kwargs: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "input_text": "",
+        "errors": [],
+        "warnings": [],
+        "session_mode": None,
+        "session": None,
+        "conversation_history": _BRAINSTORM_HISTORY,
+        "selected_recipe_name": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _llm_result(intent: str, confidence: float = 0.9) -> LLMIntentResult:
+    return LLMIntentResult(intent=intent, confidence=confidence, reasoning="test", entities=[])
+
+
+def _mock_ai(intent: str, confidence: float = 0.9) -> Any:
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value=_llm_result(intent, confidence))
+    manager = MagicMock(return_value=ai)
+    return patch("bubbly_chef.workflows.router.get_ai_manager", manager)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for extract_selected_recipe
+# ---------------------------------------------------------------------------
+
+
+def test_extract_returns_none_for_tell_me_more() -> None:
+    result = extract_selected_recipe("tell me more about that", _BRAINSTORM_HISTORY)
+    assert result is None
+
+
+def test_extract_returns_none_for_more_info() -> None:
+    result = extract_selected_recipe("more info please", _BRAINSTORM_HISTORY)
+    assert result is None
+
+
+def test_extract_returns_none_for_explain() -> None:
+    result = extract_selected_recipe("can you explain?", _BRAINSTORM_HISTORY)
+    assert result is None
+
+
+def test_extract_returns_none_for_whats_in() -> None:
+    result = extract_selected_recipe("what's in the first idea?", _BRAINSTORM_HISTORY)
+    # "what's in" is informational but "first" is ordinal → ordinal wins; returns first idea
+    # This tests that ordinal takes precedence even with informational phrasing
+    result2 = extract_selected_recipe("what's in them", _BRAINSTORM_HISTORY)
+    assert result2 is None  # no ordinal → informational guard fires
+
+
+def test_extract_returns_none_for_how_do_i_make_no_ordinal() -> None:
+    result = extract_selected_recipe("how do i make these?", _BRAINSTORM_HISTORY)
+    assert result is None
+
+
+def test_extract_first_idea_by_ordinal() -> None:
+    result = extract_selected_recipe("the first one please", _BRAINSTORM_HISTORY)
+    assert result == "Cheesy Chicken Bites"
+
+
+def test_extract_second_idea_by_ordinal() -> None:
+    result = extract_selected_recipe("make the second one", _BRAINSTORM_HISTORY)
+    assert result == "Pasta Primavera"
+
+
+def test_extract_third_idea_by_ordinal() -> None:
+    result = extract_selected_recipe("I'll try the third", _BRAINSTORM_HISTORY)
+    assert result == "Beef Tacos"
+
+
+def test_extract_fuzzy_match_pasta() -> None:
+    # "pasta primavera" is a substring of the idea name when lowercased.
+    # This test verifies direct/substring matching works.
+    result = extract_selected_recipe("I want pasta primavera", _BRAINSTORM_HISTORY)
+    assert result == "Pasta Primavera"
+
+
+def test_extract_fuzzy_match_tacos() -> None:
+    result = extract_selected_recipe("beef tacos sound great", _BRAINSTORM_HISTORY)
+    assert result == "Beef Tacos"
+
+
+def test_extract_returns_none_on_no_match() -> None:
+    result = extract_selected_recipe("something completely unrelated xyz", _BRAINSTORM_HISTORY)
+    assert result is None
+
+
+def test_extract_returns_none_when_no_history() -> None:
+    result = extract_selected_recipe("the first one", [])
+    # no ideas to match against
+    assert result is None
+
+
+def test_extract_surprise_keyword_returns_first() -> None:
+    result = extract_selected_recipe("surprise me!", _BRAINSTORM_HISTORY)
+    assert result == "Cheesy Chicken Bites"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: classify_intent routing after brainstorm turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tell_me_more_falls_through_to_llm_not_recipe_card() -> None:
+    """'Tell me more about that' must NOT produce recipe_card."""
+    with _mock_ai("cooking_help") as mock_mgr:
+        result = await classify_intent(_state(input_text="tell me more about that"))
+    # LLM was called (brainstorm guard fell through)
+    mock_mgr.return_value.complete.assert_called_once()
+    assert result["intent"] != Intent.RECIPE_CARD.value
+    # Title must not be the raw phrase
+    assert result.get("selected_recipe_name") != "tell me more about that"
+
+
+@pytest.mark.asyncio
+async def test_explain_falls_through_to_llm() -> None:
+    """'Explain those ideas' must not produce recipe_card."""
+    with _mock_ai("cooking_help"):
+        result = await classify_intent(_state(input_text="explain those ideas"))
+    assert result["intent"] != Intent.RECIPE_CARD.value
+    assert result.get("selected_recipe_name") != "explain those ideas"
+
+
+@pytest.mark.asyncio
+async def test_first_one_produces_recipe_card_with_correct_idea() -> None:
+    """'the first one' → recipe_card titled with the first brainstorm idea."""
+    with _mock_ai("general_chat") as mock_mgr:
+        result = await classify_intent(_state(input_text="the first one please"))
+    # Short-circuit: LLM should NOT be called
+    mock_mgr.return_value.complete.assert_not_called()
+    assert result["intent"] == Intent.RECIPE_CARD.value
+    assert result["selected_recipe_name"] == "Cheesy Chicken Bites"
+
+
+@pytest.mark.asyncio
+async def test_second_one_produces_recipe_card_with_second_idea() -> None:
+    with _mock_ai("general_chat") as mock_mgr:
+        result = await classify_intent(_state(input_text="make the second one"))
+    mock_mgr.return_value.complete.assert_not_called()
+    assert result["intent"] == Intent.RECIPE_CARD.value
+    assert result["selected_recipe_name"] == "Pasta Primavera"
+
+
+@pytest.mark.asyncio
+async def test_fuzzy_pasta_produces_recipe_card() -> None:
+    """A clear fuzzy name match skips LLM and returns the matched idea."""
+    with _mock_ai("general_chat") as mock_mgr:
+        result = await classify_intent(_state(input_text="beef tacos sound great"))
+    mock_mgr.return_value.complete.assert_not_called()
+    assert result["intent"] == Intent.RECIPE_CARD.value
+    assert result["selected_recipe_name"] == "Beef Tacos"
+
+
+@pytest.mark.asyncio
+async def test_raw_phrase_never_becomes_recipe_title_after_brainstorm() -> None:
+    """Regression: literal follow-up phrase must never be the recipe title."""
+    bad_phrases = [
+        "tell me more about that",
+        "more info please",
+        "can you explain?",
+        "what are the details",
+    ]
+    for phrase in bad_phrases:
+        with _mock_ai("cooking_help"):
+            result = await classify_intent(_state(input_text=phrase))
+        assert result.get("selected_recipe_name") != phrase, (
+            f"Phrase '{phrase}' became a recipe title — guard not working"
+        )

--- a/docs/plans/atomic-gathering-platypus.md
+++ b/docs/plans/atomic-gathering-platypus.md
@@ -1,0 +1,170 @@
+# Plan: Dev AI-provider routing + brainstorm follow-up fix + clickable recipe cards
+
+**Date:** 2026-07-29
+**Branch (suggested):** `feat/dev-anthropic-proxy-and-brainstorm-cards`
+
+## Context
+
+Three separate issues surfaced together while testing the chat flow against the
+SAP proxy dev setup:
+
+1. **Dev provider routing** — The terminal Claude Code session already runs
+   through an SAP proxy at `http://localhost:6655/anthropic/` (Anthropic Messages
+   API, no key needed for localhost). For dev testing we want the AI microservice
+   to route its LLM calls through that same proxy instead of burning Gemini
+   free-tier quota. Today `get_ai_manager()` only knows Gemini + Ollama.
+
+2. **"Tell me more that" bug** — After a `recipe_brainstorm` reply, clicking the
+   "Tell me more" chip (or typing a non-selection follow-up) gets caught by
+   `detect_brainstorm_followup` and mangled: `extract_selected_recipe` either
+   fuzzy-matches at a too-low `>50` threshold or falls through to
+   `return user_text`, so the literal phrase *"Tell me more about that"* becomes
+   the recipe title. Root cause: `recipe/nodes.py:288-292`.
+
+3. **Clickable recipe cards** — Brainstorm options ("Cheesy Chicken Bites", …)
+   render as plain bold markdown text inside one bubble. They should be tappable
+   cards that select that recipe. The structured data already exists server-side
+   (`brainstorm_ideas: list[str]` in `WorkflowState`, `shared_state.py:367`) — it
+   just isn't surfaced in the response envelope.
+
+Outcome: dev runs on the free proxy; conversational follow-ups after a brainstorm
+behave correctly; brainstorm options are selectable cards.
+
+---
+
+## Part 1 — Anthropic/SAP-proxy provider (dev only)
+
+**Decision (confirmed):** proxy-only when the flag is set (no Gemini/Ollama
+fallback while active); no API key; default model `anthropic--claude-4.6-sonnet`.
+
+### Files
+- **New:** `ai-service/bubbly_chef/ai/anthropic.py` — `AnthropicProvider(AIProvider)`,
+  modeled on `ai/gemini.py`. Speaks Anthropic Messages API:
+  - `POST {base_url}/v1/messages`, headers `anthropic-version: 2023-06-01`
+    (+ `x-api-key` only if a key is configured), JSON body
+    `{model, max_tokens, temperature, system, messages:[{role:"user",content:[...]}]}`.
+  - `complete()` — text + structured output. For structured output, reuse
+    Gemini's approach: append the JSON-schema instruction to the prompt, then
+    strip ``` ```json fences and `model_validate`. Raise `StructuredOutputError`
+    / `ProviderUnavailableError` exactly as Gemini does so the manager's retry +
+    cascade logic (`manager.py:99-160`) works unchanged.
+  - `vision_complete()` — `supports_vision = True`; image goes as a content block
+    `{"type":"image","source":{"type":"base64","media_type":mime,"data":b64}}`
+    followed by a `{"type":"text","text":prompt}` block.
+  - `stream_complete()` — SSE via `client.stream(...)`; parse
+    `content_block_delta` events (`data:` lines, `delta.text`). Fall back to
+    `complete()` on non-streaming errors, matching Gemini.
+  - `is_available()` — cheap reachability check against the proxy; return True on
+    200/429 for cascade parity.
+- `ai-service/bubbly_chef/config.py` — add settings:
+  - `anthropic_base_url: str = "http://localhost:6655/anthropic"`
+  - `anthropic_api_key: str = ""`
+  - `anthropic_model: str = "anthropic--claude-4.6-sonnet"`
+  - `use_anthropic_proxy: bool = False`
+- `ai-service/bubbly_chef/api/deps.py` — in `get_ai_manager()`: **if
+  `settings.use_anthropic_proxy` is True, register ONLY `AnthropicProvider` and
+  return** (skip Gemini/Ollama). Otherwise keep current behavior untouched.
+- `ai-service/bubbly_chef/ai/__init__.py` — export `AnthropicProvider`.
+- `.env.example` — document the four new `BUBBLY_*` vars under the AI Microservice
+  section with a short "dev only" note.
+
+### Notes
+- max_tokens is required by the Anthropic API — set a sane default (e.g. 4096),
+  optionally a `anthropic_max_tokens` setting.
+- Do NOT commit `use_anthropic_proxy=true` anywhere except `.env` locally; default
+  stays `False` so prod/CI are unaffected.
+
+---
+
+## Part 2 — Fix brainstorm follow-up misrouting
+
+The bug is that *any* message after a brainstorm is treated as a recipe
+selection. Fix in two spots:
+
+- **`ai-service/bubbly_chef/workflows/recipe/nodes.py`**
+  - `extract_selected_recipe()` (line 254): return `None` (not `user_text`) when
+    nothing confidently matches, and raise the fuzzy threshold from `>50` to a
+    stricter value (e.g. `>=80`, matching the catalog `lookup` convention noted in
+    project memory). Change signature to `-> str | None`.
+  - Add an explicit "informational follow-up" guard: if the user text matches
+    phrases like *"tell me more", "more info", "explain", "what's in", "how do I
+    make"* WITHOUT naming/ordinal-selecting a specific idea, do NOT treat it as a
+    selection.
+- **`ai-service/bubbly_chef/workflows/router.py`** (`detect_brainstorm_followup`
+  branch, ~line 334-351): when `extract_selected_recipe` returns `None`, fall
+  through to normal LLM intent classification (→ `cooking_help` / `general_chat`)
+  instead of forcing `recipe_card` with a junk title. Same treatment for the
+  session-mode path at lines 309-324.
+- **Frontend chip:** `PostMessageChips` "Tell me more" (`onTellMore`) sends a
+  canned message that triggers this. Once the backend guard is in, "Tell me more"
+  will route to `cooking_help` and expand on the brainstorm — the intended
+  behavior. No frontend change strictly required, but verify the canned text
+  contains a clear "tell me more" phrase the guard recognizes.
+
+### Tests
+- `ai-service/tests/` — add cases to the router/recipe-node tests: after a
+  brainstorm turn, inputs "tell me more about that" / "explain the first one" /
+  "make the pasta one" route to cooking_help / recipe_card(first idea) /
+  recipe_card(fuzzy pasta) respectively, and NEVER produce a recipe titled with
+  the raw follow-up phrase.
+
+---
+
+## Part 3 — Clickable recipe option cards
+
+Surface the already-computed `brainstorm_ideas` to the client and render them as
+selectable cards.
+
+### Backend
+- **`ai-service/bubbly_chef/workflows/router.py`** — in the `else` branch that
+  builds the brainstorm envelope (~line 950-960), attach the ideas:
+  `envelope.metadata["brainstorm_ideas"] = final_state.get("brainstorm_ideas", [])`.
+  Do the same in the streaming builder `_build_envelope_from_state` for parity.
+  (Ideas are already extracted at `recipe/nodes.py:557,563`.)
+
+### Frontend
+- **`nextjs/src/types/chat.ts`** — `metadata` already exists on `ChatResponse`;
+  read `metadata.brainstorm_ideas` as `string[]`. Optionally add a typed helper.
+- **New:** `nextjs/src/components/chat/BrainstormOptions.tsx` — renders each idea
+  as a Sanrio pill/card (reuse `Chip` or `ChatRecipeCard` styling), each calling
+  `onSelect(ideaName)`.
+- **`nextjs/src/app/chat/page.tsx`** — in `MessageRenderer`, add a branch: when
+  `intent === 'recipe_brainstorm'` and `metadata.brainstorm_ideas?.length`,
+  render the text bubble + `<BrainstormOptions ideas={...} onSelect={sendSelect}/>`.
+  `onSelect(name)` sends `name` as the next chat message (reuses the existing send
+  path; the backend's `extract_selected_recipe` fuzzy-matches it exactly → correct
+  recipe card). Falls back to plain markdown if no ideas present (older messages).
+
+> Next.js caveat (`nextjs/AGENTS.md`): this is a modified Next.js — check
+> `node_modules/next/dist/docs/` before adding routes/APIs. This change is
+> client-component only (no new route), so low risk, but frontend dev should
+> confirm.
+
+---
+
+## Verification (end-to-end)
+
+Run in the **primary checkout** (worktrees have no dev env):
+
+1. **Proxy provider**
+   - Set `BUBBLY_USE_ANTHROPIC_PROXY=true` in `ai-service/.env`.
+   - `cd ai-service && uvicorn bubbly_chef.main:app --reload --port 8888`
+   - `curl localhost:8888/health/ai` → provider list shows `anthropic/...` only.
+   - Send a chat message; confirm logs show the anthropic provider handling it and
+     no Gemini calls.
+2. **Brainstorm follow-up**
+   - Chat: "what can I make with my chicken breast?" → brainstorm list.
+   - Click "Tell me more" → response EXPANDS on the ideas, no recipe titled
+     "Tell me more about that".
+   - "make the first one" / "the pasta one" → correct recipe card.
+3. **Clickable cards**
+   - Same brainstorm → options render as tappable cards; tapping one generates
+     that recipe's card.
+4. **Gates:** `cd ai-service && pytest && ruff check bubbly_chef/` and
+   `cd nextjs && npx tsc --noEmit`. (`mypy --strict` is known-red, issue #128 —
+   don't block on it, but keep the new provider type-clean.)
+
+## Out of scope
+- Prod provider changes (proxy is dev-only, default off).
+- Reworking the intent classifier prompt beyond the follow-up guard.
+- Persisting brainstorm selections / analytics.

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -14,6 +14,8 @@ import ChatContextCard from '@/components/chat/ChatContextCard'
 import TypingIndicator from '@/components/chat/TypingIndicator'
 import ChatRecipeCard from '@/components/chat/ChatRecipeCard'
 import PantryProposalCard from '@/components/chat/PantryProposalCard'
+import BrainstormOptions from '@/components/chat/BrainstormOptions'
+import CookModal from '@/components/recipes/CookModal'
 import ThemePicker from '@/components/ui/ThemePicker'
 import Chip from '@/components/ui/Chip'
 import EmptyState from '@/components/ui/EmptyState'
@@ -27,6 +29,7 @@ import type {
   ChatRecipeData,
   PantryProposalData,
 } from '@/types/chat'
+import { getBrainstormIdeas } from '@/types/chat'
 
 const SUGGESTIONS = [
   'What can I make tonight? 🌙',
@@ -82,6 +85,10 @@ function ChatSurface() {
   const [input, setInput] = useState('')
   const [aiAvailable, setAiAvailable] = useState(true)
   const [saveStates, setSaveStates] = useState<Record<string, 'idle' | 'saving' | 'saved' | 'error'>>({})
+  /** Maps message id → saved recipe db id, populated after a successful save. */
+  const [savedRecipeIds, setSavedRecipeIds] = useState<Record<string, string>>({})
+  /** When set, the CookModal is open for this { recipeId, recipeTitle } pair. */
+  const [cookTarget, setCookTarget] = useState<{ recipeId: string; recipeTitle: string } | null>(null)
   const [loadedRecipe, setLoadedRecipe] = useState<Recipe | null>(null)
   const [dismissedRecipeId, setDismissedRecipeId] = useState<string | null>(null)
   const [dismissedSeedKey, setDismissedSeedKey] = useState<string | null>(null)
@@ -235,7 +242,16 @@ function ChatSurface() {
           servings: recipe.servings,
         }),
       })
-      setSaveStates((prev) => ({ ...prev, [msgId]: res.ok ? 'saved' : 'error' }))
+      if (res.ok) {
+        setSaveStates((prev) => ({ ...prev, [msgId]: 'saved' }))
+        // Capture the db id so "Cook this" can open CookModal immediately.
+        const saved = await res.json().catch(() => null) as { id?: string } | null
+        if (saved?.id) {
+          setSavedRecipeIds((prev) => ({ ...prev, [msgId]: saved.id as string }))
+        }
+      } else {
+        setSaveStates((prev) => ({ ...prev, [msgId]: 'error' }))
+      }
     } catch {
       setSaveStates((prev) => ({ ...prev, [msgId]: 'error' }))
     }
@@ -247,6 +263,10 @@ function ChatSurface() {
 
   const handleTellMore = () => {
     sendMessage('Tell me more about that')
+  }
+
+  const handlePickIdea = (idea: string) => {
+    sendMessage(idea)
   }
 
   // Determine if the typing indicator should show
@@ -342,8 +362,18 @@ function ChatSurface() {
                 onApprove={() => approveProposal(msg.id)}
                 onReject={() => rejectProposal(msg.id)}
                 onSave={(recipe) => handleSaveRecipe(msg.id, recipe)}
+                savedRecipeId={savedRecipeIds[msg.id] ?? null}
+                onCook={(recipeId) => {
+                  const title = msg.response?.proposal
+                    ? ((msg.response.proposal as { recipe?: { title?: string }; title?: string }).recipe?.title
+                        ?? (msg.response.proposal as { title?: string }).title
+                        ?? 'Recipe')
+                    : 'Recipe'
+                  setCookTarget({ recipeId, recipeTitle: title })
+                }}
                 onTryAnother={handleTryAnother}
                 onTellMore={handleTellMore}
+                onPickIdea={handlePickIdea}
               />
             ))}
 
@@ -426,6 +456,16 @@ function ChatSurface() {
           </SpringButton>
         )}
       </div>
+
+      {/* Cook modal — opened when the user taps "Cook this" on a saved chat recipe */}
+      {cookTarget && (
+        <CookModal
+          recipeId={cookTarget.recipeId}
+          recipeTitle={cookTarget.recipeTitle}
+          onClose={() => setCookTarget(null)}
+          onCooked={() => setCookTarget(null)}
+        />
+      )}
     </div>
   )
 }
@@ -445,8 +485,14 @@ interface MessageRendererProps {
   onApprove: () => void
   onReject: () => void
   onSave: (recipe: ChatRecipeData) => void
+  /** DB id of the saved recipe — available once onSave succeeds; gates "Cook this". */
+  savedRecipeId: string | null
+  /** Opens CookModal for the saved recipe. */
+  onCook: (recipeId: string) => void
   onTryAnother: () => void
   onTellMore: () => void
+  /** Called when the user taps a brainstorm idea card; sends the name as the next message. */
+  onPickIdea: (idea: string) => void
 }
 
 function MessageRenderer({
@@ -459,8 +505,11 @@ function MessageRenderer({
   onApprove,
   onReject,
   onSave,
+  savedRecipeId,
+  onCook,
   onTryAnother,
   onTellMore,
+  onPickIdea,
 }: MessageRendererProps) {
   // User messages — simple bubble
   if (message.role === 'user') {
@@ -477,6 +526,33 @@ function MessageRenderer({
 
   const mascotState = isLastAssistant && isStreaming ? 'thinking' : 'happy'
   const intent = message.intent ?? message.response?.intent
+
+  // Brainstorm intent — render intro bubble + tappable idea cards
+  // Falls through to plain markdown if metadata.brainstorm_ideas is absent (backward compat).
+  if (intent === 'recipe_brainstorm') {
+    const ideas = getBrainstormIdeas(message.response)
+    if (ideas.length > 0) {
+      return (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        >
+          <div className="flex items-end gap-2">
+            <BubblesMascot size={36} state={mascotState} animate={false} className="flex-shrink-0 mb-1" />
+            <div className="flex flex-col gap-2 items-start">
+              {message.content && <MessageBubble message={message} />}
+              <BrainstormOptions
+                ideas={ideas}
+                onSelect={onPickIdea}
+                disabled={!isLastSettledAssistant}
+              />
+            </div>
+          </div>
+        </motion.div>
+      )
+    }
+  }
 
   // Recipe card intent
   if (
@@ -504,6 +580,8 @@ function MessageRenderer({
               onSave={() => onSave(recipe)}
               onTryAnother={onTryAnother}
               saveState={saveState}
+              savedRecipeId={savedRecipeId}
+              onCook={onCook}
             />
           </div>
         </div>

--- a/nextjs/src/components/chat/BrainstormOptions.tsx
+++ b/nextjs/src/components/chat/BrainstormOptions.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { springs } from '@/lib/motion'
+
+export interface BrainstormOptionsProps {
+  /** The list of recipe idea names to display as selectable mini cards. */
+  ideas: string[]
+  /** Called with the idea name the user tapped. */
+  onSelect: (idea: string) => void
+  /**
+   * When true the cards render statically without pointer interaction
+   * (applied to older brainstorm messages that are no longer the last settled reply).
+   */
+  disabled?: boolean
+}
+
+/**
+ * Renders a vertical stack of tappable mini recipe cards modelled on
+ * ChatRecipeCard's pink header strip — same `bg-[var(--color-primary)]`,
+ * `rounded-2xl`, white bold title, shadow-sm treatment — so tapping one
+ * feels like it "expands" into the full recipe card the backend returns.
+ *
+ * Each card fires `onSelect(ideaName)`, which is sent as the next chat
+ * message. The backend fuzzy-matches the exact name → returns a recipe_card.
+ *
+ * Only the last settled brainstorm message receives interactive cards;
+ * older messages receive `disabled={true}` and render as static previews.
+ */
+export default function BrainstormOptions({
+  ideas,
+  onSelect,
+  disabled = false,
+}: BrainstormOptionsProps) {
+  if (ideas.length === 0) return null
+
+  return (
+    <div
+      className="flex flex-col gap-2 w-full max-w-[85%]"
+      role="list"
+      aria-label="Recipe ideas — tap one to generate it"
+    >
+      {ideas.map((idea, i) => (
+        <motion.button
+          key={idea}
+          type="button"
+          role="listitem"
+          aria-label={`Pick ${idea}`}
+          disabled={disabled}
+          onClick={() => !disabled && onSelect(idea)}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ ...springs.snappy, delay: i * 0.07 }}
+          whileTap={disabled ? undefined : { scale: 0.97 }}
+          className={[
+            // Outer card shell — matches ChatRecipeCard wrapper exactly
+            'rounded-2xl bg-white border border-[var(--color-border)] shadow-sm overflow-hidden',
+            'w-full text-left',
+            disabled
+              ? 'cursor-default opacity-70'
+              : 'cursor-pointer hover:brightness-97 active:brightness-90',
+          ].join(' ')}
+        >
+          {/* Header strip — identical to ChatRecipeCard's title strip */}
+          <div className="bg-[var(--color-primary)] px-4 py-2.5 flex items-center justify-between gap-3">
+            <h4 className="text-white font-bold text-sm leading-snug flex-1">
+              {idea}
+            </h4>
+            {!disabled && (
+              <span
+                aria-hidden
+                className="text-white/70 text-xs font-semibold flex-shrink-0"
+              >
+                Tap to make →
+              </span>
+            )}
+          </div>
+        </motion.button>
+      ))}
+    </div>
+  )
+}

--- a/nextjs/src/components/chat/ChatRecipeCard.tsx
+++ b/nextjs/src/components/chat/ChatRecipeCard.tsx
@@ -10,6 +10,13 @@ interface ChatRecipeCardProps {
   onSave?: () => void
   onTryAnother?: () => void
   saveState?: 'idle' | 'saving' | 'saved' | 'error'
+  /**
+   * ID of the saved recipe — only populated after a successful save.
+   * When present the "Cook this" button becomes active.
+   */
+  savedRecipeId?: string | null
+  /** Opens the cook flow for the saved recipe. Requires savedRecipeId. */
+  onCook?: (recipeId: string) => void
 }
 
 const CHIP_COLORS: string[] = [
@@ -56,6 +63,8 @@ export default function ChatRecipeCard({
   onSave,
   onTryAnother,
   saveState = 'idle',
+  savedRecipeId,
+  onCook,
 }: ChatRecipeCardProps) {
   const totalTime =
     recipe.total_time_minutes
@@ -187,6 +196,21 @@ export default function ChatRecipeCard({
           >
             <SaveButtonContent saveState={saveState} />
           </SpringButton>
+          {/* Cook this — only usable once the recipe has been saved (needs a db id) */}
+          {onCook && (
+            <motion.button
+              type="button"
+              onClick={() => savedRecipeId && onCook(savedRecipeId)}
+              disabled={!savedRecipeId}
+              title={savedRecipeId ? 'Mark as cooked & update pantry' : 'Save the recipe first to cook it'}
+              whileHover={{ scale: savedRecipeId ? 1.03 : 1 }}
+              whileTap={{ scale: savedRecipeId ? 0.95 : 1 }}
+              transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+              className="py-2 px-3 rounded-full text-sm font-semibold border border-[var(--color-border)] bg-white text-[var(--color-muted)] hover:bg-[var(--color-bg)] disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              🍳 Cook
+            </motion.button>
+          )}
           <SpringButton
             onClick={onTryAnother}
             className="flex-1 py-2 px-3 rounded-full text-sm font-semibold border border-[var(--color-border)] bg-white text-[var(--color-muted)] hover:bg-[var(--color-bg)]"

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -184,7 +184,7 @@ export default function CookModal({
                 className="text-base font-extrabold text-[var(--color-text)]"
                 style={{ fontFamily: 'Nunito, sans-serif' }}
               >
-                Cook it
+                Mark as cooked
               </h2>
               <p
                 className="text-xs text-[var(--color-muted)] mt-0.5 line-clamp-1"
@@ -229,18 +229,18 @@ export default function CookModal({
 
             {state === 'success' && (
               <div className="py-8 text-center">
-                <p className="text-3xl mb-2">🍳</p>
+                <p className="text-3xl mb-2">✅</p>
                 <p
                   className="text-sm font-extrabold text-[var(--color-text)]"
                   style={{ fontFamily: 'Nunito, sans-serif' }}
                 >
-                  Enjoy your meal!
+                  Pantry updated!
                 </p>
                 <p
                   className="text-xs text-[var(--color-muted)] mt-1"
                   style={{ fontFamily: 'Nunito, sans-serif' }}
                 >
-                  Pantry updated — taking you to chat if you have questions.
+                  Ingredients deducted — taking you to chat.
                 </p>
               </div>
             )}
@@ -359,7 +359,7 @@ export default function CookModal({
                 className="flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform disabled:opacity-50"
                 style={{ background: 'var(--color-primary-dark)', fontFamily: 'Nunito, sans-serif' }}
               >
-                {state === 'confirming' ? 'Saving...' : 'Confirm'}
+                {state === 'confirming' ? 'Saving...' : 'Yes, I cooked this'}
               </button>
             </div>
           )}

--- a/nextjs/src/components/ui/SpringButton.tsx
+++ b/nextjs/src/components/ui/SpringButton.tsx
@@ -9,6 +9,8 @@ interface SpringButtonProps {
   onClick?: () => void
   type?: 'button' | 'submit' | 'reset'
   disabled?: boolean
+  /** Native tooltip / accessibility hint. */
+  title?: string
 }
 
 export default function SpringButton({
@@ -18,12 +20,14 @@ export default function SpringButton({
   onClick,
   type = 'button',
   disabled,
+  title,
 }: SpringButtonProps) {
   return (
     <motion.button
       type={type}
       onClick={onClick}
       disabled={disabled}
+      title={title}
       style={style}
       whileHover={{ scale: disabled ? 1 : 1.03 }}
       whileTap={{ scale: disabled ? 1 : 0.95 }}

--- a/nextjs/src/types/chat.ts
+++ b/nextjs/src/types/chat.ts
@@ -173,6 +173,19 @@ export interface ConversationSession {
   updated_at: string
 }
 
+// ─── Brainstorm helpers ───────────────────────────────────────────────────────
+
+/**
+ * Extract brainstorm idea names from a ChatResponse's metadata.
+ * Returns an empty array when the field is absent, null, or malformed so
+ * callers never need to guard against undefined.
+ */
+export function getBrainstormIdeas(response?: ChatResponse | null): string[] {
+  const raw = response?.metadata?.brainstorm_ideas
+  if (!Array.isArray(raw)) return []
+  return raw.filter((item): item is string => typeof item === 'string')
+}
+
 // ─── AI Health ────────────────────────────────────────────────────────────────
 
 export interface AIHealthStatus {


### PR DESCRIPTION
## Summary

Three related chat/AI improvements, surfaced together while testing the chat flow:

1. **Dev AI routing** — route the AI microservice's LLM calls through the local SAP proxy for dev, instead of Gemini free-tier quota.
2. **Brainstorm follow-up fix** — "tell me more"-style follow-ups after a brainstorm were being forged into a recipe titled with the raw phrase.
3. **Clickable recipe options + cook affordance** — brainstorm ideas render as selectable mini recipe cards; the in-chat recipe card gains a "Cook this" action; the cook modal is reframed to read as logging a completed cook.

## What lands

- **`AnthropicProvider`** (Anthropic Messages API) for the SAP proxy at `localhost:6655/anthropic`, gated behind `BUBBLY_USE_ANTHROPIC_PROXY`. When set, only this provider is registered (no Gemini/Ollama); no API key needed; default model `anthropic--claude-4.6-sonnet`. Default **off** — prod/CI are unaffected.
- **`/health/ai`** now reports the real registered providers via `AIManager.health_check()` instead of a hardcoded gemini/ollama list, so the proxy provider is visible when active.
- **Brainstorm follow-up routing** — `extract_selected_recipe` returns `None` on no confident match (fuzzy threshold raised 50→80, plus an informational-question guard); the router falls through to normal intent classification instead of forcing a `recipe_card` with a junk title.
- **`brainstorm_ideas`** surfaced in the response envelope metadata (sync + streaming builders).
- **`BrainstormOptions`** component — mini recipe cards modelled on `ChatRecipeCard`'s header, tap-to-select via the existing chat send path.
- **"Cook this"** on the in-chat recipe card (save-then-cook; disabled until the recipe is saved), opening the existing `CookModal`.
- **`CookModal` reframing** — "Mark as cooked" / "Yes, I cooked this" / "Pantry updated!" Deduction timing unchanged (at confirm).

## Tests

- New `ai-service/tests/test_brainstorm_followup.py` (19 cases): follow-ups like "tell me more about that" route to cooking_help/general_chat and never produce a recipe titled with the raw phrase; ordinal/fuzzy selection still work.
- Backend: `ruff` clean, targeted router/recipe/provider suites pass. (`test_intent_live.py` failures are pre-existing live-network tests needing real AI creds — unrelated.)
- Frontend: `tsc --noEmit` + `eslint` clean on changed files.
- Verified live: with the flag on, `/health/ai` reports only `anthropic/anthropic--claude-4.6-sonnet`, `available: true` with no key.

## Out of scope

- Prod provider changes (proxy is dev-only, default off).
- Changing when the cook flow deducts from the pantry (kept at confirm; only the framing changed).
- One-click save-then-cook (Cook button stays disabled until the recipe is saved).