### PR TITLE
fix(chat): restyle 'Tell me more' pill to match 'Try another' affordance (#172)

### DIFF
--- a/nextjs/src/components/chat/PostMessageChips.tsx
+++ b/nextjs/src/components/chat/PostMessageChips.tsx
@@ -33,7 +33,7 @@ export default function PostMessageChips({
       )}
       {onTellMore && (
         <Chip
-          tone="muted"
+          tone="primary"
           emoji="💬"
           onClick={onTellMore}
           ariaLabel="Ask Bubbles to explain further"


### PR DESCRIPTION
## Summary

- Fixes #172: the "Tell me more" 💬 follow-up chip after an AI brainstorm response was using `tone="muted"`, which maps to `--color-bg` (#FFF0F5, near-white) background and `--color-muted` (#9B8A93, gray-mauve) text — visually identical to a disabled state.
- Changed to `tone="primary"`, giving it the pink pastel fill (`--color-primary` = #FFB7C5) with charcoal `--color-text` — equal visual weight to the mint "Try another" chip (`tone="accent"`).
- Both pills now read as live, equally-actionable choices in the kawaii palette, consistent with the welcome-screen suggestion chips.

## What lands

- `PostMessageChips.tsx`: `tone="muted"` → `tone="primary"` on the "Tell me more" chip (1-line change).
- No new tokens, no new variants — reuses existing design-system `primary` tone that already works across all 5 themes (Sakura, Mint, Lavender, Yuzu, Bluebell).

## Tests

- TypeScript: structural change only (valid `ChipTone` value); no new types introduced.
- Manual verify: open `/chat`, trigger a brainstorm reply, confirm both pills appear with equal pastel fill weight — mint 🔄 and pink 💬 side by side, neither washed out.

## Out of scope

- No hover/focus state changes needed — `Chip` already applies `whileTap` spring animation on all clickable tones.