### PR TITLE
fix: implement receipt image deskewing before OCR (#181)

### DIFF
--- a/ai-service/bubbly_chef/services/image_preprocessor.py
+++ b/ai-service/bubbly_chef/services/image_preprocessor.py
@@ -304,9 +304,10 @@ class ImagePreprocessor:
         binary_img = Image.fromarray((binary * 255).astype(np.uint8), mode="L")
 
         for angle in angles:
-            # PIL.Image.rotate: positive angle = counter-clockwise; we later
-            # correct with the *negative* of the detected angle, so the sign
-            # convention is internally consistent.
+            # PIL.Image.rotate: positive angle = counter-clockwise. This is the
+            # candidate *correction* applied to the skewed image; the angle that
+            # maximises row-sum variance best straightens the text. The reported
+            # tilt is the negative of this (see the return statement).
             rotated = binary_img.rotate(
                 float(angle), resample=Image.Resampling.BILINEAR, expand=False
             )
@@ -343,7 +344,12 @@ class ImagePreprocessor:
             )
             return 0.0
 
-        return best_angle
+        # The sweep's ``best_angle`` is the rotation that, applied to the
+        # skewed image, maximises alignment — i.e. it is the *correction*
+        # rotation.  The reported skew of the document is the negative of that
+        # (a document tilted +θ CCW is straightened by rotating −θ).  Return the
+        # tilt; ``_deskew_image`` negates it again to derive the correction.
+        return -best_angle
 
     def _deskew_image(self, image: Image.Image) -> Image.Image:
         """

--- a/ai-service/bubbly_chef/services/image_preprocessor.py
+++ b/ai-service/bubbly_chef/services/image_preprocessor.py
@@ -1,9 +1,8 @@
 """Image preprocessing service for optimal OCR performance."""
 
 import io
-from typing import Literal
-
 import logging
+from typing import ClassVar, Literal
 
 import numpy as np
 from PIL import Image, ImageEnhance, ImageFilter, ImageOps
@@ -244,27 +243,148 @@ class ImagePreprocessor:
 
         return image
 
+    # ------------------------------------------------------------------ #
+    # Deskew constants                                                    #
+    # ------------------------------------------------------------------ #
+    _DESKEW_MAX_ANGLE: ClassVar[float] = 15.0  # degrees — clamp correction to ±15°
+    _DESKEW_ANGLE_STEP: ClassVar[float] = 0.5  # degrees — sweep resolution
+    # Minimum relative variance improvement to commit a rotation.
+    # A value of 0.02 means the best angle must improve row-sum variance by
+    # at least 2 % over the 0° baseline — protects already-straight images.
+    _DESKEW_MIN_IMPROVEMENT: ClassVar[float] = 0.02
+
+    def detect_skew_angle(self, image: Image.Image) -> float:
+        """
+        Estimate the skew angle of a document image using horizontal
+        projection-profile analysis (pure Pillow + NumPy, no OpenCV).
+
+        Algorithm
+        ---------
+        1. Down-scale to a working resolution (≤800 px wide) for speed.
+        2. Convert to binary (Otsu-like global threshold).
+        3. Sweep candidate angles from –MAX to +MAX degrees.
+        4. For each candidate, rotate the binary image and compute the
+           variance of its horizontal projection profile (row sums of dark
+           pixels).  Well-aligned text produces sharp, high-variance row
+           peaks; misaligned text smears those peaks horizontally.
+        5. Return the angle that maximises row-sum variance.
+           Return 0.0 if the improvement over the 0° baseline is below
+           ``_DESKEW_MIN_IMPROVEMENT`` (confidence guard).
+
+        Args:
+            image: Grayscale (L-mode) PIL Image.
+
+        Returns:
+            Detected skew angle in degrees.  Positive → clockwise tilt;
+            negative → counter-clockwise tilt.  0.0 means "no correction".
+        """
+        # --- 1. Resize to a fast working size (≤ 800 px wide) ----------
+        max_width = 800
+        scale = min(1.0, max_width / max(image.width, 1))
+        work_w = max(1, int(image.width * scale))
+        work_h = max(1, int(image.height * scale))
+        small = image.resize((work_w, work_h), Image.Resampling.LANCZOS)
+
+        # --- 2. Binarise (invert so text pixels = 1, background = 0) ---
+        arr = np.array(small, dtype=np.float32)
+        threshold = float(np.mean(arr))
+        # text is dark → below threshold
+        binary = (arr < threshold).astype(np.float32)
+
+        # --- 3. Sweep angles and record row-sum variance ----------------
+        best_angle = 0.0
+        best_variance = -1.0
+
+        angles = np.arange(
+            -self._DESKEW_MAX_ANGLE,
+            self._DESKEW_MAX_ANGLE + self._DESKEW_ANGLE_STEP,
+            self._DESKEW_ANGLE_STEP,
+        )
+
+        binary_img = Image.fromarray((binary * 255).astype(np.uint8), mode="L")
+
+        for angle in angles:
+            # PIL.Image.rotate: positive angle = counter-clockwise; we later
+            # correct with the *negative* of the detected angle, so the sign
+            # convention is internally consistent.
+            rotated = binary_img.rotate(
+                float(angle), resample=Image.Resampling.BILINEAR, expand=False
+            )
+            rot_arr = np.array(rotated, dtype=np.float32)
+            row_sums = rot_arr.sum(axis=1)
+            variance = float(np.var(row_sums))
+            if variance > best_variance:
+                best_variance = variance
+                best_angle = float(angle)
+
+        # --- 4. Confidence guard: compare best against 0° baseline -----
+        baseline_sums = np.array(binary_img, dtype=np.float32).sum(axis=1)
+        baseline_variance = float(np.var(baseline_sums))
+
+        if baseline_variance <= 0:
+            logger.debug("Deskew: baseline variance is zero, skipping correction")
+            return 0.0
+
+        improvement = (best_variance - baseline_variance) / baseline_variance
+        logger.debug(
+            f"Deskew: best_angle={best_angle:.1f}°, "
+            f"baseline_var={baseline_variance:.1f}, best_var={best_variance:.1f}, "
+            f"improvement={improvement:.4f}"
+        )
+
+        if abs(best_angle) < self._DESKEW_ANGLE_STEP / 2:
+            # The 0° candidate already won — no rotation needed.
+            return 0.0
+
+        if improvement < self._DESKEW_MIN_IMPROVEMENT:
+            logger.debug(
+                f"Deskew: improvement {improvement:.4f} below threshold "
+                f"{self._DESKEW_MIN_IMPROVEMENT}, skipping correction"
+            )
+            return 0.0
+
+        return best_angle
+
     def _deskew_image(self, image: Image.Image) -> Image.Image:
         """
         Correct image rotation (deskewing).
 
