### PR TITLE
docs: R3 Cooking Companion + R4 unified ingest design stubs

### DIFF
--- a/docs/plans/2026-07-29-r3-cooking-companion.md
+++ b/docs/plans/2026-07-29-r3-cooking-companion.md
@@ -1,0 +1,55 @@
+# R3 — Cooking Companion sub-graph (design stub)
+
+**Status:** Stub / not started · **Tracking:** #187 (R5 #189 depends on this)
+**Date:** 2026-07-29
+
+> This is a scoping stub, not a finished design. It captures what R3 delivers, the
+> foundation it must build, and the open questions to resolve before implementation.
+
+## Goal
+
+A ReAct-style chat sub-graph the assistant enters when the user is cooking and asks
+help questions — "I'm out of buttermilk, what do I use?", "how do I fold egg whites?".
+The assistant reasons and calls **tools** to answer, rather than free-generating.
+
+Per CONTEXT.md, the Cooking sub-graph is "ReAct-style with tool access
+(substitutions, techniques)". Initial tools named in `docs/plans/2026-04-29-active-work-items.md`:
+`suggest_substitution`, `explain_technique`.
+
+## The foundation this phase must build (load-bearing)
+
+There is **no tool-calling / ReAct infrastructure in the codebase today** — confirmed
+no `ToolNode`, `bind_tools`, or `create_react_agent` anywhere. The `tools/` directory
+holds plain async functions (`expiry`, `normalizer`, `product_lookup`, `web_search`)
+but none are bound to an LLM.
+
+R3 is therefore where the **shared tool registry** gets built — the piece the docs
+describe as: *"plain Python async functions callable from sub-graph nodes, API routes,
+and LLM ToolNode (eliminates scan/chat duplication)."* This registry is the shared
+dependency that **R5 (#189) also needs** — build it once here.
+
+Concretely R3 delivers:
+1. A tool-registry pattern (decorate/register plain async fns; expose them as LLM tools).
+2. The ReAct loop wired into a LangGraph sub-graph (model ↔ ToolNode).
+3. First two tools: `suggest_substitution`, `explain_technique`.
+4. Router wiring: a Cooking intent that dispatches into this sub-graph.
+5. No data mutation (read-only cooking help).
+
+## Dependencies
+
+- **Blocks R5 (#189)** — R5 reuses this tool registry + ReAct base for proactive general chat.
+- **Independent of R4** (ingest consolidation).
+- Provider caveat: tool-calling must work through `AIManager` (Gemini primary, Ollama
+  fallback) — verify both providers support the tool-calling path, or gate by provider.
+
+## Open questions (resolve before build)
+
+- LangGraph prebuilt (`create_react_agent`/`ToolNode`) vs. a hand-rolled loop?
+- Tool-registry shape — decorator vs. explicit registration; how routes reuse it.
+- Which model tier runs the loop, and Gemini-vs-Ollama tool-calling parity.
+- Intent boundary: how does the router decide "cooking help" vs. recipe-generate/general-chat?
+- Tool scope for v1 — just substitution + technique, or more (unit help, timing)?
+
+## Size
+
+Medium–large. The value is mostly the reusable foundation; the two tools themselves are small.

--- a/docs/plans/2026-07-29-r4-unified-ingest.md
+++ b/docs/plans/2026-07-29-r4-unified-ingest.md
@@ -1,0 +1,60 @@
+# R4 — Unified multimodal Ingest sub-graph (design stub)
+
+**Status:** Stub / not started · **Tracking:** #188 (epic over #190 video, #180 URL cleanup)
+**Date:** 2026-07-29
+
+> Scoping stub, not a finished design. Captures what R4 consolidates and the open
+> questions before implementation.
+
+## Goal
+
+One multimodal **Ingest sub-graph** that handles every "get stuff into the app" path —
+photo/receipt, product barcode, recipe URL, video, pasted text — instead of today's
+separate, partially-wired workflows. Per CONTEXT.md: *"Ingest — unified multimodal:
+photo, URL, video, receipt, text."*
+
+## Current state (fragmented — the problem R4 solves)
+
+Ingestion is scattered across `ai-service/bubbly_chef/workflows/`:
+
+| Path | Today | Notes |
+|------|-------|-------|
+| Receipt | `receipt_ingest.py` | Live, wired to the scan route |
+| Recipe URL | `services/recipe_url_ingestor.py` | Live (recipe-scrapers + Gemini fallback), wired to `/v1/ingest/recipe-url` |
+| Recipe URL (old) | `recipe_ingest.py` | **Dead stub** — being removed in #180 |
+| Product/barcode | `product_ingest.py` | Graph built but **no caller**; lookup is a stub (real work in #191) |
+| Video | — | **Absent** (#190) |
+
+So the same conceptual operation lives in 4+ places with inconsistent wiring, and the
+chat router only emits "handoff" messages for most of them rather than running the graph.
+
+## What R4 delivers
+
+- A single Ingest sub-graph: **detect modality → route to the right extractor → normalize
+  → proposal envelope** (the existing proposal/confidence pattern).
+- Absorbs the concrete ingest issues as its extractors:
+  - **#190 video ingestion** — the new subsystem (transcription + extraction).
+  - **#180** URL stub removal — leaves `recipe_url_ingestor.py` as the URL extractor.
+  - **#191 barcode** — product lookup + entry point (can ship standalone first, folded in later).
+- Consistent entry point + router dispatch so ingestion actually runs from chat, not just handoff text.
+
+## Dependencies
+
+- **Independent of R3/R5** (no tool-calling foundation needed).
+- Soft-consumes #190, #180, #191 — those can ship standalone; R4 consolidates them.
+- The frontend URL classifier (`nextjs/src/lib/url-classifier.ts`) is currently dead code;
+  R4's modality detection is where it would finally get consumed (or replaced server-side).
+
+## Open questions (resolve before build)
+
+- Modality detection: client-side (existing url-classifier) vs. server-side sniffing?
+- Do we consolidate *before* or *after* video (#190) exists? (Building R4 first gives video a home;
+  building video standalone first gives R4 a working extractor to fold in.)
+- Video pipeline is the big unknown — transcription provider, cost, whether it's in v1 of R4 at all.
+- One `/ingest` endpoint with a modality param vs. keeping per-modality routes behind a shared graph.
+
+## Size
+
+Large (consolidation + the video subsystem). Sequencing note: the individual extractors
+(#180 cleanup, #191 barcode) are cheaper standalone; R4 is worth doing once ≥2 modalities
+justify the shared graph, or when video (#190) needs a home.


### PR DESCRIPTION
## Summary

Two scoping stubs in \`docs/plans/\` for the remaining AI-workflow refactor epics, written during the 2026-07-29 QA/triage session. Docs only — no code.

## What lands

- \`docs/plans/2026-07-29-r3-cooking-companion.md\` — R3 Cooking Companion sub-graph (#187). Key finding: no tool-calling/ReAct infra exists yet, so R3 is where the shared tool registry gets built; R5 (#189) reuses it.
- \`docs/plans/2026-07-29-r4-unified-ingest.md\` — R4 unified multimodal ingest (#188), consolidating the fragmented receipt/URL/product/video paths. Epic over #190/#180/#191.

Both list open questions to resolve before implementation. Neither is agent-ready yet.

## Tests

N/A — documentation only.

## Linked

#187, #188, #189

## Out of scope

Implementation of any refactor phase; resolving the open design questions.