### PR TITLE
fix: guard RecipeBook mutations and surface errors (#176)

### DIFF
--- a/nextjs/src/components/recipes/RecipeBook.tsx
+++ b/nextjs/src/components/recipes/RecipeBook.tsx
@@ -170,7 +170,8 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
   }
 
   const handleFavorite = async () => {
-    if (!selectedRecipe) return
+    if (!selectedRecipe || mutating) return
+    setMutating(true)
     setErrorMessage(null)
     const id = selectedRecipe.id
     const newVal = !selectedRecipe.is_favorite
@@ -186,6 +187,8 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
     } catch {
       setFavoriteOverrides((prev) => ({ ...prev, [id]: !newVal }))
       setErrorMessage('Could not update favorite. Please try again.')
+    } finally {
+      setMutating(false)
     }
   }
 
@@ -239,26 +242,31 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
 
   const handleImportSave = async (updates: Partial<Recipe>) => {
     setMutating(true)
-    const res = await fetch('/api/recipes', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ ...importDraft, ...updates, source_type: 'url' }),
-    })
-    setMutating(false)
-    setImportDraft(null)
-    if (res.status === 409) {
-      // Already saved — navigate to the existing recipe instead
-      const data = await res.json()
-      setImportOpen(false)
-      if (data.existing_id) setSelectedId(data.existing_id)
-      setErrorMessage(`"${data.existing_title ?? 'This recipe'}" is already in your book.`)
-      return
-    }
-    if (res.ok) {
+    setErrorMessage(null)
+    try {
+      const res = await fetch('/api/recipes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...importDraft, ...updates, source_type: 'url' }),
+      })
+      if (res.status === 409) {
+        // Already saved — navigate to the existing recipe instead
+        const data = await res.json()
+        setImportOpen(false)
+        if (data.existing_id) setSelectedId(data.existing_id)
+        setErrorMessage(`"${data.existing_title ?? 'This recipe'}" is already in your book.`)
+        return
+      }
+      if (!res.ok) throw new Error('Failed to import recipe')
       const saved = await res.json()
       setImportOpen(false)
+      setImportDraft(null)
       onMutate?.()
       setSelectedId(saved.id ?? null)
+    } catch {
+      setErrorMessage('Could not import recipe. Please try again.')
+    } finally {
+      setMutating(false)
     }
   }
 
@@ -793,6 +801,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
           recipe={selectedRecipe}
           onSave={handleEditSave}
           onClose={() => setEditOpen(false)}
+          disabled={mutating}
         />
       )}
 
@@ -809,6 +818,7 @@ export default function RecipeBook({ recipes, onMutate }: RecipeBookProps) {
           recipe={{ id: '', user_id: '', created_at: '', ...importDraft } as Recipe}
           onSave={handleImportSave}
           onClose={() => setImportDraft(null)}
+          disabled={mutating}
         />
       )}
 

--- a/nextjs/src/components/recipes/RecipeEditModal.tsx
+++ b/nextjs/src/components/recipes/RecipeEditModal.tsx
@@ -14,9 +14,11 @@ interface RecipeEditModalProps {
   recipe: Recipe
   onSave: (updates: Partial<Recipe>) => Promise<void>
   onClose: () => void
+  /** When true, the close/cancel buttons are blocked (parent mutation in-flight) */
+  disabled?: boolean
 }
 
-export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditModalProps) {
+export default function RecipeEditModal({ recipe, onSave, onClose, disabled = false }: RecipeEditModalProps) {
   const [title, setTitle] = useState(recipe.title)
   const [description, setDescription] = useState(recipe.description ?? '')
   const [tags, setTags] = useState((recipe.tags ?? []).join(', '))
@@ -69,7 +71,7 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          onClick={onClose}
+          onClick={saving || disabled ? undefined : onClose}
         />
 
         {/* Modal panel */}
@@ -101,8 +103,9 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
               Edit Recipe
             </h2>
             <button
-              onClick={onClose}
-              className="w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95"
+              onClick={saving || disabled ? undefined : onClose}
+              disabled={saving || disabled}
+              className="w-8 h-8 rounded-full flex items-center justify-center transition-opacity hover:opacity-70 active:scale-95 disabled:opacity-40 disabled:cursor-not-allowed"
               style={{ background: 'var(--color-bg)', color: 'var(--color-muted)' }}
               aria-label="Close"
             >
@@ -279,15 +282,15 @@ export default function RecipeEditModal({ recipe, onSave, onClose }: RecipeEditM
           >
             <button
               onClick={handleSave}
-              disabled={saving || !title.trim()}
+              disabled={saving || disabled || !title.trim()}
               className="flex-1 py-2.5 rounded-full text-sm font-bold text-white disabled:opacity-50 active:scale-95 transition-transform"
               style={{ background: 'var(--color-primary)', fontFamily: 'Nunito, sans-serif' }}
             >
               {saving ? 'Saving...' : 'Save'}
             </button>
             <button
-              onClick={onClose}
-              disabled={saving}
+              onClick={saving || disabled ? undefined : onClose}
+              disabled={saving || disabled}
               className="flex-1 py-2.5 rounded-full text-sm font-bold disabled:opacity-50 active:scale-95 transition-transform"
               style={{
                 background: 'var(--color-bg)',


### PR DESCRIPTION
## Summary
Recipe-library save/delete/favourite buttons stayed enabled during in-flight requests (double-fire risk) and failures were silent.

## What lands
- `handleFavorite` now sets/clears `mutating` (it previously never did, so the heart button's existing `disabled={mutating}` never engaged during a favourite toggle) and shows an error on failure.
- `handleImportSave` wrapped in try/catch/finally with a user-visible error message and reliable `mutating` reset.
- `RecipeEditModal` gains a `disabled` prop; close/cancel/backdrop and the save button are blocked while a parent mutation is in flight. Both call sites pass `disabled={mutating}`.
- Cook/heart/menu buttons and `RecipeDeleteConfirm` already carried the in-flight guard; this closes the remaining gaps.

## Tests
- Manual: rapidly tap Save/Delete/Favourite — buttons disable during the request; a simulated failure surfaces an inline error instead of silence.

## Linked
Closes #176

## Out of scope
React Query migration of these mutations.