-        Uses a simple approach: detect text orientation and rotate if needed.
-        For production, consider using libraries like deskew or scikit-image.
+        Detects the skew angle using horizontal projection-profile analysis
+        (pure Pillow + NumPy) and rotates the image to horizontal.  Correction
+        is clamped to ±``_DESKEW_MAX_ANGLE`` degrees and skipped when
+        confidence is too low to avoid harming already-straight images.
+
+        Args:
+            image: Grayscale (L-mode) PIL Image.
+
+        Returns:
+            Deskewed PIL Image (same mode as input).
+
+        Raises:
+            ValueError: Re-raised as a warning — caller falls back to original.
         """
         try:
-            # Convert to numpy array
-            np.array(image)
+            angle = self.detect_skew_angle(image)
 
-            # Calculate projection profile to detect skew
-            # This is a simplified implementation
-            # For better results, use dedicated libraries like deskew
+            if angle == 0.0:
+                logger.debug("Deskew: no correction needed")
+                return image
 
-            # For now, we'll just do a basic check
-            # In production, you'd use more sophisticated methods
+            # Clamp (redundant given the sweep range, but defensive)
+            angle = max(-self._DESKEW_MAX_ANGLE, min(self._DESKEW_MAX_ANGLE, angle))
 
-            # Return original image for now
-            # TODO: Implement proper deskewing with angle detection
-            return image
+            # PIL.Image.rotate with a positive angle rotates counter-clockwise.
+            # Our detected angle is the CCW angle that maximises alignment, so
+            # we rotate by *negative* that angle to undo the tilt.
+            correction = -angle
+            deskewed = image.rotate(
+                correction,
+                resample=Image.Resampling.BILINEAR,
+                expand=False,
+                fillcolor=255,  # fill new corners with white (background)
+            )
+            logger.info(f"Deskew: corrected {angle:.1f}° → applied {correction:.1f}° rotation")
+            return deskewed
 
         except Exception as e:
             logger.warning(f"Deskewing failed: {e}, returning original image")

--- a/ai-service/tests/test_image_preprocessor.py
+++ b/ai-service/tests/test_image_preprocessor.py
@@ -1,0 +1,236 @@
+"""Tests for ImagePreprocessor deskewing logic (issue #181).
+
+All tests are pure-Python / PIL + NumPy — no real images, no AI calls,
+no network access required.
+
+Synthetic images
+----------------
+* A "receipt-like" image is created by drawing horizontal bands of dark
+  pixels on a white background (mimicking lines of text).  When that image
+  is rotated by a known angle, `detect_skew_angle` should return an angle
+  close to the applied tilt, and `_deskew_image` should produce output that
+  is measurably more horizontal (higher row-sum variance) than the
+  deliberately skewed input.
+
+* A flat, featureless image (uniform grey) is used to verify that the
+  confidence guard returns 0.0 and no rotation is applied.
+"""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from bubbly_chef.services.image_preprocessor import ImagePreprocessor, get_image_preprocessor
+
+
+# --------------------------------------------------------------------------- #
+# Helpers                                                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _make_lined_image(
+    width: int = 400,
+    height: int = 600,
+    n_lines: int = 20,
+    line_thickness: int = 3,
+    bg: int = 255,
+    fg: int = 30,
+) -> Image.Image:
+    """Create a grayscale image with evenly-spaced horizontal dark bands.
+
+    This simulates the horizontal text lines on a receipt; it gives the
+    projection-profile algorithm a clear signal to work with.
+    """
+    arr = np.full((height, width), bg, dtype=np.uint8)
+    step = height // (n_lines + 1)
+    for i in range(1, n_lines + 1):
+        y = i * step
+        arr[y : y + line_thickness, :] = fg
+    return Image.fromarray(arr, mode="L")
+
+
+def _rotate_image(image: Image.Image, angle: float) -> Image.Image:
+    """Rotate image by *angle* degrees (CCW in PIL convention), white fill."""
+    return image.rotate(angle, resample=Image.Resampling.BILINEAR, expand=False, fillcolor=255)
+
+
+def _row_sum_variance(image: Image.Image) -> float:
+    """Return variance of horizontal projection profile (row sums of dark pixels)."""
+    arr = np.array(image, dtype=np.float32)
+    # invert so dark = 1
+    dark = 255.0 - arr
+    return float(np.var(dark.sum(axis=1)))
+
+
+# --------------------------------------------------------------------------- #
+# detect_skew_angle                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestDetectSkewAngle:
+    """Unit tests for ImagePreprocessor.detect_skew_angle()."""
+
+    preprocessor: ImagePreprocessor
+
+    def setup_method(self) -> None:
+        self.preprocessor = ImagePreprocessor(mode="aggressive")
+
+    def test_straight_image_returns_near_zero(self) -> None:
+        """A perfectly horizontal image should not trigger any correction."""
+        img = _make_lined_image()
+        angle = self.preprocessor.detect_skew_angle(img)
+        # The confidence guard should prevent spurious small corrections.
+        assert abs(angle) < 1.0, f"Expected ~0°, got {angle:.2f}°"
+
+    def test_detects_positive_skew(self) -> None:
+        """Rotating the reference image by +8° should yield a detected angle near +8°."""
+        applied = 8.0
+        img = _rotate_image(_make_lined_image(), applied)
+        detected = self.preprocessor.detect_skew_angle(img)
+        # Allow ±2.0° tolerance (sweep step is 0.5°; PIL rotation introduces
+        # minor aliasing that can shift the optimum by a step or two).
+        assert abs(detected - applied) <= 2.0, (
+            f"Applied {applied}°, detected {detected:.1f}° — too far off"
+        )
+
+    def test_detects_negative_skew(self) -> None:
+        """Rotating by –7° should yield a detected angle near –7°."""
+        applied = -7.0
+        img = _rotate_image(_make_lined_image(), applied)
+        detected = self.preprocessor.detect_skew_angle(img)
+        assert abs(detected - applied) <= 2.0, (
+            f"Applied {applied}°, detected {detected:.1f}° — too far off"
+        )
+
+    def test_uniform_image_returns_zero(self) -> None:
+        """A blank/uniform image has no projection signal — should return 0.0."""
+        uniform = Image.fromarray(np.full((200, 300), 200, dtype=np.uint8), mode="L")
+        angle = self.preprocessor.detect_skew_angle(uniform)
+        assert angle == 0.0, f"Expected 0.0 for featureless image, got {angle}"
+
+    def test_large_skew_clamped_to_max_angle(self) -> None:
+        """Skew beyond ±15° is outside the sweep range; detected angle must stay ≤ MAX."""
+        # Rotate by 20° — beyond _DESKEW_MAX_ANGLE; the sweep can only return up to 15°.
+        img = _rotate_image(_make_lined_image(), 20.0)
+        detected = self.preprocessor.detect_skew_angle(img)
+        assert abs(detected) <= ImagePreprocessor._DESKEW_MAX_ANGLE + 0.01, (
+            f"Detected angle {detected:.1f}° exceeds clamped maximum"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# _deskew_image                                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestDeskewImage:
+    """Unit tests for ImagePreprocessor._deskew_image()."""
+
+    preprocessor: ImagePreprocessor
+
+    def setup_method(self) -> None:
+        self.preprocessor = ImagePreprocessor(mode="aggressive")
+
+    def test_deskewed_output_is_more_horizontal_than_input(self) -> None:
+        """After deskewing a 10°-tilted image the row-sum variance should increase."""
+        original = _make_lined_image()
+        skewed = _rotate_image(original, 10.0)
+
+        before_variance = _row_sum_variance(skewed)
+        deskewed = self.preprocessor._deskew_image(skewed)
+        after_variance = _row_sum_variance(deskewed)
+
+        assert after_variance > before_variance, (
+            f"Deskewing did not improve alignment: "
+            f"before={before_variance:.1f}, after={after_variance:.1f}"
+        )
+
+    def test_straight_image_unchanged(self) -> None:
+        """A straight image should come out pixel-identical (no rotation applied)."""
+        img = _make_lined_image()
+        result = self.preprocessor._deskew_image(img)
+        # If no rotation was applied, the returned object is the same instance.
+        assert result is img, "Straight image should not be rotated (identity return expected)"
+
+    def test_deskew_returns_l_mode_image(self) -> None:
+        """Output must remain in grayscale L mode."""
+        skewed = _rotate_image(_make_lined_image(), 5.0)
+        deskewed = self.preprocessor._deskew_image(skewed)
+        assert deskewed.mode == "L", f"Expected L mode, got {deskewed.mode}"
+
+    def test_deskew_does_not_change_image_dimensions(self) -> None:
+        """Output must have the same WxH as input (expand=False)."""
+        skewed = _rotate_image(_make_lined_image(400, 600), 8.0)
+        deskewed = self.preprocessor._deskew_image(skewed)
+        assert deskewed.size == skewed.size, (
+            f"Dimensions changed: {skewed.size} → {deskewed.size}"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Integration: aggressive pipeline includes deskew                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestAggressivePipelineIncludesDeskew:
+    """Smoke-test that the aggressive preprocessing pipeline runs end-to-end
+    without error when given a skewed image, and that the output is a valid
+    single-channel image of the same dimensions.
+    """
+
+    @pytest.mark.asyncio
+    async def test_aggressive_preprocess_runs_without_error(self) -> None:
+        """preprocess(mode='aggressive') must complete without raising."""
+        preprocessor = ImagePreprocessor(mode="aggressive")
+
+        # Build a skewed receipt-like image and encode to PNG bytes
+        skewed = _rotate_image(_make_lined_image(300, 500), 7.0)
+        buf = io.BytesIO()
+        skewed.save(buf, format="PNG")
+        image_bytes = buf.getvalue()
+
+        result = await preprocessor.preprocess(image_bytes, return_format="image")
+        assert isinstance(result, Image.Image)
+        # Output is grayscale (binarized at end of aggressive pipeline)
+        assert result.mode == "L"
+
+    @pytest.mark.asyncio
+    async def test_aggressive_preprocess_returns_bytes_by_default(self) -> None:
+        """preprocess() with return_format='bytes' returns raw bytes."""
+        preprocessor = ImagePreprocessor(mode="aggressive")
+
+        straight = _make_lined_image(200, 300)
+        buf = io.BytesIO()
+        straight.save(buf, format="PNG")
+        image_bytes = buf.getvalue()
+
+        result = await preprocessor.preprocess(image_bytes, return_format="bytes")
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Singleton / factory helper                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_get_image_preprocessor_returns_instance() -> None:
+    p = get_image_preprocessor(mode="aggressive")
+    assert isinstance(p, ImagePreprocessor)
+    assert p.mode == "aggressive"
+
+
+def test_get_image_preprocessor_caches_by_mode() -> None:
+    p1 = get_image_preprocessor(mode="light")
+    p2 = get_image_preprocessor(mode="light")
+    assert p1 is p2, "Should return the same cached instance for the same mode"
+
+
+def test_get_image_preprocessor_different_modes_are_different_instances() -> None:
+    p_light = get_image_preprocessor(mode="light")
+    p_agg = get_image_preprocessor(mode="aggressive")
+    assert p_light is not p_agg


### PR DESCRIPTION
## Summary
Receipt preprocessing had a deskew TODO — angled photos were sent to OCR untilted, hurting parse quality.

## What lands
- `detect_skew_angle` — projection-profile sweep (−15°…+15° at 0.5°), pure Pillow + NumPy, no new dependency. Picks the rotation maximising horizontal row-sum variance; a 2% confidence guard leaves already-straight images untouched.
- `_deskew_image` applies the correction (clamped ±15°, white corner fill), wired into the aggressive pipeline exactly where the TODO was, before binarization.
- Sign convention corrected so detection reports the document tilt and correction straightens it (an earlier revision inverted this and worsened alignment; caught by the tests below).

## Tests
- `test_image_preprocessor.py` (14): angle detection for straight/±skew/uniform/clamped inputs, deskew improves row-sum variance on a tilted image, identity on straight, mode/dimensions preserved, pipeline integration. All green.

## Linked
Closes #181

## Out of scope
OpenCV-based detection; per-angle rotate cost optimization.