### PR TITLE
fix: auto-categorize manually added pantry items (#177)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/pantry.py
+++ b/ai-service/bubbly_chef/api/routes/pantry.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel, Field
 
 from bubbly_chef.api.auth import get_current_user_id
 from bubbly_chef.domain.catalog import categorize
+from bubbly_chef.domain.normalizer import detect_category
 from bubbly_chef.models.pantry import FoodCategory, StorageLocation
 from bubbly_chef.tools.expiry import get_expiry_heuristics
 
@@ -105,10 +106,16 @@ async def estimate_category(
     request: EstimateCategoryRequest,
     user_id: str = Depends(get_current_user_id),
 ) -> EstimateCategoryResponse:
-    """Infer a food category from an item name using the catalog fuzzy matcher.
+    """Infer a food category from an item name.
 
-    Deterministic — no LLM call. Returns null when the catalog has no match
-    above the confidence threshold (95). Callers should fall back to 'other'
-    on null so that a failed or absent estimate never blocks the add.
+    Uses the same two-stage logic as the receipt parser for consistency (#177):
+    1. Keyword matching via ``detect_category`` (normalizer) — high priority,
+       handles common items like "yogurt", "milk", "chicken" immediately.
+    2. Catalog fuzzy match via ``categorize`` (catalog, threshold=95) — covers
+       USDA-backed items not in the keyword list.
+
+    Returns null when neither stage has a confident match. Callers should fall
+    back to 'other' on null so that a failed estimate never blocks the add.
     """
-    return EstimateCategoryResponse(category=categorize(request.name))
+    category = detect_category(request.name) or categorize(request.name)
+    return EstimateCategoryResponse(category=category)

--- a/ai-service/tests/test_pantry_estimate_category.py
+++ b/ai-service/tests/test_pantry_estimate_category.py
@@ -3,13 +3,19 @@
 The endpoint itself requires JWT auth + wires FastAPI, but the interesting
 behaviour is the catalog lookup and that known items resolve to the right
 category while unknown items return None. These test that layer directly.
+
+Updated in #177: the endpoint now uses detect_category (keyword-first) before
+falling back to catalog.categorize, matching the receipt-parser path.
 """
+
+import pytest
 
 from bubbly_chef.api.routes.pantry import (
     EstimateCategoryRequest,
     EstimateCategoryResponse,
 )
 from bubbly_chef.domain.catalog import categorize
+from bubbly_chef.domain.normalizer import detect_category
 
 
 def test_request_model_accepts_name() -> None:
@@ -47,3 +53,77 @@ def test_unknown_item_returns_none() -> None:
 def test_empty_string_returns_none() -> None:
     result = categorize("")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# detect_category (keyword-first path — the same stage the receipt parser uses)
+# These cover the #177 fix: items matched by keyword before catalog is tried.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("yogurt", "dairy"),
+        ("greek yogurt", "dairy"),
+        ("plain yogurt", "dairy"),
+        ("milk", "dairy"),
+        ("cheddar cheese", "dairy"),
+        ("butter", "dairy"),
+        ("sour cream", "dairy"),
+    ],
+)
+def test_detect_category_dairy(name: str, expected: str) -> None:
+    """Keyword matching should resolve all common dairy names to 'dairy' (#177)."""
+    assert detect_category(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("banana", "produce"),
+        ("apple", "produce"),
+        ("tomato", "produce"),
+        ("spinach", "produce"),
+    ],
+)
+def test_detect_category_produce(name: str, expected: str) -> None:
+    assert detect_category(name) == expected
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("chicken breast", "meat"),
+        ("ground beef", "meat"),
+        ("bacon", "meat"),
+        ("salmon", "seafood"),
+        ("tuna", "seafood"),
+    ],
+)
+def test_detect_category_protein(name: str, expected: str) -> None:
+    assert detect_category(name) == expected
+
+
+def test_detect_category_unknown_returns_none() -> None:
+    """Unknown items return None from detect_category so callers can fall back."""
+    result = detect_category("xyzunknownitem123")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Combined path (detect_category or catalog) — mirrors what the endpoint does
+# ---------------------------------------------------------------------------
+
+
+def test_combined_yogurt_resolves_dairy() -> None:
+    """The core bug from #177: 'yogurt' must resolve to 'dairy', not 'other'."""
+    result = detect_category("yogurt") or categorize("yogurt")
+    assert result == "dairy"
+
+
+def test_combined_unknown_returns_none() -> None:
+    """When neither stage matches, callers should fall back to 'other'."""
+    result = detect_category("xyzunknownitem123") or categorize("xyzunknownitem123")
+    assert result is None
+

--- a/nextjs/src/app/api/pantry/bulk/route.ts
+++ b/nextjs/src/app/api/pantry/bulk/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server'
 import { requireAuth, errorResponse } from '@/lib/response-helpers'
 import { enrichPantryItem } from '@/lib/pantry-helpers'
-import { estimateExpiry } from '@/lib/api/ai-proxy'
+import { estimateExpiry, estimateCategory } from '@/lib/api/ai-proxy'
 import type { PantryItemRow } from '@/lib/pantry-helpers'
 
 interface BulkItemInput {
@@ -25,23 +25,28 @@ export async function POST(request: Request) {
     return errorResponse('items must be a non-empty array', 400)
   }
 
-  // Fill in a default expiry for any item the user didn't date (#158). The
-  // estimate comes from the AI service's Python heuristic (single source of
-  // truth); a failure falls back to null and never blocks the add.
+  // Fill in category and expiry for items the user left at defaults (#177, #158).
+  // Both come from the AI service's Python catalog/heuristic (single source of
+  // truth); failures fall back to 'other'/null and never block the add.
   const rows = await Promise.all(
     items.map(async (item) => {
+      const category =
+        item.category && item.category !== 'other'
+          ? item.category
+          : (await estimateCategory(item.name)) || item.category || 'other'
+
       const expiry =
         item.expiry_date ||
         (await estimateExpiry({
           name: item.name,
-          category: item.category,
+          category,
           location: item.storage_location,
         }))
       return {
         user_id: user.id,
         name: item.name,
         name_normalized: item.name.toLowerCase().trim(),
-        category: item.category || 'other',
+        category,
         location: item.storage_location || 'pantry',
         quantity: item.quantity ?? 1.0,
         unit: item.unit || 'item',


### PR DESCRIPTION
## Summary
Manually added pantry items landed in `other` (e.g. "yogurt") because the estimate-category endpoint used only the catalog fuzzy matcher (threshold 95), which misses common items the keyword normalizer catches. Receipt-scan and chat-add already categorize correctly.

## What lands
- Backend: `estimate_category` now runs `detect_category` (keyword, high priority) before the `categorize` catalog fallback, matching the receipt parser. "yogurt" → "dairy".
- Frontend: `/api/pantry/bulk` (the manual-add path via `PantryAddSheet`) calls `estimateCategory` for items left at default/`other`, with graceful fallback so a failed estimate never blocks the add.

## Tests
- `pytest`: keyword-path coverage for dairy/produce/protein + the exact "yogurt" → "dairy" regression. Full non-live suite green (174 passed).

## Linked
Closes #177

## Out of scope
Re-categorizing items already stored as `other`.