### PR TITLE
fix: reserve hamburger-tab clearance for no-image recipe title (#171)

### DIFF
--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -568,9 +568,12 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
                 </div>
               </div>
             ) : (
-              /* Plain header — no thumbnail */
+              /* Plain header — no thumbnail.
+                 pl-10 (40px) reserves clearance for the 28px-wide hamburger tab
+                 that is absolutely positioned at left-0; without it the first
+                 character of the title is hidden behind the button. */
               <div
-                className="px-4 pt-4 pb-3 flex-shrink-0"
+                className="pl-10 pr-4 pt-4 pb-3 flex-shrink-0"
               >
                 <h2
                   className="text-xl font-extrabold text-[var(--color-text)] leading-tight"


### PR DESCRIPTION
## Summary

- In the no-image recipe header, `px-4` (16px left padding) left the title starting under the 28px-wide hamburger tab, clipping the first character.
- Changed `px-4` → `pl-10 pr-4` (40px left, 16px right) on the plain-header `<div>` only.
- The with-image (hero) variant is unchanged — title is inside a full-bleed overlay that already clears the button vertically.

## What lands

- `nextjs/src/components/recipes/RecipeBook.tsx` line 576: `className="pl-10 pr-4 pt-4 pb-3 flex-shrink-0"` (was `"px-4 pt-4 pb-3 flex-shrink-0"`)
- One file, one class change, no logic or state touched.

## Tests

**Manual verify:** Open `/recipes`, select (or create) a recipe that has **no thumbnail image**. Confirm the full title is visible — no character hidden behind the ☰ tab. At 480px viewport width the clearance should still hold. With-image recipes unaffected.

## Linked

Fixes #171