### PR TITLE
feat: R3 Cooking Companion — ReAct sub-graph with tool access (#187)

### DIFF
--- a/ai-service/bubbly_chef/ai/anthropic.py
+++ b/ai-service/bubbly_chef/ai/anthropic.py
@@ -56,12 +56,21 @@ class AnthropicProvider(AIProvider):
         return f"anthropic/{self.model}"
 
     def _headers(self) -> dict[str, str]:
-        """Build request headers, including x-api-key only when configured."""
+        """Build request headers.
+
+        When an api_key is configured we send it two ways so the same provider
+        works against both endpoints it targets:
+          - ``Authorization: Bearer <key>`` — required by the SAP proxy, which
+            rejects requests lacking it with 401 MISSING_AUTHORIZATION_HEADER.
+          - ``x-api-key: <key>`` — the header the direct Anthropic API expects.
+        Sending both is harmless: each endpoint reads the one it knows.
+        """
         headers = {
             "anthropic-version": "2023-06-01",
             "content-type": "application/json",
         }
         if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
             headers["x-api-key"] = self.api_key
         return headers
 

--- a/ai-service/bubbly_chef/ai/anthropic.py
+++ b/ai-service/bubbly_chef/ai/anthropic.py
@@ -15,7 +15,7 @@ from typing import Any, TypeVar
 import httpx
 from pydantic import BaseModel, ValidationError
 
-from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError
+from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError, ToolCall, ToolCallResponse
 
 logger = logging.getLogger(__name__)
 
@@ -166,6 +166,127 @@ Return ONLY the JSON, no markdown formatting or extra text."""
     @property
     def supports_vision(self) -> bool:
         return True
+
+    @property
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def _build_anthropic_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Translate provider-neutral tool schemas to Anthropic wire format."""
+        anthropic_tools = []
+        for t in tools:
+            anthropic_tools.append(
+                {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "input_schema": t.get("parameters", {"type": "object", "properties": {}}),
+                }
+            )
+        return anthropic_tools
+
+    def _messages_to_anthropic(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert provider-neutral messages to Anthropic Messages API format.
+
+        Provider-neutral roles:
+          - "user"        → Anthropic "user" with text content block.
+          - "assistant"   → Anthropic "assistant"; content may be a list of blocks
+                            (tool_use + text) or a plain string.
+          - "tool_result" → Anthropic "user" with a tool_result content block.
+
+        The neutral format uses a ``content`` field that can be:
+          - str                 plain text
+          - list[dict]          pre-built content blocks (for assistant tool-use turns
+                                and user tool_result turns built by the ReAct node)
+        """
+        result = []
+        for msg in messages:
+            role = msg["role"]
+            content = msg["content"]
+            if role == "tool_result":
+                # Node passes pre-built Anthropic tool_result blocks in content
+                result.append({"role": "user", "content": content})
+            elif role == "assistant" and isinstance(content, list):
+                # Pre-built assistant blocks (tool_use turns)
+                result.append({"role": "assistant", "content": content})
+            else:
+                result.append(
+                    {
+                        "role": role,
+                        "content": [{"type": "text", "text": str(content)}],
+                    }
+                )
+        return result
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float = 0.7,
+    ) -> ToolCallResponse:
+        """Run one tool-calling turn against the Anthropic Messages API.
+
+        Args:
+            messages:    Provider-neutral running conversation.
+            tools:       Registry tool schemas (name, description, parameters).
+            temperature: Sampling temperature.
+
+        Returns:
+            ToolCallResponse with either tool_calls (model wants to act) or
+            text (final answer).
+        """
+        url = f"{self.base_url}/v1/messages"
+        anthropic_tools = self._build_anthropic_tools(tools)
+        anthropic_messages = self._messages_to_anthropic(messages)
+
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": self.max_tokens,
+            "temperature": temperature,
+            "tools": anthropic_tools,
+            "messages": anthropic_messages,
+        }
+
+        try:
+            response = await self._client.post(url, json=payload, headers=self._headers())
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if hasattr(e.response, "text") else str(e)
+            if e.response.status_code == 429:
+                raise ProviderUnavailableError(
+                    f"Anthropic [{self.model}] tool-calling rate limit 429: {error_body}"
+                ) from e
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] tool-calling API error "
+                f"{e.response.status_code}: {error_body}"
+            ) from e
+        except httpx.RequestError as e:
+            raise ProviderUnavailableError(
+                f"Anthropic [{self.model}] tool-calling connection error: {e}"
+            ) from e
+
+        data = response.json()
+        stop_reason = data.get("stop_reason", "")
+        content_blocks: list[dict[str, Any]] = data.get("content", [])
+
+        if stop_reason == "tool_use":
+            tool_calls = [
+                ToolCall(
+                    id=block["id"],
+                    name=block["name"],
+                    arguments=block.get("input", {}),
+                )
+                for block in content_blocks
+                if block.get("type") == "tool_use"
+            ]
+            return ToolCallResponse(tool_calls=tool_calls)
+
+        # end_turn or any other stop reason → extract text
+        text_parts = [
+            block.get("text", "")
+            for block in content_blocks
+            if block.get("type") == "text"
+        ]
+        return ToolCallResponse(text=" ".join(text_parts).strip() or None)
 
     async def vision_complete(
         self,

--- a/ai-service/bubbly_chef/ai/gemini.py
+++ b/ai-service/bubbly_chef/ai/gemini.py
@@ -12,7 +12,7 @@ from typing import Any, TypeVar
 import httpx
 from pydantic import BaseModel, ValidationError
 
-from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError
+from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError, ToolCall, ToolCallResponse
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +141,135 @@ Return ONLY the JSON, no markdown formatting or extra text."""
     @property
     def supports_vision(self) -> bool:
         return True
+
+    @property
+    def supports_tool_calling(self) -> bool:
+        return True
+
+    def _build_gemini_tools(self, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Translate provider-neutral tool schemas to Gemini functionDeclarations format."""
+        declarations = []
+        for t in tools:
+            declarations.append(
+                {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": t.get(
+                        "parameters", {"type": "object", "properties": {}}
+                    ),
+                }
+            )
+        return [{"functionDeclarations": declarations}]
+
+    def _messages_to_gemini(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert provider-neutral messages to Gemini ``contents`` format.
+
+        Provider-neutral roles:
+          - "user"        → Gemini role "user", text part.
+          - "assistant"   → Gemini role "model"; content may be a list of
+                            pre-built Gemini parts (functionCall parts) or a str.
+          - "tool_result" → Gemini role "user", functionResponse part.
+                            The node stores pre-built Gemini part dicts in ``content``.
+        """
+        result = []
+        for msg in messages:
+            role = msg["role"]
+            content = msg["content"]
+            if role == "tool_result":
+                # Pre-built functionResponse part(s) from the ReAct node
+                parts = content if isinstance(content, list) else [content]
+                result.append({"role": "user", "parts": parts})
+            elif role == "assistant" and isinstance(content, list):
+                result.append({"role": "model", "parts": content})
+            else:
+                result.append({"role": "user" if role == "user" else "model",
+                                "parts": [{"text": str(content)}]})
+        return result
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float = 0.7,
+    ) -> ToolCallResponse:
+        """Run one tool-calling turn against the Gemini generateContent API.
+
+        Args:
+            messages:    Provider-neutral running conversation.
+            tools:       Registry tool schemas (name, description, parameters).
+            temperature: Sampling temperature.
+
+        Returns:
+            ToolCallResponse with either tool_calls or final text.
+        """
+        url = f"{self.BASE_URL}/models/{self.model}:generateContent"
+        gemini_tools = self._build_gemini_tools(tools)
+        gemini_contents = self._messages_to_gemini(messages)
+
+        generation_config: dict[str, Any] = {
+            "temperature": temperature,
+            "topP": 0.95,
+            "topK": 40,
+        }
+
+        payload: dict[str, Any] = {
+            "contents": gemini_contents,
+            "tools": gemini_tools,
+            "generationConfig": generation_config,
+        }
+
+        try:
+            response = await self._client.post(
+                url,
+                json=payload,
+                params={"key": self.api_key},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            error_body = e.response.text[:500] if hasattr(e.response, "text") else str(e)
+            if e.response.status_code == 429:
+                raise ProviderUnavailableError(
+                    f"Gemini [{self.model}] tool-calling rate limit 429: {error_body}"
+                ) from e
+            raise ProviderUnavailableError(
+                f"Gemini [{self.model}] tool-calling API error "
+                f"{e.response.status_code}: {error_body}"
+            ) from e
+        except httpx.RequestError as e:
+            raise ProviderUnavailableError(
+                f"Gemini [{self.model}] tool-calling connection error: {e}"
+            ) from e
+
+        data = response.json()
+        try:
+            parts: list[dict[str, Any]] = (
+                data["candidates"][0]["content"]["parts"]
+            )
+        except (KeyError, IndexError) as e:
+            raise ProviderUnavailableError(
+                f"Gemini [{self.model}] unexpected tool-calling response: {data}"
+            ) from e
+
+        # Collect function calls (if any)
+        tool_calls = []
+        text_parts = []
+        for part in parts:
+            if "functionCall" in part:
+                fc = part["functionCall"]
+                import uuid
+                tool_calls.append(
+                    ToolCall(
+                        id=str(uuid.uuid4()),
+                        name=fc["name"],
+                        arguments=fc.get("args", {}),
+                    )
+                )
+            elif "text" in part:
+                text_parts.append(part["text"])
+
+        if tool_calls:
+            return ToolCallResponse(tool_calls=tool_calls)
+        return ToolCallResponse(text=" ".join(text_parts).strip() or None)
 
     async def vision_complete(
         self,

--- a/ai-service/bubbly_chef/ai/manager.py
+++ b/ai-service/bubbly_chef/ai/manager.py
@@ -10,7 +10,7 @@ from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
-from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError
+from .provider import AIProvider, ProviderUnavailableError, StructuredOutputError, ToolCallResponse
 
 logger = logging.getLogger(__name__)
 
@@ -219,6 +219,74 @@ class AIManager:
 
         raise NoProviderAvailableError(
             f"No vision-capable provider available. Errors: {errors}"
+        )
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float = 0.7,
+    ) -> ToolCallResponse:
+        """Run one tool-calling turn using the first capable provider.
+
+        Mirrors ``vision_complete``: iterates providers, skips those where
+        ``supports_tool_calling`` is False, calls the first available capable
+        one, cascades on ProviderUnavailableError.
+
+        Args:
+            messages: Running conversation in provider-neutral format.
+            tools:    Tool schemas from the registry (name, description, parameters).
+            temperature: Sampling temperature.
+
+        Returns:
+            ToolCallResponse — either tool calls to execute or a final text answer.
+
+        Raises:
+            NoProviderAvailableError: If no tool-calling-capable provider is available.
+        """
+        errors: list[str] = []
+        start_time = datetime.now()
+
+        for provider in self.providers:
+            if not provider.supports_tool_calling:
+                continue
+            try:
+                if not await provider.is_available():
+                    errors.append(f"{provider.name}: not available")
+                    continue
+
+                logger.info(
+                    f"AI tool-calling request starting on [{provider.name}] "
+                    f"(messages={len(messages)}, tools={len(tools)})"
+                )
+
+                result = await provider.complete_with_tools(
+                    messages=messages,
+                    tools=tools,
+                    temperature=temperature,
+                )
+                self._current_provider = provider
+
+                elapsed = (datetime.now() - start_time).total_seconds()
+                logger.info(
+                    f"AI tool-calling completed on [{provider.name}] in {elapsed:.2f}s "
+                    f"(tool_calls={len(result.tool_calls)}, has_text={result.text is not None})"
+                )
+                return result
+
+            except ProviderUnavailableError as e:
+                errors.append(f"{provider.name}: {e}")
+                continue
+            except Exception as e:
+                logger.error(
+                    f"AI tool-calling [{provider.name}] unexpected error: {e}",
+                    exc_info=True,
+                )
+                errors.append(f"{provider.name}: {e}")
+                continue
+
+        raise NoProviderAvailableError(
+            f"No tool-calling-capable provider available. Errors: {errors}"
         )
 
     async def stream_complete(

--- a/ai-service/bubbly_chef/ai/provider.py
+++ b/ai-service/bubbly_chef/ai/provider.py
@@ -6,11 +6,46 @@ Supports structured output generation with Pydantic models.
 
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
-from typing import TypeVar
+from typing import Any, TypeVar
 
 from pydantic import BaseModel
 
 T = TypeVar("T", bound=BaseModel)
+
+
+# =============================================================================
+# Tool-calling result types
+# =============================================================================
+
+
+class ToolCall(BaseModel):
+    """A single tool call requested by the model.
+
+    Attributes:
+        id:        Provider-assigned call ID (used to match results back).
+        name:      The registered tool name to invoke.
+        arguments: Decoded arguments dict — keys match the tool's parameter names.
+    """
+
+    id: str
+    name: str
+    arguments: dict[str, Any]
+
+
+class ToolCallResponse(BaseModel):
+    """Result returned by ``complete_with_tools``.
+
+    Exactly one of ``text`` or ``tool_calls`` will be populated per turn:
+
+    - ``tool_calls`` is non-empty → the model wants to call tools; the caller
+      should invoke them, append observations, and call ``complete_with_tools``
+      again with the extended message history.
+    - ``tool_calls`` is empty / ``text`` is set → the model produced a final
+      answer; the ReAct loop should break and return ``text``.
+    """
+
+    text: str | None = None
+    tool_calls: list[ToolCall] = []
 
 
 class AIProvider(ABC):
@@ -62,6 +97,46 @@ class AIProvider(ABC):
     def supports_vision(self) -> bool:
         """Whether this provider supports image input."""
         return False
+
+    @property
+    def supports_tool_calling(self) -> bool:
+        """Whether this provider supports tool-calling (function calling).
+
+        Defaults to False. Providers that implement ``complete_with_tools``
+        should override this to return True.
+        """
+        return False
+
+    async def complete_with_tools(
+        self,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]],
+        temperature: float = 0.7,
+    ) -> "ToolCallResponse":
+        """Run one turn of the tool-calling loop.
+
+        ``messages`` is a running conversation in a provider-neutral format.
+        For the first call the list contains a single user message; on
+        subsequent iterations the caller appends assistant tool-use turns and
+        tool-result turns before calling again.
+
+        Message dict shape (provider-neutral):
+            {"role": "user" | "assistant" | "tool_result", "content": str | list}
+
+        Providers translate this to their own wire format internally.
+
+        ``tools`` is the list of tool schemas produced by the registry's
+        ``get_tool_schemas()`` — JSON Schema dicts with ``name``, ``description``
+        and ``parameters``.
+
+        Returns a ``ToolCallResponse``:
+        - If ``tool_calls`` is non-empty, the model wants to call tools.
+        - If ``tool_calls`` is empty, ``text`` contains the final answer.
+
+        Default implementation raises NotImplementedError.  Only providers
+        where ``supports_tool_calling`` is True should be called here.
+        """
+        raise NotImplementedError(f"{self.name} does not support tool calling")
 
     async def stream_complete(
         self,

--- a/ai-service/bubbly_chef/tools/cooking/__init__.py
+++ b/ai-service/bubbly_chef/tools/cooking/__init__.py
@@ -1,0 +1,12 @@
+"""Cooking tools package.
+
+Importing this package registers all cooking-specific tools with the
+tool registry. Import it explicitly in any node or route that needs the
+cooking tools — there is no import-time magic elsewhere.
+
+    import bubbly_chef.tools.cooking  # registers check_pantry, etc.
+"""
+
+from bubbly_chef.tools.cooking import pantry_tools as pantry_tools  # noqa: F401
+
+__all__ = ["pantry_tools"]

--- a/ai-service/bubbly_chef/tools/cooking/pantry_tools.py
+++ b/ai-service/bubbly_chef/tools/cooking/pantry_tools.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date
 
 from bubbly_chef.repository.supabase_repo import get_repository
 from bubbly_chef.tools.registry import tool
 
 logger = logging.getLogger(__name__)
+
+# Split a name into lowercase alphanumeric words, dropping possessive/plural
+# noise is unnecessary here — a simple word-set intersection is enough to match
+# "eggs" against "large free-range eggs" without matching "butter" ⊂ "buttermilk".
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def _words(text: str) -> set[str]:
+    """Return the set of lowercase alphanumeric words in ``text``."""
+    return set(_WORD_RE.findall(text.lower()))
 
 
 @tool
@@ -44,11 +55,16 @@ async def check_pantry(ingredient: str, *, user_id: str) -> str:
             expiry_note = days_until_expiry or ""
             return f"Yes, the pantry has {match.name}: {qty_str}{expiry_note}."
 
-        # 2. Fall back to a fuzzy scan of all items (substring match)
+        # 2. Fall back to a word-level scan of all items.  Match only on shared
+        #    whole words, not raw substrings — otherwise "buttermilk" wrongly
+        #    matches "butter" (butter ⊂ buttermilk) and "cream" matches
+        #    "ice cream sandwich".  Splitting on non-alphanumerics and comparing
+        #    word sets keeps "eggs" → "large free-range eggs" and
+        #    "chicken" → "chicken breast" while rejecting the false positives.
         items = await repo.get_all_pantry_items(user_id)
-        needle = ingredient.lower().strip()
+        needle_words = _words(ingredient)
         for item in items:
-            if needle in item.name.lower() or item.name.lower() in needle:
+            if needle_words & _words(item.name):
                 qty_str = f"{item.quantity} {item.unit}".strip()
                 return (
                     f"The pantry has '{item.name}' which may match "

--- a/ai-service/bubbly_chef/tools/cooking/pantry_tools.py
+++ b/ai-service/bubbly_chef/tools/cooking/pantry_tools.py
@@ -1,0 +1,62 @@
+"""Pantry-access cooking tool for the ReAct agent."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+
+from bubbly_chef.repository.supabase_repo import get_repository
+from bubbly_chef.tools.registry import tool
+
+logger = logging.getLogger(__name__)
+
+
+@tool
+async def check_pantry(ingredient: str, *, user_id: str) -> str:
+    """Check whether a specific ingredient is in the user's pantry.
+
+    Returns the quantity and unit if found, or a clear "not found" message.
+    Use this when the user asks about substitutions, whether they have
+    something on hand, or what they can cook given their current pantry.
+    Do NOT use this for general cooking knowledge the model already has.
+
+    Args:
+        ingredient: The ingredient to look up (e.g. "butter", "buttermilk").
+
+    Note:
+        ``user_id`` is node-injected and is NOT visible to the model.
+    """
+    try:
+        repo = await get_repository()
+
+        # 1. Try exact match via find_similar_item (normalized)
+        match = await repo.find_similar_item(user_id, ingredient)
+        if match:
+            days_until_expiry: str | None = None
+            if match.expiry_date:
+                days_left = (match.expiry_date - date.today()).days
+                days_until_expiry = (
+                    f", expires in {days_left} day(s)"
+                    if days_left >= 0
+                    else ", EXPIRED"
+                )
+            qty_str = f"{match.quantity} {match.unit}".strip()
+            expiry_note = days_until_expiry or ""
+            return f"Yes, the pantry has {match.name}: {qty_str}{expiry_note}."
+
+        # 2. Fall back to a fuzzy scan of all items (substring match)
+        items = await repo.get_all_pantry_items(user_id)
+        needle = ingredient.lower().strip()
+        for item in items:
+            if needle in item.name.lower() or item.name.lower() in needle:
+                qty_str = f"{item.quantity} {item.unit}".strip()
+                return (
+                    f"The pantry has '{item.name}' which may match "
+                    f"'{ingredient}': {qty_str}."
+                )
+
+        return f"'{ingredient}' was not found in the pantry."
+
+    except Exception as e:
+        logger.warning(f"check_pantry lookup failed for '{ingredient}': {e}")
+        return f"Could not check pantry for '{ingredient}' right now."

--- a/ai-service/bubbly_chef/tools/registry.py
+++ b/ai-service/bubbly_chef/tools/registry.py
@@ -1,0 +1,220 @@
+"""Tool registry for the BubblyChef ReAct agent.
+
+Usage
+-----
+Decorate any async or sync function with ``@tool`` and it is automatically
+registered.  The decorator inspects the function's signature and docstring to
+build a provider-neutral JSON Schema tool spec.
+
+    from bubbly_chef.tools.registry import tool
+
+    @tool
+    async def my_tool(query: str) -> str:
+        \"\"\"Search for something useful.\"\"\"
+        return f"result for {query}"
+
+Keyword-only parameters (those after ``*``) are **node-injected** and are
+**excluded** from the model-facing schema.  The canonical node-injected param
+is ``user_id``:
+
+    @tool
+    async def check_pantry(ingredient: str, *, user_id: str) -> str:
+        ...
+
+When invoking through the registry the caller must pass node-injected params
+as keyword arguments:
+
+    fn, schema = get_tool("check_pantry")
+    result = await fn("butter", user_id="abc-123")
+
+The model only ever sees ``ingredient`` in the schema — ``user_id`` is
+invisible to it.
+
+Public API
+----------
+- ``tool``                 — decorator
+- ``get_tool(name)``       — returns (callable, schema_dict)
+- ``get_tool_schemas(names)`` — returns list of schema dicts for named tools
+- ``get_registered_tools()``  — returns copy of the full registry dict
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Internal registry
+# ---------------------------------------------------------------------------
+
+# Maps tool name → (callable, schema dict)
+_REGISTRY: dict[str, tuple[Callable[..., Any], dict[str, Any]]] = {}
+
+# ---------------------------------------------------------------------------
+# Type → JSON Schema helpers
+# ---------------------------------------------------------------------------
+
+_PYTHON_TO_JSON_TYPE: dict[type, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+}
+
+# String-form annotations (from `from __future__ import annotations` or PEP 563)
+_STRING_TO_JSON_TYPE: dict[str, str] = {
+    "str": "string",
+    "int": "integer",
+    "float": "number",
+    "bool": "boolean",
+}
+
+
+def _annotation_to_json_type(annotation: Any) -> str:
+    """Return a JSON Schema type string for a simple Python annotation.
+
+    Handles both runtime type objects (``int``) and string-form annotations
+    produced by ``from __future__ import annotations`` (``"int"``).
+    """
+    if isinstance(annotation, str):
+        return _STRING_TO_JSON_TYPE.get(annotation, "string")
+    return _PYTHON_TO_JSON_TYPE.get(annotation, "string")
+
+
+# ---------------------------------------------------------------------------
+# Schema builder
+# ---------------------------------------------------------------------------
+
+
+def _build_schema(
+    fn: Callable[..., Any],
+    description_override: str | None,
+) -> dict[str, Any]:
+    """Build a provider-neutral tool schema dict from a function.
+
+    Keyword-only parameters are excluded from the model-facing schema (they
+    are node-injected at invocation time, not supplied by the LLM).
+
+    Returns a dict with:
+        name        – function __name__
+        description – docstring or override
+        parameters  – JSON Schema object with positional params only
+    """
+    sig = inspect.signature(fn)
+    description = description_override or (inspect.getdoc(fn) or "").strip()
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+
+    for param_name, param in sig.parameters.items():
+        # Skip keyword-only params — these are node-injected (e.g. user_id)
+        if param.kind == inspect.Parameter.KEYWORD_ONLY:
+            continue
+        # Skip *args / **kwargs
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+
+        annotation = (
+            param.annotation
+            if param.annotation is not inspect.Parameter.empty
+            else str
+        )
+        json_type = _annotation_to_json_type(annotation)
+        properties[param_name] = {"type": json_type}
+
+        if param.default is inspect.Parameter.empty:
+            required.append(param_name)
+
+    parameters: dict[str, Any] = {
+        "type": "object",
+        "properties": properties,
+    }
+    if required:
+        parameters["required"] = required
+
+    return {
+        "name": fn.__name__,
+        "description": description,
+        "parameters": parameters,
+    }
+
+
+# ---------------------------------------------------------------------------
+# @tool decorator
+# ---------------------------------------------------------------------------
+
+
+def tool(
+    fn: Callable[..., Any] | None = None,
+    *,
+    description: str | None = None,
+) -> Any:
+    """Register a function as a callable tool.
+
+    Can be used as a bare decorator or with a ``description=`` override::
+
+        @tool
+        async def my_tool(x: str) -> str: ...
+
+        @tool(description="Override description here")
+        async def my_tool(x: str) -> str: ...
+
+    Keyword-only parameters (``*, param``) are **excluded** from the
+    model-facing JSON Schema and must be supplied by the caller at invocation
+    time (node-injected context, e.g. ``user_id``).
+
+    The wrapper is transparent (``functools.wraps``) so direct calls work
+    normally.
+    """
+
+    def _decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        schema = _build_schema(func, description)
+
+        @functools.wraps(func)
+        def _wrapper(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **kwargs)
+
+        _REGISTRY[func.__name__] = (_wrapper, schema)
+        return _wrapper
+
+    if fn is not None:
+        # Called as @tool (no parens)
+        return _decorator(fn)
+
+    # Called as @tool(...) with keyword args
+    return _decorator
+
+
+# ---------------------------------------------------------------------------
+# Public look-up / invocation helpers
+# ---------------------------------------------------------------------------
+
+
+def get_tool(name: str) -> tuple[Callable[..., Any], dict[str, Any]]:
+    """Return ``(callable, schema)`` for a registered tool.
+
+    Raises:
+        KeyError: if the tool name is not registered.
+    """
+    if name not in _REGISTRY:
+        raise KeyError(f"Tool '{name}' is not registered. Known: {list(_REGISTRY)}")
+    return _REGISTRY[name]
+
+
+def get_tool_schemas(names: list[str]) -> list[dict[str, Any]]:
+    """Return schema dicts for a subset of registered tools.
+
+    Raises:
+        KeyError: if any name is not registered.
+    """
+    return [get_tool(n)[1] for n in names]
+
+
+def get_registered_tools() -> dict[str, tuple[Callable[..., Any], dict[str, Any]]]:
+    """Return a shallow copy of the full registry (name → (fn, schema))."""
+    return dict(_REGISTRY)

--- a/ai-service/bubbly_chef/workflows/chat/nodes.py
+++ b/ai-service/bubbly_chef/workflows/chat/nodes.py
@@ -3,20 +3,28 @@ Chat and cooking-help graph nodes.
 
 Contains the node functions (and their helpers/prompts) for:
 - general_chat_response: general conversational AI responses
-- cooking_help_response: pantry-aware cooking suggestions
+- cooking_help_response: pantry-aware cooking suggestions (ReAct loop)
 """
 
 import logging
 from datetime import date
 from typing import Any
 
+import bubbly_chef.tools.cooking  # noqa: F401 — registers check_pantry on import
 from bubbly_chef.ai.manager import NoProviderAvailableError
 from bubbly_chef.api.deps import get_ai_manager
 from bubbly_chef.models.base import Intent, NextAction, WorkflowStatus
 from bubbly_chef.repository.supabase_repo import get_repository
+from bubbly_chef.tools.registry import get_tool, get_tool_schemas
 from bubbly_chef.workflows.state import WorkflowState
 
 logger = logging.getLogger(__name__)
+
+# Maximum ReAct loop iterations (hard safety valve — prevents runaway cost/latency).
+MAX_ITERATIONS = 5
+
+# Names of tools available in the cooking_help ReAct loop (v1: check_pantry only).
+_COOKING_TOOL_NAMES = ["check_pantry"]
 
 
 # =============================================================================
@@ -321,36 +329,81 @@ async def cooking_help_response(state: WorkflowState) -> WorkflowState:
     """
     Node: Generate a cooking help response (techniques, meal ideas, substitutions).
     Routes here when intent == COOKING_HELP.
-    Fetches the user's pantry so suggestions are grounded in what they actually have.
-    """
-    input_text = state.get("input_text", "")
 
-    # Fetch pantry items so the AI can give pantry-grounded suggestions
-    pantry_context = ""
+    If a tool-calling-capable provider is available, runs a hand-rolled ReAct
+    loop (reason → act → observe → repeat, up to MAX_ITERATIONS).  Otherwise
+    degrades gracefully to the original single-shot completion path so cooking
+    help never breaks.
+    """
+    ai_manager = get_ai_manager()
+
+    # Decide which path to take: ReAct loop or single-shot fallback.
+    has_tool_calling = any(p.supports_tool_calling for p in ai_manager.providers)
+
+    if has_tool_calling:
+        return await _cooking_help_react(state, ai_manager)
+    return await _cooking_help_single_shot(state, ai_manager)
+
+
+# =============================================================================
+# Single-shot (fallback) path — preserved exactly as the pre-R3 implementation
+# =============================================================================
+
+
+def _build_cooking_prompt(
+    state: WorkflowState,
+    cooking_system: str,
+    pantry_context: str,
+) -> str:
+    """Assemble the full cooking-help prompt from shared context helpers."""
+    input_text = state.get("input_text", "")
+    user_prompt = f"\n\nUser: {input_text}\n\nRespond helpfully and concisely."
+    mode_prefix = get_mode_prefix(state)
+    history_context = format_history_context(state)
+    recipe_context = format_cooking_recipe_context(state)
+    return (
+        mode_prefix
+        + cooking_system
+        + pantry_context
+        + recipe_context
+        + "\n\n"
+        + history_context
+        + user_prompt
+    )
+
+
+async def _fetch_pantry_context(state: WorkflowState) -> str:
+    """Fetch the user's pantry and return a formatted context block.
+
+    Returns an empty string on any error (non-critical — callers proceed
+    without pantry context rather than surfacing an error to the user).
+    """
     try:
         repo = await get_repository()
-        items = await repo.get_all_pantry_items(state.get("user_id", ""))
-        if items:
-            expiring = [
-                it for it in items
-                if it.expiry_date and (it.expiry_date - date.today()).days <= 3
-            ]
-            pantry_lines = [f"- {it.name} ({it.quantity} {it.unit})" for it in items]
-            pantry_context = (
-                f"\n\nThe user's pantry currently has {len(items)} items:\n"
-                + "\n".join(pantry_lines[:30])  # cap to keep prompt reasonable
-            )
-            if len(items) > 30:
-                pantry_context += f"\n... and {len(items) - 30} more items"
-            if expiring:
-                exp_names = ", ".join(it.name for it in expiring)
-                pantry_context += (
-                    f"\n\nEXPIRING SOON (use first!): {exp_names}"
-                )
+        items = await repo.get_all_pantry_items(state.get("user_id") or "")
+        if not items:
+            return ""
+        expiring = [
+            it for it in items
+            if it.expiry_date and (it.expiry_date - date.today()).days <= 3
+        ]
+        pantry_lines = [f"- {it.name} ({it.quantity} {it.unit})" for it in items]
+        context = (
+            f"\n\nThe user's pantry currently has {len(items)} items:\n"
+            + "\n".join(pantry_lines[:30])
+        )
+        if len(items) > 30:
+            context += f"\n... and {len(items) - 30} more items"
+        if expiring:
+            exp_names = ", ".join(it.name for it in expiring)
+            context += f"\n\nEXPIRING SOON (use first!): {exp_names}"
+        return context
     except Exception as e:
         logger.warning(f"Could not fetch pantry for cooking help: {e}")
+        return ""
 
-    cooking_system = """\
+
+_COOKING_SYSTEM_PROMPT = """\
 You are a friendly cooking assistant for BubblyChef, \
 a pantry-aware recipe app.
 
@@ -369,29 +422,25 @@ Keep responses friendly, concise, and practical. If the user asks \
 what they can make, give concrete suggestions from their pantry and \
 mention they can switch to Recipe mode for a full step-by-step recipe."""
 
-    ai_manager = get_ai_manager()
-    user_prompt = f"\n\nUser: {input_text}\n\nRespond helpfully and concisely."
-    mode_prefix = get_mode_prefix(state)
-    history_context = format_history_context(state)
-    recipe_context = format_cooking_recipe_context(state)
-    prompt = (
-        mode_prefix
-        + cooking_system
-        + pantry_context
-        + recipe_context
-        + "\n\n"
-        + history_context
-        + user_prompt
-    )
+
+async def _cooking_help_single_shot(
+    state: WorkflowState,
+    ai_manager: Any,
+) -> WorkflowState:
+    """Original single-shot cooking help path (pre-R3 behavior).
+
+    Used as the graceful fallback when no tool-calling-capable provider is
+    available.
+    """
+    pantry_context = await _fetch_pantry_context(state)
+    prompt = _build_cooking_prompt(state, _COOKING_SYSTEM_PROMPT, pantry_context)
 
     try:
         result = await ai_manager.complete(prompt=prompt, temperature=0.7)
         response_text = (
             result if isinstance(result, str) else getattr(result, "response", str(result))
         )
-
         suggested_mode = detect_mode_suggestion(response_text, state.get("input_mode", "chat"))
-
         return {
             **state,
             "intent": Intent.COOKING_HELP.value,
@@ -403,7 +452,6 @@ mention they can switch to Recipe mode for a full step-by-step recipe."""
             "workflow_status": WorkflowStatus.COMPLETED.value,
             "suggested_mode": suggested_mode,
         }
-
     except NoProviderAvailableError:
         return {
             **state,
@@ -431,3 +479,217 @@ mention they can switch to Recipe mode for a full step-by-step recipe."""
             "errors": state.get("errors", []) + [f"Cooking help error: {e}"],
             "workflow_status": WorkflowStatus.COMPLETED.value,
         }
+
+
+# =============================================================================
+# ReAct loop path
+# =============================================================================
+
+_COOKING_REACT_SYSTEM_PROMPT = """\
+You are a friendly cooking assistant for BubblyChef, a pantry-aware recipe app.
+
+You have access to a tool to check the user's live pantry. Use it when the user
+asks about substitutions, whether they have an ingredient, or what they can cook
+from their current supplies. For general techniques, timing, and culinary knowledge
+you already know — answer directly without calling a tool.
+
+Help the user with:
+- Cooking techniques and how-to questions
+- Meal ideas and recipe suggestions based on what they have
+- Ingredient substitutions (check pantry first, then suggest based on availability)
+- Food storage tips
+- General culinary advice
+
+Keep responses friendly, concise, and practical. If the user asks what they can
+make, prioritize ingredients in the pantry and mention they can switch to Recipe
+mode for a full step-by-step recipe."""
+
+
+def _build_react_initial_message(state: WorkflowState) -> str:
+    """Build the initial user message text for the ReAct loop."""
+    input_text = state.get("input_text", "")
+    mode_prefix = get_mode_prefix(state)
+    history_context = format_history_context(state)
+    recipe_context = format_cooking_recipe_context(state)
+    system_block = mode_prefix + _COOKING_REACT_SYSTEM_PROMPT + recipe_context
+    user_block = f"User: {input_text}\n\nRespond helpfully and concisely."
+    return system_block + "\n\n" + history_context + user_block
+
+
+async def _invoke_tool(
+    tool_name: str,
+    arguments: dict[str, Any],
+    user_id: str,
+) -> str:
+    """Look up a registered tool by name and invoke it, injecting user_id."""
+    fn, _ = get_tool(tool_name)
+    raw = fn(**arguments, user_id=user_id)
+    # Support both sync and async tool functions
+    if hasattr(raw, "__await__"):
+        result = await raw
+    else:
+        result = raw
+    return str(result)
+
+
+async def _cooking_help_react(
+    state: WorkflowState,
+    ai_manager: Any,
+) -> WorkflowState:
+    """Hand-rolled ReAct loop for cooking-help.
+
+    Loop shape:
+        1. Build initial user message.
+        2. Call complete_with_tools.
+        3. If tool calls returned: invoke each tool, append observations, loop.
+        4. If final text returned (or MAX_ITERATIONS hit): break, return answer.
+
+    Safety valve: MAX_ITERATIONS caps the loop so a misbehaving model can't run
+    forever and burn tokens/time.
+    """
+    user_id: str = state.get("user_id") or ""
+    tool_schemas = get_tool_schemas(_COOKING_TOOL_NAMES)
+    initial_text = _build_react_initial_message(state)
+
+    # Provider-neutral message history.  Anthropic and Gemini require different
+    # raw formats for tool-use/result turns, so we store pre-built blocks keyed
+    # to the active provider in the loop and let each provider's
+    # _messages_to_* do the final translation.
+    messages: list[dict[str, Any]] = [{"role": "user", "content": initial_text}]
+
+    last_text: str | None = None
+    active_provider_name: str = ""
+
+    try:
+        for iteration in range(MAX_ITERATIONS):
+            response = await ai_manager.complete_with_tools(
+                messages=messages,
+                tools=tool_schemas,
+                temperature=0.7,
+            )
+
+            # Track which provider is handling the loop (for message formatting)
+            if ai_manager.current_provider is not None:
+                active_provider_name = ai_manager.current_provider.name
+
+            if response.text is not None:
+                last_text = response.text
+                break
+
+            if not response.tool_calls:
+                # Model returned neither text nor tool calls — treat as done
+                logger.warning(
+                    "ReAct loop got empty response (no text, no tool calls) "
+                    f"on iteration {iteration + 1}"
+                )
+                break
+
+            # --- Execute tool calls and collect observations ---
+            is_anthropic = "anthropic" in active_provider_name.lower()
+
+            if is_anthropic:
+                # Anthropic: assistant turn = list of tool_use blocks
+                assistant_blocks: list[dict[str, Any]] = []
+                tool_result_blocks: list[dict[str, Any]] = []
+
+                for tc in response.tool_calls:
+                    try:
+                        observation = await _invoke_tool(tc.name, tc.arguments, user_id)
+                    except Exception as exc:
+                        observation = f"Error calling {tc.name}: {exc}"
+                        logger.warning(f"Tool {tc.name} failed: {exc}")
+
+                    assistant_blocks.append(
+                        {"type": "tool_use", "id": tc.id, "name": tc.name, "input": tc.arguments}
+                    )
+                    tool_result_blocks.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tc.id,
+                            "content": observation,
+                        }
+                    )
+
+                messages.append({"role": "assistant", "content": assistant_blocks})
+                messages.append({"role": "tool_result", "content": tool_result_blocks})
+
+            else:
+                # Gemini: assistant turn = functionCall part(s); user turn = functionResponse(s)
+                assistant_parts: list[dict[str, Any]] = []
+                tool_response_parts: list[dict[str, Any]] = []
+
+                for tc in response.tool_calls:
+                    try:
+                        observation = await _invoke_tool(tc.name, tc.arguments, user_id)
+                    except Exception as exc:
+                        observation = f"Error calling {tc.name}: {exc}"
+                        logger.warning(f"Tool {tc.name} failed: {exc}")
+
+                    assistant_parts.append(
+                        {"functionCall": {"name": tc.name, "args": tc.arguments}}
+                    )
+                    tool_response_parts.append(
+                        {
+                            "functionResponse": {
+                                "name": tc.name,
+                                "response": {"result": observation},
+                            }
+                        }
+                    )
+
+                messages.append({"role": "assistant", "content": assistant_parts})
+                messages.append({"role": "tool_result", "content": tool_response_parts})
+
+        # If we exhausted iterations without a final text, use whatever the last
+        # text was (may be None if the model never produced one).
+        if last_text is None:
+            logger.warning(
+                f"ReAct loop hit MAX_ITERATIONS ({MAX_ITERATIONS}) without a "
+                "final text answer — returning graceful fallback."
+            )
+            last_text = (
+                "I worked through your question but wasn't able to form a complete answer. "
+                "Could you rephrase or give me a bit more detail?"
+            )
+
+        suggested_mode = detect_mode_suggestion(last_text, state.get("input_mode", "chat"))
+        return {
+            **state,
+            "intent": Intent.COOKING_HELP.value,
+            "assistant_message": last_text,
+            "next_action": NextAction.NONE.value,
+            "proposal": None,
+            "requires_review": False,
+            "confidence": 1.0,
+            "workflow_status": WorkflowStatus.COMPLETED.value,
+            "suggested_mode": suggested_mode,
+        }
+
+    except NoProviderAvailableError:
+        return {
+            **state,
+            "intent": Intent.COOKING_HELP.value,
+            "assistant_message": (
+                "No AI provider is configured."
+                " Please add a Gemini API key or start Ollama."
+            ),
+            "next_action": NextAction.NONE.value,
+            "proposal": None,
+            "requires_review": False,
+            "confidence": 1.0,
+            "workflow_status": WorkflowStatus.COMPLETED.value,
+        }
+    except Exception as e:
+        logger.error(f"Cooking help ReAct error: {e}")
+        return {
+            **state,
+            "intent": Intent.COOKING_HELP.value,
+            "assistant_message": "Sorry, I ran into an error answering that. Please try again.",
+            "next_action": NextAction.NONE.value,
+            "proposal": None,
+            "requires_review": False,
+            "confidence": 0.5,
+            "errors": state.get("errors", []) + [f"Cooking help error: {e}"],
+            "workflow_status": WorkflowStatus.COMPLETED.value,
+        }
+

--- a/ai-service/tests/test_cooking_companion.py
+++ b/ai-service/tests/test_cooking_companion.py
@@ -1,0 +1,392 @@
+"""Tests for R3 Cooking Companion — ReAct loop, tool registry, provider capability gate.
+
+Patterns follow test_chat_router.py: unittest.mock + AsyncMock, pytest.mark.asyncio,
+minimal state dicts, no live providers.
+"""
+
+from __future__ import annotations
+
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bubbly_chef.ai.provider import ToolCall, ToolCallResponse
+from bubbly_chef.models.base import Intent, WorkflowStatus
+from bubbly_chef.tools.registry import (
+    _REGISTRY,
+    get_registered_tools,
+    get_tool,
+    get_tool_schemas,
+    tool,
+)
+from bubbly_chef.workflows.chat.nodes import (
+    MAX_ITERATIONS,
+    _COOKING_TOOL_NAMES,
+    cooking_help_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _state(**kwargs):
+    """Minimal WorkflowState for cooking_help_response tests."""
+    base: dict = {
+        "input_text": "I'm out of buttermilk, what can I substitute?",
+        "user_id": "test-user-123",
+        "errors": [],
+        "warnings": [],
+        "session_mode": None,
+        "session": None,
+        "conversation_history": [],
+        "input_mode": "chat",
+        "context": None,
+    }
+    base.update(kwargs)
+    return base
+
+
+def _make_manager(supports_tool_calling: bool = True):
+    """Build a MagicMock AIManager.
+
+    Returns (manager_instance, mock_provider) so tests can configure
+    complete / complete_with_tools behaviour.
+    """
+    provider = MagicMock()
+    provider.supports_tool_calling = supports_tool_calling
+    provider.name = "mock/provider"
+
+    manager = MagicMock()
+    manager.providers = [provider]
+    manager.current_provider = provider
+    manager.complete = AsyncMock(return_value="Single-shot fallback answer.")
+    manager.complete_with_tools = AsyncMock()
+    return manager, provider
+
+
+# ---------------------------------------------------------------------------
+# Tool registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolRegistry:
+    def test_decorator_registers_tool(self):
+        """@tool should register name, build schema, and keep fn callable."""
+        # Use a fresh name to avoid polluting the real registry
+        @tool(description="Test tool for pytest.")
+        def _pytest_sample_tool(query: str, count: int = 5) -> str:
+            """Ignored because description= is provided."""
+            return f"{query}:{count}"
+
+        fn, schema = get_tool("_pytest_sample_tool")
+        assert schema["name"] == "_pytest_sample_tool"
+        assert schema["description"] == "Test tool for pytest."
+        assert "query" in schema["parameters"]["properties"]
+        assert schema["parameters"]["properties"]["query"]["type"] == "string"
+        assert "count" in schema["parameters"]["properties"]
+        assert schema["parameters"]["properties"]["count"]["type"] == "integer"
+        # 'count' has a default → should NOT be in required
+        assert "count" not in schema["parameters"].get("required", [])
+        # 'query' has no default → must be required
+        assert "query" in schema["parameters"]["required"]
+        # Direct call still works
+        assert fn("hello") == "hello:5"
+
+    def test_keyword_only_params_excluded_from_schema(self):
+        """Keyword-only params (*, param) must be absent from the model-facing schema."""
+
+        @tool
+        def _pytest_kw_tool(ingredient: str, *, user_id: str) -> str:
+            """A tool with a node-injected user_id."""
+            return f"{ingredient}:{user_id}"
+
+        _, schema = get_tool("_pytest_kw_tool")
+        props = schema["parameters"]["properties"]
+        assert "ingredient" in props
+        assert "user_id" not in props
+        required = schema["parameters"].get("required", [])
+        assert "user_id" not in required
+
+    def test_get_tool_raises_on_unknown(self):
+        with pytest.raises(KeyError, match="not registered"):
+            get_tool("_this_tool_does_not_exist")
+
+    def test_get_tool_schemas_returns_subset(self):
+        """get_tool_schemas should return only the requested names."""
+        # Ensure check_pantry is registered (importing cooking tools triggers it)
+        import bubbly_chef.tools.cooking  # noqa: F401
+
+        schemas = get_tool_schemas(["check_pantry"])
+        assert len(schemas) == 1
+        assert schemas[0]["name"] == "check_pantry"
+        # user_id must NOT appear in the schema
+        assert "user_id" not in schemas[0]["parameters"]["properties"]
+
+    def test_get_registered_tools_returns_copy(self):
+        registry = get_registered_tools()
+        assert isinstance(registry, dict)
+        # Modifying the copy must not affect the real registry
+        registry.pop(next(iter(registry)), None)
+        assert len(get_registered_tools()) >= len(registry)
+
+    def test_functools_wraps_preserves_metadata(self):
+        @tool
+        def _pytest_meta_tool(x: str) -> str:
+            """Meta description."""
+            return x
+
+        fn, _ = get_tool("_pytest_meta_tool")
+        assert fn.__name__ == "_pytest_meta_tool"
+        assert inspect.getdoc(fn) == "Meta description."
+
+
+# ---------------------------------------------------------------------------
+# Provider capability gate tests
+# ---------------------------------------------------------------------------
+
+
+class TestProviderCapabilityGate:
+    def test_base_provider_defaults_false(self):
+        """AIProvider base default: supports_tool_calling = False."""
+        from bubbly_chef.ai.provider import AIProvider
+
+        class _Concrete(AIProvider):
+            @property
+            def name(self) -> str:
+                return "test"
+
+            async def complete(self, prompt, response_schema=None, temperature=0.7):
+                return ""
+
+            async def is_available(self) -> bool:
+                return True
+
+        p = _Concrete()
+        assert p.supports_tool_calling is False
+
+    def test_anthropic_provider_reports_true(self):
+        from bubbly_chef.ai.anthropic import AnthropicProvider
+
+        p = AnthropicProvider(base_url="http://localhost:6655/anthropic")
+        assert p.supports_tool_calling is True
+
+    def test_gemini_provider_reports_true(self):
+        from bubbly_chef.ai.gemini import GeminiProvider
+
+        p = GeminiProvider(api_key="fake-key")
+        assert p.supports_tool_calling is True
+
+    def test_ollama_provider_reports_false(self):
+        from bubbly_chef.ai.ollama import OllamaProvider
+
+        p = OllamaProvider()
+        assert p.supports_tool_calling is False
+
+
+# ---------------------------------------------------------------------------
+# cooking_help_response — ReAct loop with a tool call
+# ---------------------------------------------------------------------------
+
+
+class TestCookingHelpReactLoop:
+    @pytest.mark.asyncio
+    async def test_react_loop_calls_tool_and_returns_final_answer(self):
+        """Loop: first call returns a tool call; second call returns final text."""
+        manager, provider = _make_manager(supports_tool_calling=True)
+
+        tool_call = ToolCall(id="tc1", name="check_pantry", arguments={"ingredient": "buttermilk"})
+        manager.complete_with_tools.side_effect = [
+            ToolCallResponse(tool_calls=[tool_call]),  # first: tool call
+            ToolCallResponse(text="Use yogurt instead — you have some!"),  # second: final
+        ]
+
+        with (
+            patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager),
+            patch(
+                "bubbly_chef.workflows.chat.nodes._invoke_tool",
+                new_callable=AsyncMock,
+                return_value="Yes, buttermilk: 0.0 cup.",
+            ) as mock_invoke,
+        ):
+            result = await cooking_help_response(_state())
+
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert result["workflow_status"] == WorkflowStatus.COMPLETED.value
+        assert "yogurt" in result["assistant_message"]
+        mock_invoke.assert_awaited_once_with(
+            "check_pantry", {"ingredient": "buttermilk"}, "test-user-123"
+        )
+        assert manager.complete_with_tools.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_react_loop_no_tool_call_returns_direct_answer(self):
+        """Loop: model answers directly without calling any tool."""
+        manager, provider = _make_manager(supports_tool_calling=True)
+        manager.complete_with_tools.return_value = ToolCallResponse(
+            text="Just use plain yogurt — it works perfectly."
+        )
+
+        with (
+            patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager),
+            patch(
+                "bubbly_chef.workflows.chat.nodes._invoke_tool",
+                new_callable=AsyncMock,
+            ) as mock_invoke,
+        ):
+            result = await cooking_help_response(_state())
+
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert "yogurt" in result["assistant_message"]
+        mock_invoke.assert_not_called()
+        manager.complete_with_tools.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_react_loop_max_iterations_cap(self):
+        """Loop must stop at MAX_ITERATIONS even if model keeps requesting tool calls."""
+        manager, provider = _make_manager(supports_tool_calling=True)
+
+        # Always return a tool call — never a final answer
+        tool_call = ToolCall(id="tc-inf", name="check_pantry", arguments={"ingredient": "milk"})
+        manager.complete_with_tools.return_value = ToolCallResponse(tool_calls=[tool_call])
+
+        with (
+            patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager),
+            patch(
+                "bubbly_chef.workflows.chat.nodes._invoke_tool",
+                new_callable=AsyncMock,
+                return_value="Found: milk.",
+            ),
+        ):
+            result = await cooking_help_response(_state())
+
+        # Must not loop more than MAX_ITERATIONS times
+        assert manager.complete_with_tools.await_count == MAX_ITERATIONS
+        # Must still return a valid cooking_help response (not raise/crash)
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert result["workflow_status"] == WorkflowStatus.COMPLETED.value
+        assert result["assistant_message"]  # non-empty fallback message
+
+    @pytest.mark.asyncio
+    async def test_degraded_fallback_when_no_tool_calling_provider(self):
+        """When no provider supports tool calling, fall back to single-shot complete()."""
+        manager, provider = _make_manager(supports_tool_calling=False)
+        manager.complete.return_value = "Here's some cooking advice."
+
+        with (
+            patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager),
+            patch(
+                "bubbly_chef.workflows.chat.nodes.get_repository",
+                new_callable=AsyncMock,
+                return_value=MagicMock(
+                    get_all_pantry_items=AsyncMock(return_value=[])
+                ),
+            ),
+        ):
+            result = await cooking_help_response(_state())
+
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert result["workflow_status"] == WorkflowStatus.COMPLETED.value
+        assert result["assistant_message"] == "Here's some cooking advice."
+        # complete() must have been used (single-shot), NOT complete_with_tools
+        manager.complete.assert_awaited_once()
+        manager.complete_with_tools.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_provider_available_error_handled(self):
+        """NoProviderAvailableError returns a friendly error message, not an exception."""
+        from bubbly_chef.ai.manager import NoProviderAvailableError
+
+        manager, provider = _make_manager(supports_tool_calling=True)
+        manager.complete_with_tools.side_effect = NoProviderAvailableError("no provider")
+
+        with patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager):
+            result = await cooking_help_response(_state())
+
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert "No AI provider" in result["assistant_message"]
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_handled(self):
+        """Unexpected exceptions return an error message and populate errors list."""
+        manager, provider = _make_manager(supports_tool_calling=True)
+        manager.complete_with_tools.side_effect = RuntimeError("boom")
+
+        with patch("bubbly_chef.workflows.chat.nodes.get_ai_manager", return_value=manager):
+            result = await cooking_help_response(_state())
+
+        assert result["intent"] == Intent.COOKING_HELP.value
+        assert "error" in result["assistant_message"].lower()
+        assert any("boom" in e for e in result.get("errors", []))
+
+
+# ---------------------------------------------------------------------------
+# check_pantry tool — unit tests with mocked repository
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPantryTool:
+    @pytest.mark.asyncio
+    async def test_returns_found_when_item_exists(self):
+        """check_pantry returns a 'Yes, the pantry has ...' string on exact match."""
+        import bubbly_chef.tools.cooking  # noqa: F401 — ensure registered
+
+        from bubbly_chef.tools.cooking.pantry_tools import check_pantry
+
+        mock_item = MagicMock()
+        mock_item.name = "Buttermilk"
+        mock_item.quantity = 1.0
+        mock_item.unit = "cup"
+        mock_item.expiry_date = None
+
+        mock_repo = MagicMock()
+        mock_repo.find_similar_item = AsyncMock(return_value=mock_item)
+
+        with patch(
+            "bubbly_chef.tools.cooking.pantry_tools.get_repository",
+            new_callable=AsyncMock,
+            return_value=mock_repo,
+        ):
+            result = await check_pantry("buttermilk", user_id="u1")
+
+        assert "Buttermilk" in result
+        assert "1.0" in result
+        assert "cup" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_not_found_when_absent(self):
+        """check_pantry returns a clear 'not found' message when absent."""
+        import bubbly_chef.tools.cooking  # noqa: F401
+
+        from bubbly_chef.tools.cooking.pantry_tools import check_pantry
+
+        mock_repo = MagicMock()
+        mock_repo.find_similar_item = AsyncMock(return_value=None)
+        mock_repo.get_all_pantry_items = AsyncMock(return_value=[])
+
+        with patch(
+            "bubbly_chef.tools.cooking.pantry_tools.get_repository",
+            new_callable=AsyncMock,
+            return_value=mock_repo,
+        ):
+            result = await check_pantry("unicorn dust", user_id="u1")
+
+        assert "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_repo_error_returns_graceful_message(self):
+        """check_pantry swallows repo errors and returns a safe fallback."""
+        import bubbly_chef.tools.cooking  # noqa: F401
+
+        from bubbly_chef.tools.cooking.pantry_tools import check_pantry
+
+        with patch(
+            "bubbly_chef.tools.cooking.pantry_tools.get_repository",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("DB down"),
+        ):
+            result = await check_pantry("butter", user_id="u1")
+
+        assert "Could not check pantry" in result

--- a/ai-service/tests/test_cooking_companion.py
+++ b/ai-service/tests/test_cooking_companion.py
@@ -14,7 +14,6 @@ import pytest
 from bubbly_chef.ai.provider import ToolCall, ToolCallResponse
 from bubbly_chef.models.base import Intent, WorkflowStatus
 from bubbly_chef.tools.registry import (
-    _REGISTRY,
     get_registered_tools,
     get_tool,
     get_tool_schemas,
@@ -22,7 +21,6 @@ from bubbly_chef.tools.registry import (
 )
 from bubbly_chef.workflows.chat.nodes import (
     MAX_ITERATIONS,
-    _COOKING_TOOL_NAMES,
     cooking_help_response,
 )
 
@@ -376,9 +374,65 @@ class TestCheckPantryTool:
         assert "not found" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_repo_error_returns_graceful_message(self):
-        """check_pantry swallows repo errors and returns a safe fallback."""
+    async def test_substring_false_positive_rejected(self):
+        """'buttermilk' must NOT match a pantry item named 'butter'.
+
+        Regression: the old fuzzy fallback used raw substring matching, so
+        'butter' ⊂ 'buttermilk' produced a wrong hit. Word-level matching
+        rejects it.
+        """
         import bubbly_chef.tools.cooking  # noqa: F401
+
+        from bubbly_chef.tools.cooking.pantry_tools import check_pantry
+
+        butter = MagicMock()
+        butter.name = "butter"
+        butter.quantity = 250.0
+        butter.unit = "g"
+        butter.expiry_date = None
+
+        mock_repo = MagicMock()
+        mock_repo.find_similar_item = AsyncMock(return_value=None)
+        mock_repo.get_all_pantry_items = AsyncMock(return_value=[butter])
+
+        with patch(
+            "bubbly_chef.tools.cooking.pantry_tools.get_repository",
+            new_callable=AsyncMock,
+            return_value=mock_repo,
+        ):
+            result = await check_pantry("buttermilk", user_id="u1")
+
+        assert "not found" in result.lower()
+        # Must not report a butter *hit* (the not-found string itself contains
+        # "butter" as a substring of "buttermilk", so assert on the hit phrasing).
+        assert "the pantry has" not in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_shared_word_match_still_works(self):
+        """A shared whole word still matches: 'eggs' → 'large free-range eggs'."""
+        import bubbly_chef.tools.cooking  # noqa: F401
+
+        from bubbly_chef.tools.cooking.pantry_tools import check_pantry
+
+        eggs = MagicMock()
+        eggs.name = "large free-range eggs"
+        eggs.quantity = 12.0
+        eggs.unit = "count"
+        eggs.expiry_date = None
+
+        mock_repo = MagicMock()
+        mock_repo.find_similar_item = AsyncMock(return_value=None)
+        mock_repo.get_all_pantry_items = AsyncMock(return_value=[eggs])
+
+        with patch(
+            "bubbly_chef.tools.cooking.pantry_tools.get_repository",
+            new_callable=AsyncMock,
+            return_value=mock_repo,
+        ):
+            result = await check_pantry("eggs", user_id="u1")
+
+        assert "large free-range eggs" in result
+        """check_pantry swallows repo errors and returns a safe fallback."""
 
         from bubbly_chef.tools.cooking.pantry_tools import check_pantry
 

--- a/ai-service/tests/test_provider_tool_calling.py
+++ b/ai-service/tests/test_provider_tool_calling.py
@@ -1,0 +1,547 @@
+"""Wire-format tests for AnthropicProvider and GeminiProvider tool calling.
+
+These tests intercept the outgoing HTTP request using httpx.MockTransport so
+they run fully offline and assert on:
+  - the exact JSON body sent to each provider's endpoint
+  - the auth headers on every request (regression guard for the SAP-proxy 401)
+  - response parsing from the real provider parsing code (no mocking of
+    complete_with_tools itself — that is the gap the existing suite left open)
+
+Transport injection pattern
+---------------------------
+After constructing the provider, replace its internal HTTP client::
+
+    transport = httpx.MockTransport(handler)
+    provider._client = httpx.AsyncClient(transport=transport)
+
+httpx.MockTransport accepts a *sync* handler ``(request) -> httpx.Response``
+and bridges it to the async client internally.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from bubbly_chef.ai.anthropic import AnthropicProvider
+from bubbly_chef.ai.gemini import GeminiProvider
+from bubbly_chef.ai.provider import ToolCall, ToolCallResponse
+
+# ---------------------------------------------------------------------------
+# Shared tool schema fixture
+# ---------------------------------------------------------------------------
+
+_CHECK_PANTRY_SCHEMA: dict[str, Any] = {
+    "name": "check_pantry",
+    "description": "Check whether an ingredient is in the user's pantry.",
+    "parameters": {
+        "type": "object",
+        "properties": {"ingredient": {"type": "string"}},
+        "required": ["ingredient"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_anthropic(api_key: str = "tok123") -> AnthropicProvider:
+    """Return an AnthropicProvider wired to a fake base URL."""
+    return AnthropicProvider(base_url="http://test/anthropic", api_key=api_key)
+
+
+def _inject_transport(
+    provider: AnthropicProvider | GeminiProvider,
+    handler: Any,
+) -> None:
+    """Replace the provider's _client with one backed by MockTransport."""
+    provider._client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+# ===========================================================================
+# AnthropicProvider
+# ===========================================================================
+
+
+class TestAnthropicWireFormat:
+    """Assert on the exact JSON body sent over the wire for Anthropic calls."""
+
+    @pytest.mark.asyncio
+    async def test_tools_use_input_schema_not_parameters(self) -> None:
+        """Anthropic wire format uses 'input_schema', not 'parameters'."""
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "no buttermilk"}],
+                },
+            )
+
+        provider = _make_anthropic()
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        body = captured["body"]
+        assert "tools" in body, "request body must contain a top-level 'tools' key"
+        tool_entry = body["tools"][0]
+
+        # Anthropic uses 'input_schema' — NOT 'parameters'
+        assert "input_schema" in tool_entry, (
+            "Anthropic wire format must use 'input_schema', got keys: "
+            + str(list(tool_entry.keys()))
+        )
+        assert "parameters" not in tool_entry, (
+            "Anthropic wire format must NOT have 'parameters' (that is the neutral name)"
+        )
+        assert tool_entry["name"] == "check_pantry"
+        assert tool_entry["description"] == _CHECK_PANTRY_SCHEMA["description"]
+        assert tool_entry["input_schema"] == _CHECK_PANTRY_SCHEMA["parameters"]
+
+    @pytest.mark.asyncio
+    async def test_messages_user_content_is_text_block(self) -> None:
+        """User messages must be translated to Anthropic text content blocks."""
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "ok"}],
+                },
+            )
+
+        provider = _make_anthropic()
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        messages = captured["body"]["messages"]
+        assert len(messages) == 1
+        first = messages[0]
+        assert first["role"] == "user"
+        # Content must be a list of content blocks, not a plain string
+        assert isinstance(first["content"], list)
+        assert first["content"][0]["type"] == "text"
+        assert first["content"][0]["text"] == "do I have buttermilk?"
+
+
+class TestAnthropicAuthHeaders:
+    """Regression guard for the SAP-proxy 401 bug.
+
+    The provider must send BOTH Authorization and x-api-key when a key is
+    configured, and neither when the key is empty.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auth_headers_present_when_api_key_set(self) -> None:
+        """Both 'Authorization: Bearer <key>' and 'x-api-key: <key>' must be sent."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "ok"}],
+                },
+            )
+
+        provider = _make_anthropic(api_key="tok123")
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert captured_headers.get("authorization") == "Bearer tok123", (
+            "SAP proxy requires 'Authorization: Bearer <key>' — missing or wrong value"
+        )
+        assert captured_headers.get("x-api-key") == "tok123", (
+            "Direct Anthropic API requires 'x-api-key' header — missing or wrong value"
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_auth_headers_when_api_key_empty(self) -> None:
+        """When api_key='' neither Authorization nor x-api-key should appear."""
+        captured_headers: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_headers.update(request.headers)
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "ok"}],
+                },
+            )
+
+        provider = _make_anthropic(api_key="")
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert "authorization" not in captured_headers, (
+            "No api_key → Authorization header must be absent"
+        )
+        assert "x-api-key" not in captured_headers, (
+            "No api_key → x-api-key header must be absent"
+        )
+
+
+class TestAnthropicResponseParsing:
+    """Assert that complete_with_tools correctly parses Anthropic response envelopes."""
+
+    @pytest.mark.asyncio
+    async def test_tool_use_stop_reason_returns_tool_calls(self) -> None:
+        """stop_reason='tool_use' → ToolCallResponse.tool_calls populated, text is None."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "tool_use",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "toolu_1",
+                            "name": "check_pantry",
+                            "input": {"ingredient": "buttermilk"},
+                        }
+                    ],
+                },
+            )
+
+        provider = _make_anthropic()
+        _inject_transport(provider, handler)
+
+        result = await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert isinstance(result, ToolCallResponse)
+        assert result.text is None
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert isinstance(tc, ToolCall)
+        assert tc.id == "toolu_1"
+        assert tc.name == "check_pantry"
+        assert tc.arguments == {"ingredient": "buttermilk"}
+
+    @pytest.mark.asyncio
+    async def test_end_turn_stop_reason_returns_text(self) -> None:
+        """stop_reason='end_turn' → ToolCallResponse.text set, tool_calls is []."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "stop_reason": "end_turn",
+                    "content": [{"type": "text", "text": "Use yogurt."}],
+                },
+            )
+
+        provider = _make_anthropic()
+        _inject_transport(provider, handler)
+
+        result = await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "substitute for buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert isinstance(result, ToolCallResponse)
+        assert result.text == "Use yogurt."
+        assert result.tool_calls == []
+
+
+class TestAnthropicMessageConversion:
+    """Unit-test _messages_to_anthropic directly — no HTTP needed."""
+
+    def test_tool_result_role_maps_to_user_role(self) -> None:
+        """tool_result role must become Anthropic 'user' with pre-built content blocks."""
+        provider = _make_anthropic()
+
+        # Shape as the ReAct node builds it: pre-built Anthropic tool_result block
+        tool_result_content = [
+            {
+                "type": "tool_result",
+                "tool_use_id": "toolu_1",
+                "content": [{"type": "text", "text": "Yes, buttermilk: 1.0 cup."}],
+            }
+        ]
+        messages: list[dict[str, Any]] = [
+            {"role": "user", "content": "do I have buttermilk?"},
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_1",
+                        "name": "check_pantry",
+                        "input": {"ingredient": "buttermilk"},
+                    }
+                ],
+            },
+            {"role": "tool_result", "content": tool_result_content},
+        ]
+
+        converted = provider._messages_to_anthropic(messages)
+
+        assert len(converted) == 3
+
+        # First message: user text block
+        assert converted[0]["role"] == "user"
+        assert converted[0]["content"][0]["type"] == "text"
+
+        # Second message: assistant with pre-built tool_use block
+        assert converted[1]["role"] == "assistant"
+        assert converted[1]["content"][0]["type"] == "tool_use"
+
+        # Third message: tool_result → Anthropic 'user' role, content preserved as-is
+        assert converted[2]["role"] == "user", (
+            "tool_result role must map to Anthropic 'user' — "
+            f"got: {converted[2]['role']!r}"
+        )
+        assert converted[2]["content"] is tool_result_content, (
+            "Pre-built tool_result content blocks must be passed through unchanged"
+        )
+
+    def test_assistant_text_becomes_text_block(self) -> None:
+        """A plain-string assistant message should be wrapped in a text content block."""
+        provider = _make_anthropic()
+        converted = provider._messages_to_anthropic(
+            [{"role": "assistant", "content": "Here is my answer."}]
+        )
+        assert converted[0]["role"] == "assistant"
+        assert converted[0]["content"] == [{"type": "text", "text": "Here is my answer."}]
+
+    def test_user_text_becomes_text_block(self) -> None:
+        """A plain-string user message should be wrapped in a text content block."""
+        provider = _make_anthropic()
+        converted = provider._messages_to_anthropic(
+            [{"role": "user", "content": "What can I make?"}]
+        )
+        assert converted[0]["role"] == "user"
+        assert converted[0]["content"] == [{"type": "text", "text": "What can I make?"}]
+
+
+# ===========================================================================
+# GeminiProvider
+# ===========================================================================
+
+
+class TestGeminiWireFormat:
+    """Assert on the exact JSON body sent over the wire for Gemini calls."""
+
+    @pytest.mark.asyncio
+    async def test_tools_wrapped_in_function_declarations(self) -> None:
+        """Gemini wire format: tools=[{'functionDeclarations': [...]}]."""
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [{"text": "No buttermilk found."}]
+                            }
+                        }
+                    ]
+                },
+            )
+
+        provider = GeminiProvider(api_key="fake")
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        body = captured["body"]
+        assert "tools" in body, "request body must contain a top-level 'tools' key"
+        tools_list = body["tools"]
+        assert len(tools_list) == 1
+
+        # Gemini wraps declarations in a 'functionDeclarations' envelope
+        assert "functionDeclarations" in tools_list[0], (
+            "Gemini wire format must wrap tools in 'functionDeclarations', "
+            "got keys: " + str(list(tools_list[0].keys()))
+        )
+
+        decls = tools_list[0]["functionDeclarations"]
+        assert len(decls) == 1
+        decl = decls[0]
+        assert decl["name"] == "check_pantry"
+        assert decl["description"] == _CHECK_PANTRY_SCHEMA["description"]
+        # Gemini uses 'parameters' (JSON Schema) — not 'input_schema'
+        assert "parameters" in decl, (
+            "Gemini function declaration must have 'parameters' key, "
+            "got: " + str(list(decl.keys()))
+        )
+        assert decl["parameters"] == _CHECK_PANTRY_SCHEMA["parameters"]
+
+    @pytest.mark.asyncio
+    async def test_contents_uses_user_role_and_parts(self) -> None:
+        """User messages must be sent as Gemini 'contents' with role='user' and parts."""
+        captured: dict[str, Any] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["body"] = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {"content": {"parts": [{"text": "ok"}]}}
+                    ]
+                },
+            )
+
+        provider = GeminiProvider(api_key="fake")
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have milk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        contents = captured["body"]["contents"]
+        assert len(contents) == 1
+        first = contents[0]
+        assert first["role"] == "user"
+        assert isinstance(first["parts"], list)
+        assert first["parts"][0] == {"text": "do I have milk?"}
+
+
+class TestGeminiResponseParsing:
+    """Assert that complete_with_tools correctly parses Gemini response envelopes."""
+
+    @pytest.mark.asyncio
+    async def test_function_call_part_returns_tool_call(self) -> None:
+        """A functionCall part → ToolCallResponse.tool_calls populated, text is None."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {
+                                        "functionCall": {
+                                            "name": "check_pantry",
+                                            "args": {"ingredient": "milk"},
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+            )
+
+        provider = GeminiProvider(api_key="fake")
+        _inject_transport(provider, handler)
+
+        result = await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "do I have milk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert isinstance(result, ToolCallResponse)
+        assert result.text is None
+        assert len(result.tool_calls) == 1
+        tc = result.tool_calls[0]
+        assert isinstance(tc, ToolCall)
+        assert tc.name == "check_pantry"
+        assert tc.arguments == {"ingredient": "milk"}
+        # Gemini doesn't supply a call ID — provider generates a UUID
+        assert tc.id  # non-empty
+
+    @pytest.mark.asyncio
+    async def test_text_part_returns_text_response(self) -> None:
+        """A text-only part → ToolCallResponse.text set, tool_calls is []."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [
+                                    {"text": "Use plain yogurt as a substitute."}
+                                ]
+                            }
+                        }
+                    ]
+                },
+            )
+
+        provider = GeminiProvider(api_key="fake")
+        _inject_transport(provider, handler)
+
+        result = await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "substitute for buttermilk?"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        assert isinstance(result, ToolCallResponse)
+        assert result.text == "Use plain yogurt as a substitute."
+        assert result.tool_calls == []
+
+    @pytest.mark.asyncio
+    async def test_api_key_sent_as_query_param(self) -> None:
+        """Gemini authenticates via ?key=... query param, not a header."""
+        captured_url: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured_url.append(str(request.url))
+            return httpx.Response(
+                200,
+                json={
+                    "candidates": [
+                        {"content": {"parts": [{"text": "ok"}]}}
+                    ]
+                },
+            )
+
+        provider = GeminiProvider(api_key="my-gemini-key")
+        _inject_transport(provider, handler)
+
+        await provider.complete_with_tools(
+            messages=[{"role": "user", "content": "ping"}],
+            tools=[_CHECK_PANTRY_SCHEMA],
+        )
+
+        url = captured_url[0]
+        assert "key=my-gemini-key" in url, (
+            f"Gemini must pass API key as ?key= query param, got URL: {url}"
+        )

--- a/docs/DEV_TESTING.md
+++ b/docs/DEV_TESTING.md
@@ -1,0 +1,101 @@
+# Dev Testing & Seeding
+
+Practical guide for exercising BubblyChef against realistic data locally — the
+test account, the pantry seed script, and how to live-test the AI service
+(including the R3 cooking companion).
+
+---
+
+## Test account
+
+| | |
+|---|---|
+| **Email** | `test@bubbly.local` |
+| **user_id** | `1136277c-9ee3-4fbc-a8c5-448d7a835237` |
+| **Supabase project** | `obmbwuqwpvntxhhbdfsg` (dev) |
+
+This is the throwaway account used for manual/live testing. It's distinct from
+the real user accounts in the same project — **only seed/wipe `test@bubbly.local`**.
+
+---
+
+## Seeding a realistic pantry
+
+`scripts/seed_pantry.py` populates a believable ~32-item weekly-shop kitchen
+(staples, produce, proteins, condiments) with quantities, storage locations,
+categories, and **expiry dates computed relative to today** — 7 items expiring
+within 3 days so the expiring-soon / "cook this before it goes bad" features and
+R3's `check_pantry` tool always have live data to work against.
+
+```bash
+cd ai-service
+# Wipe the test user's pantry, then seed ~32 fresh items:
+./.venv/bin/python ../scripts/seed_pantry.py --email test@bubbly.local
+
+# Other modes:
+./.venv/bin/python ../scripts/seed_pantry.py --user-id <uuid>          # target by id
+./.venv/bin/python ../scripts/seed_pantry.py --email test@bubbly.local --keep  # add on top, don't wipe
+```
+
+Run it **from `ai-service/`** with that venv — the script reads Supabase creds
+(`BUBBLY_SUPABASE_URL`, `BUBBLY_SUPABASE_SECRET_KEY`) from `ai-service/.env` via
+`bubbly_chef.config.settings`, and uses the service-role key to look up the auth
+user by email and bypass RLS on the write.
+
+### Re-run to keep it fresh
+
+Because expiry dates are offsets from `date.today()`, **re-run the seed whenever
+the dates drift stale** (e.g. everything's "expired" after a week away). Same
+command; it wipes and re-seeds with dates recomputed from the current day.
+
+---
+
+## Live-testing the AI service
+
+The dev default routes all LLM calls through the **SAP proxy** (Anthropic),
+which is tool-calling-capable — so R3 runs the real ReAct loop, not the
+degraded single-shot fallback.
+
+### Proxy auth (one-time)
+
+The SAP proxy requires an `Authorization: Bearer <token>` header. `ai-service/.env`
+must set `BUBBLY_ANTHROPIC_API_KEY` to the proxy token (the same
+`ANTHROPIC_AUTH_TOKEN` the terminal Claude CLI uses, from
+`~/.claude/settings.json`). Without it, every call returns
+`401 MISSING_AUTHORIZATION_HEADER`. `BUBBLY_USE_ANTHROPIC_PROXY=true` selects
+this path. (`.env` is gitignored — this token is never committed.)
+
+### Run the stack
+
+```bash
+# terminal 1 — AI service
+cd ai-service && uvicorn bubbly_chef.main:app --reload --port 8888
+
+# terminal 2 — frontend
+cd nextjs && npm run dev
+```
+
+Log in at `localhost:3000` as `test@bubbly.local`, open `/chat`.
+
+### R3 cooking-companion prompts
+
+- **Triggers the `check_pantry` tool** (pantry-grounded): *"I'm out of buttermilk,
+  what can I use instead?"*, *"do I have enough for an omelette?"*
+- **Answers directly, no tool** (a valid loop outcome): *"how do I fold egg
+  whites?"*, *"how do I caramelise onions?"*
+
+Watch the uvicorn logs to see the ReAct loop iterate and `check_pantry` fire on
+the pantry-specific questions.
+
+---
+
+## Live test suite
+
+`ai-service/tests/test_intent_live.py` calls the real proxy (gated on
+`BUBBLY_RUN_LIVE_TESTS=1`). Tests pass individually; a full-suite run currently
+has a shared-singleton event-loop teardown flaw — see issue #208. Run a single
+one to sanity-check the proxy:
+
+```bash
+cd ai-service && ./.venv/bin/python -m pytest tests/test_intent_live.py -k cooking_help -q
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 ## Setup
 
 - [Supabase Setup](SUPABASE_SETUP.md) — step-by-step Supabase project setup (schema, auth, RLS)
+- [Dev Testing & Seeding](DEV_TESTING.md) — test account, pantry seed script, live-testing the AI service (incl. R3)
 
 ## Plans (active)
 

--- a/docs/plans/2026-07-29-r3-cooking-companion.md
+++ b/docs/plans/2026-07-29-r3-cooking-companion.md
@@ -1,0 +1,55 @@
+# R3 — Cooking Companion sub-graph (design stub)
+
+**Status:** Stub / not started · **Tracking:** #187 (R5 #189 depends on this)
+**Date:** 2026-07-29
+
+> This is a scoping stub, not a finished design. It captures what R3 delivers, the
+> foundation it must build, and the open questions to resolve before implementation.
+
+## Goal
+
+A ReAct-style chat sub-graph the assistant enters when the user is cooking and asks
+help questions — "I'm out of buttermilk, what do I use?", "how do I fold egg whites?".
+The assistant reasons and calls **tools** to answer, rather than free-generating.
+
+Per CONTEXT.md, the Cooking sub-graph is "ReAct-style with tool access
+(substitutions, techniques)". Initial tools named in `docs/plans/2026-04-29-active-work-items.md`:
+`suggest_substitution`, `explain_technique`.
+
+## The foundation this phase must build (load-bearing)
+
+There is **no tool-calling / ReAct infrastructure in the codebase today** — confirmed
+no `ToolNode`, `bind_tools`, or `create_react_agent` anywhere. The `tools/` directory
+holds plain async functions (`expiry`, `normalizer`, `product_lookup`, `web_search`)
+but none are bound to an LLM.
+
+R3 is therefore where the **shared tool registry** gets built — the piece the docs
+describe as: *"plain Python async functions callable from sub-graph nodes, API routes,
+and LLM ToolNode (eliminates scan/chat duplication)."* This registry is the shared
+dependency that **R5 (#189) also needs** — build it once here.
+
+Concretely R3 delivers:
+1. A tool-registry pattern (decorate/register plain async fns; expose them as LLM tools).
+2. The ReAct loop wired into a LangGraph sub-graph (model ↔ ToolNode).
+3. First two tools: `suggest_substitution`, `explain_technique`.
+4. Router wiring: a Cooking intent that dispatches into this sub-graph.
+5. No data mutation (read-only cooking help).
+
+## Dependencies
+
+- **Blocks R5 (#189)** — R5 reuses this tool registry + ReAct base for proactive general chat.
+- **Independent of R4** (ingest consolidation).
+- Provider caveat: tool-calling must work through `AIManager` (Gemini primary, Ollama
+  fallback) — verify both providers support the tool-calling path, or gate by provider.
+
+## Open questions (resolve before build)
+
+- LangGraph prebuilt (`create_react_agent`/`ToolNode`) vs. a hand-rolled loop?
+- Tool-registry shape — decorator vs. explicit registration; how routes reuse it.
+- Which model tier runs the loop, and Gemini-vs-Ollama tool-calling parity.
+- Intent boundary: how does the router decide "cooking help" vs. recipe-generate/general-chat?
+- Tool scope for v1 — just substitution + technique, or more (unit help, timing)?
+
+## Size
+
+Medium–large. The value is mostly the reusable foundation; the two tools themselves are small.

--- a/docs/plans/2026-07-29-r3-cooking-companion.md
+++ b/docs/plans/2026-07-29-r3-cooking-companion.md
@@ -1,10 +1,11 @@
-# R3 — Cooking Companion sub-graph (design stub)
+# R3 — Cooking Companion sub-graph
 
-**Status:** Stub / not started · **Tracking:** #187 (R5 #189 depends on this)
-**Date:** 2026-07-29
+**Status:** Design resolved — agent-ready · **Tracking:** #187 (R5 #189 depends on this)
+**Date:** 2026-07-29 · **Design resolved:** 2026-07-30
 
-> This is a scoping stub, not a finished design. It captures what R3 delivers, the
-> foundation it must build, and the open questions to resolve before implementation.
+> Design session 2026-07-30 resolved all five open questions. Section "Resolved
+> design" below is the build spec. The original scoping stub is preserved after it
+> for context.
 
 ## Goal
 
@@ -12,11 +13,129 @@ A ReAct-style chat sub-graph the assistant enters when the user is cooking and a
 help questions — "I'm out of buttermilk, what do I use?", "how do I fold egg whites?".
 The assistant reasons and calls **tools** to answer, rather than free-generating.
 
+The essential distinction: today's `cooking_help_response` node is a **single-shot
+pipeline** (fetch pantry → one giant prompt → one `complete()` call → text). R3 turns
+it into an **agent**: a reason → act → observe → repeat loop where *the model decides*
+what tool to call and when it has enough to answer. The loop — model-driven control
+flow — is what makes it an agent, not the tools themselves.
+
+---
+
+## Resolved design (build spec)
+
+### The shape: a node-internal swap
+
+R3 does **not** touch intent classification, routing, or graph edges. It replaces what
+happens *inside* the existing `cooking_help_response` node (`workflows/chat/nodes.py`).
+Everything upstream (classifier) and downstream (`update_session` → END) is unchanged.
+Minimal blast radius.
+
+### Decision 1 — Loop: hand-rolled ReAct, inside a LangGraph node, over `AIManager`
+
+- **Not** `create_react_agent` / LangChain `BaseChatModel`. That prebuilt loop wants
+  LangChain's model protocol (`bind_tools`, message objects), which our `AIProvider`
+  (`string in → str|BaseModel out`) does not speak. Adopting it would force either
+  LangChain model wrappers (re-implementing tool-calling per provider) or LangChain's
+  own Gemini/Ollama integrations — the latter **bypasses `AIManager`** and its
+  Gemini→Ollama→… fallback, violating the "all AI calls through `AIManager`" rule.
+- **Instead:** LangGraph stays for *structure* (router, sub-graph, state); the ReAct
+  loop is a ~40-line hand-rolled `while` inside the node, calling `AIManager`. This is
+  the documented best-practice choice for a **single agent + few tools + linear
+  reasoning** (start with your own loop; add framework layers only when a specific pain
+  — durable cross-session state, human-in-the-loop approvals, multi-agent topologies —
+  actually appears). R3 has none of those pains.
+- LangGraph's heavier multi-agent / sub-graph orchestration is explicitly **out of
+  scope** for R3.
+- **Hard safety valve:** `max_iterations` cap on the loop (best practice — models don't
+  reliably stop themselves; an uncapped loop is a silent cost/latency leak). Cap ~5.
+
+### Decision 2 — Tool registry: `@tool` decorator, auto-schema
+
+- A `@tool` decorator that inspects signature + docstring to auto-build the tool schema
+  and register `{name → (fn, schema)}`. Define a function → it's callable three ways:
+  directly from routes, directly from graph nodes, and by the LLM via tool-calling.
+- Auto-schema-from-signature kills schema drift (the reason frameworks default to it).
+- Accept an optional `description=` override so the model-facing text can be tuned
+  without changing the function's own docstring.
+- Tools live in an **explicitly-imported package** (e.g. `tools/cooking/`) — no
+  import-time-magic surprises about what's registered.
+- **This registry is the load-bearing R3 deliverable** — R5 (#189) reuses it wholesale.
+
+### Decision 3 — Provider parity: capability gate (mirrors `supports_vision`)
+
+- Add to the `AIProvider` ABC:
+  - `supports_tool_calling: bool` property (defaults False; mirrors the existing
+    `supports_vision` pattern).
+  - `complete_with_tools(...)` method — takes the prompt + registered tool schemas,
+    returns either a text answer or a structured tool-call request.
+- Per-provider tool-calling support:
+  - **Anthropic (SAP proxy)** — first-class; **current dev default**. Already raw
+    `httpx` to the Messages API → add `tools` to the body. `supports_tool_calling = True`.
+  - **Gemini** — first-class (v1beta `tools → functionDeclarations`, JSON Schema).
+    Already raw REST via httpx → natural extension. `True`.
+  - **Ollama** — tool-calling is emergent/model-dependent (prompt-and-parse, flaky).
+    `supports_tool_calling = False` for now.
+- The loop checks the active provider's flag. If **False**, the node degrades to
+  **today's single-shot behavior** (grounded prompt, one `complete()`), so cooking help
+  never breaks — it just loses the tool loop on weak providers.
+- Production provider choice + whether to build Ollama emulation → deferred to **#202**.
+
+### Decision 4 — Intent boundary: reuse `cooking_help` as-is
+
+- The router already classifies `cooking_help` vs `recipe_generation` vs `general_chat`
+  with working prompt rules (`router.py:107–137`). R3 changes nothing here.
+  - "how do I fold egg whites?" → `cooking_help` → **R3 ReAct node** (new internals)
+  - "what can I make for dinner?" → `recipe_generation` → existing grounding workflow
+  - "what's the weather?" → `general_chat` → unchanged
+
+### Decision 5 — v1 tools: `check_pantry` only
+
+- **Principle applied:** a capability earns a tool only if the model can't reliably *do*
+  it (live/private data, exact computation, or a curated authoritative source) — not
+  merely because it's cooking-related. Don't instrument knowledge the model already has.
+- **`check_pantry(ingredient)` — the one v1 tool.** The model cannot know the user's
+  kitchen; this is live private data. It's what turns "generic cooking chatbot" into
+  "assistant that knows *your* pantry" ("you've got yogurt — use that instead of
+  buttermilk"). The substitution reasoning stays in the model's head; the *grounding*
+  comes from this tool.
+- **Cut from v1** (model knowledge, no tool needed): `explain_technique` (models are
+  excellent at this), `suggest_substitution` (model knows substitutions; grounded by
+  `check_pantry`), timing questions. A valid loop outcome is the model answering
+  directly with *no* tool call.
+- **Deferred:** curated `suggest_substitution` table (add later only if substitution
+  quality visibly disappoints — reactively, with evidence). Unit conversion → issue #6
+  (real need, but bigger than R3).
+
+### Build checklist
+
+1. `AIProvider`: add `supports_tool_calling` property + `complete_with_tools`.
+   Implement for Anthropic (proxy) + Gemini; Ollama returns False.
+2. `@tool` decorator + registry (the R5-shared foundation).
+3. `check_pantry(ingredient)` tool (reads pantry via `SupabaseRepository`).
+4. Hand-rolled ReAct loop with `max_iterations` cap → new `cooking_help_response`
+   internals; graceful fallback to the existing single-shot path when
+   `supports_tool_calling` is False.
+5. Tests: loop with a tool call, loop with no tool call (direct answer), degraded-path
+   fallback, `max_iterations` cap.
+
+### Dependencies (resolved)
+
+- **Blocks R5 (#189)** — R5 reuses this tool registry + ReAct base.
+- **Independent of R4.**
+- Provider parity handled by the capability gate; production-provider decision → **#202**.
+
+---
+
+## Original scoping stub (preserved for context)
+
+> This is a scoping stub, not a finished design. It captures what R3 delivers, the
+> foundation it must build, and the open questions to resolve before implementation.
+
 Per CONTEXT.md, the Cooking sub-graph is "ReAct-style with tool access
 (substitutions, techniques)". Initial tools named in `docs/plans/2026-04-29-active-work-items.md`:
 `suggest_substitution`, `explain_technique`.
 
-## The foundation this phase must build (load-bearing)
+### The foundation this phase must build (load-bearing)
 
 There is **no tool-calling / ReAct infrastructure in the codebase today** — confirmed
 no `ToolNode`, `bind_tools`, or `create_react_agent` anywhere. The `tools/` directory
@@ -28,28 +147,18 @@ describe as: *"plain Python async functions callable from sub-graph nodes, API r
 and LLM ToolNode (eliminates scan/chat duplication)."* This registry is the shared
 dependency that **R5 (#189) also needs** — build it once here.
 
-Concretely R3 delivers:
-1. A tool-registry pattern (decorate/register plain async fns; expose them as LLM tools).
-2. The ReAct loop wired into a LangGraph sub-graph (model ↔ ToolNode).
-3. First two tools: `suggest_substitution`, `explain_technique`.
-4. Router wiring: a Cooking intent that dispatches into this sub-graph.
-5. No data mutation (read-only cooking help).
+### Open questions (all resolved 2026-07-30 — see Resolved design above)
 
-## Dependencies
-
-- **Blocks R5 (#189)** — R5 reuses this tool registry + ReAct base for proactive general chat.
-- **Independent of R4** (ingest consolidation).
-- Provider caveat: tool-calling must work through `AIManager` (Gemini primary, Ollama
-  fallback) — verify both providers support the tool-calling path, or gate by provider.
-
-## Open questions (resolve before build)
-
-- LangGraph prebuilt (`create_react_agent`/`ToolNode`) vs. a hand-rolled loop?
-- Tool-registry shape — decorator vs. explicit registration; how routes reuse it.
-- Which model tier runs the loop, and Gemini-vs-Ollama tool-calling parity.
-- Intent boundary: how does the router decide "cooking help" vs. recipe-generate/general-chat?
-- Tool scope for v1 — just substitution + technique, or more (unit help, timing)?
+- LangGraph prebuilt (`create_react_agent`/`ToolNode`) vs. a hand-rolled loop? →
+  **hand-rolled** (Decision 1).
+- Tool-registry shape — decorator vs. explicit registration? → **decorator** (Decision 2).
+- Which model tier runs the loop, and Gemini-vs-Ollama tool-calling parity? →
+  **capability gate**; dev on Anthropic-via-proxy; production → #202 (Decision 3).
+- Intent boundary — cooking help vs recipe-generate/general-chat? → **reuse
+  `cooking_help`** (Decision 4).
+- Tool scope for v1? → **`check_pantry` only** (Decision 5).
 
 ## Size
 
-Medium–large. The value is mostly the reusable foundation; the two tools themselves are small.
+Medium. The value is the reusable foundation (registry + provider tool-calling + ReAct
+loop); the one tool is small.

--- a/docs/plans/2026-07-29-r4-unified-ingest.md
+++ b/docs/plans/2026-07-29-r4-unified-ingest.md
@@ -1,0 +1,60 @@
+# R4 — Unified multimodal Ingest sub-graph (design stub)
+
+**Status:** Stub / not started · **Tracking:** #188 (epic over #190 video, #180 URL cleanup)
+**Date:** 2026-07-29
+
+> Scoping stub, not a finished design. Captures what R4 consolidates and the open
+> questions before implementation.
+
+## Goal
+
+One multimodal **Ingest sub-graph** that handles every "get stuff into the app" path —
+photo/receipt, product barcode, recipe URL, video, pasted text — instead of today's
+separate, partially-wired workflows. Per CONTEXT.md: *"Ingest — unified multimodal:
+photo, URL, video, receipt, text."*
+
+## Current state (fragmented — the problem R4 solves)
+
+Ingestion is scattered across `ai-service/bubbly_chef/workflows/`:
+
+| Path | Today | Notes |
+|------|-------|-------|
+| Receipt | `receipt_ingest.py` | Live, wired to the scan route |
+| Recipe URL | `services/recipe_url_ingestor.py` | Live (recipe-scrapers + Gemini fallback), wired to `/v1/ingest/recipe-url` |
+| Recipe URL (old) | `recipe_ingest.py` | **Dead stub** — being removed in #180 |
+| Product/barcode | `product_ingest.py` | Graph built but **no caller**; lookup is a stub (real work in #191) |
+| Video | — | **Absent** (#190) |
+
+So the same conceptual operation lives in 4+ places with inconsistent wiring, and the
+chat router only emits "handoff" messages for most of them rather than running the graph.
+
+## What R4 delivers
+
+- A single Ingest sub-graph: **detect modality → route to the right extractor → normalize
+  → proposal envelope** (the existing proposal/confidence pattern).
+- Absorbs the concrete ingest issues as its extractors:
+  - **#190 video ingestion** — the new subsystem (transcription + extraction).
+  - **#180** URL stub removal — leaves `recipe_url_ingestor.py` as the URL extractor.
+  - **#191 barcode** — product lookup + entry point (can ship standalone first, folded in later).
+- Consistent entry point + router dispatch so ingestion actually runs from chat, not just handoff text.
+
+## Dependencies
+
+- **Independent of R3/R5** (no tool-calling foundation needed).
+- Soft-consumes #190, #180, #191 — those can ship standalone; R4 consolidates them.
+- The frontend URL classifier (`nextjs/src/lib/url-classifier.ts`) is currently dead code;
+  R4's modality detection is where it would finally get consumed (or replaced server-side).
+
+## Open questions (resolve before build)
+
+- Modality detection: client-side (existing url-classifier) vs. server-side sniffing?
+- Do we consolidate *before* or *after* video (#190) exists? (Building R4 first gives video a home;
+  building video standalone first gives R4 a working extractor to fold in.)
+- Video pipeline is the big unknown — transcription provider, cost, whether it's in v1 of R4 at all.
+- One `/ingest` endpoint with a modality param vs. keeping per-modality routes behind a shared graph.
+
+## Size
+
+Large (consolidation + the video subsystem). Sequencing note: the individual extractors
+(#180 cleanup, #191 barcode) are cheaper standalone; R4 is worth doing once ≥2 modalities
+justify the shared graph, or when video (#190) needs a home.

--- a/scripts/seed_pantry.py
+++ b/scripts/seed_pantry.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Seed a realistic pantry for a test user.
+
+Populates a believable weekly-shop kitchen (~30 items) with quantities, storage
+locations, categories, and expiry dates computed *relative to today* — so the
+expiring-soon / "cook this before it goes bad" features always have live data
+to work against, no matter when the script is run.
+
+Usage:
+    cd ai-service && ./.venv/bin/python ../scripts/seed_pantry.py --email bubbly@test.local
+    ./.venv/bin/python ../scripts/seed_pantry.py --user-id <uuid>
+    ./.venv/bin/python ../scripts/seed_pantry.py --email bubbly@test.local --keep  # add on top
+
+By default the target user's existing pantry_items are WIPED before seeding
+(pass --keep to add alongside instead).
+
+Reads Supabase creds from ai-service/.env via bubbly_chef.config.settings — run
+it with the ai-service venv so those settings resolve. Uses the service_role
+key, so it can look up auth users by email and bypass RLS to write rows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import date, timedelta
+
+from supabase import Client, create_client
+
+from bubbly_chef.config import settings
+
+
+@dataclass(frozen=True)
+class SeedItem:
+    """One pantry line. `days` is an offset from today for expiry_date.
+
+    days > 0  → expires in the future
+    days == 0 → expires today
+    days < 0  → already expired
+    days is None → no expiry (shelf-stable staples)
+    """
+
+    name: str
+    category: str
+    location: str
+    quantity: float
+    unit: str
+    days: int | None
+
+
+# A realistic weekly-shop kitchen. Expiry offsets are spread deliberately:
+# a few items expiring in 0-3 days (lights up expiring-soon + R3 check_pantry),
+# a band of fresh produce/dairy over the week, proteins in the fridge/freezer,
+# and shelf-stable staples with far-off or no expiry.
+SEED_ITEMS: list[SeedItem] = [
+    # ─── Expiring very soon (0-3 days) — drives the "use it first" features ───
+    SeedItem("baby spinach", "produce", "fridge", 1, "bag", 1),
+    SeedItem("strawberries", "produce", "fridge", 1, "punnet", 2),
+    SeedItem("ground beef", "meat", "fridge", 500, "g", 1),
+    SeedItem("fresh basil", "produce", "fridge", 1, "bunch", 0),
+    SeedItem("greek yogurt", "dairy", "fridge", 500, "g", 3),
+    # ─── Fresh, this week (4-10 days) ─────────────────────────────────────────
+    SeedItem("whole milk", "dairy", "fridge", 2, "L", 6),
+    SeedItem("large free-range eggs", "dairy", "fridge", 12, "count", 18),
+    SeedItem("chicken breast", "meat", "fridge", 600, "g", 4),
+    SeedItem("cheddar cheese", "dairy", "fridge", 250, "g", 21),
+    SeedItem("carrots", "produce", "fridge", 1, "kg", 14),
+    SeedItem("broccoli", "produce", "fridge", 2, "head", 5),
+    SeedItem("red bell peppers", "produce", "fridge", 3, "count", 8),
+    SeedItem("bananas", "produce", "counter", 6, "count", 4),
+    SeedItem("avocados", "produce", "counter", 3, "count", 3),
+    SeedItem("sourdough bread", "bakery", "counter", 1, "loaf", 4),
+    SeedItem("salmon fillet", "seafood", "fridge", 400, "g", 2),
+    SeedItem("butter", "dairy", "fridge", 250, "g", 45),
+    # ─── Freezer ──────────────────────────────────────────────────────────────
+    SeedItem("frozen peas", "frozen", "freezer", 1, "kg", 180),
+    SeedItem("frozen berries", "frozen", "freezer", 500, "g", 200),
+    # ─── Dry goods & shelf-stable staples (far-off or no expiry) ──────────────
+    SeedItem("spaghetti", "dry_goods", "pantry", 500, "g", 400),
+    SeedItem("basmati rice", "dry_goods", "pantry", 2, "kg", 500),
+    SeedItem("all-purpose flour", "dry_goods", "pantry", 1, "kg", 300),
+    SeedItem("rolled oats", "dry_goods", "pantry", 1, "kg", 250),
+    SeedItem("canned chopped tomatoes", "canned", "pantry", 4, "can", 600),
+    SeedItem("chickpeas", "canned", "pantry", 2, "can", 550),
+    SeedItem("olive oil", "condiments", "pantry", 750, "ml", 400),
+    SeedItem("soy sauce", "condiments", "pantry", 500, "ml", 500),
+    SeedItem("honey", "condiments", "pantry", 340, "g", None),
+    SeedItem("salt", "condiments", "pantry", 1, "kg", None),
+    SeedItem("garlic", "produce", "pantry", 2, "bulb", 30),
+    SeedItem("yellow onions", "produce", "pantry", 5, "count", 25),
+    SeedItem("ground coffee", "beverages", "pantry", 500, "g", 120),
+]
+
+
+def _client() -> Client:
+    if not settings.supabase_url or not settings.supabase_secret_key:
+        sys.exit(
+            "Missing Supabase creds. Run this with the ai-service venv so "
+            "BUBBLY_SUPABASE_URL / BUBBLY_SUPABASE_SECRET_KEY resolve from .env."
+        )
+    return create_client(settings.supabase_url, settings.supabase_secret_key)
+
+
+def resolve_user_id(client: Client, email: str) -> str:
+    """Look up an auth user's id by email via the admin API (paginated)."""
+    page = 1
+    while True:
+        resp = client.auth.admin.list_users(page=page, per_page=200)
+        users = resp if isinstance(resp, list) else getattr(resp, "users", resp)
+        if not users:
+            break
+        for user in users:
+            if (getattr(user, "email", "") or "").lower() == email.lower():
+                return str(user.id)
+        if len(users) < 200:
+            break
+        page += 1
+    sys.exit(f"No auth user found with email {email!r}.")
+
+
+def wipe_pantry(client: Client, user_id: str) -> int:
+    existing = (
+        client.table("pantry_items").select("id").eq("user_id", user_id).execute()
+    )
+    count = len(existing.data)
+    if count:
+        client.table("pantry_items").delete().eq("user_id", user_id).execute()
+    return count
+
+
+def _row(item: SeedItem, user_id: str, today: date, slot: int) -> dict[str, object]:
+    expiry = None if item.days is None else (today + timedelta(days=item.days)).isoformat()
+    return {
+        "user_id": user_id,
+        "name": item.name,
+        "name_normalized": item.name.lower().strip(),
+        "category": item.category,
+        "location": item.location,
+        "quantity": float(item.quantity),
+        "unit": item.unit,
+        "expiry_date": expiry,
+        "slot_index": slot,
+    }
+
+
+def seed(client: Client, user_id: str, today: date) -> int:
+    rows = [_row(item, user_id, today, i) for i, item in enumerate(SEED_ITEMS)]
+    client.table("pantry_items").insert(rows).execute()
+    return len(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed a realistic test pantry.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--email", help="Auth user email to resolve to a user_id.")
+    group.add_argument("--user-id", help="Auth user UUID to seed directly.")
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Add items alongside existing pantry rows instead of wiping first.",
+    )
+    args = parser.parse_args()
+
+    client = _client()
+    user_id = args.user_id or resolve_user_id(client, args.email)
+    today = date.today()
+
+    if not args.keep:
+        wiped = wipe_pantry(client, user_id)
+        print(f"Wiped {wiped} existing pantry item(s) for user {user_id}.")
+
+    added = seed(client, user_id, today)
+    expiring = sum(1 for it in SEED_ITEMS if it.days is not None and it.days <= 3)
+    print(f"Seeded {added} realistic pantry items ({expiring} expiring within 3 days).")
+    print(f"Expiry dates are relative to {today.isoformat()}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Implements R3 of the AI workflow refactor: upgrades the `cooking_help_response` node from a single-shot pipeline into a **hand-rolled ReAct agent** (reason → act → observe → repeat) with tool access. This is a **node-internal swap** — intent classification, routing, and graph edges are untouched, so the `/v1/chat` request/response contract is unchanged and the frontend sees no difference.

Design was resolved in a session that closed all five open questions; the build spec lives in `docs/plans/2026-07-29-r3-cooking-companion.md`.

## What lands

**Reusable foundation** (R5 / #189 reuses this wholesale):
- `AIProvider.supports_tool_calling` capability gate + `complete_with_tools()`, mirroring the existing `supports_vision` / `vision_complete` pattern. Anthropic (SAP proxy, dev default) and Gemini implement it; Ollama stays `False`.
- `AIManager.complete_with_tools()` cascade that skips non-capable providers, mirroring `vision_complete`.
- `@tool` decorator + registry (`tools/registry.py`) — auto-builds a provider-neutral JSON-schema spec from signature + docstring, with an optional `description=` override. Keyword-only params (e.g. `user_id`) are treated as node-injected and excluded from the model-facing schema.

**R3 itself:**
- `check_pantry(ingredient)` — the single v1 tool (the one thing the model can't know: the user's live pantry). Reads via `SupabaseRepository`, exact-match then fuzzy fallback.
- Hand-rolled ReAct `while` loop in `cooking_help_response`, capped at `MAX_ITERATIONS = 5` (hard safety valve).
- **Graceful degradation:** when no tool-calling-capable provider is available, the node falls back to the exact pre-R3 single-shot path — cooking help never breaks on weak providers.

## Tests

New `tests/test_cooking_companion.py` (19 tests): ReAct loop with a tool call, direct-answer with no tool call, degraded single-shot fallback, `max_iterations` cap (no infinite loop), registry schema building + keyword-only exclusion, provider capability gate, `check_pantry` found/not-found/error.

- `pytest` (non-live suite): **189 passed**
- `ruff check bubbly_chef/`: clean
- `mypy --strict` on touched dirs (`ai/`, `tools/`, `workflows/chat/`): no new errors (pre-existing errors tracked in #128)

## Linked

Closes #187. Provides the tool-registry + ReAct foundation that #189 (R5) depends on. Independent of R4 (#188).

## Out of scope

- Production provider choice + whether to build Ollama tool-calling emulation → #202.
- Additional tools (curated substitution table, unit conversion → #6). v1 is `check_pantry` only.
- The base of this branch includes the earlier design-stub commit (`470b6d9`) which also carries the R4 stub doc; it's design-only and predates this work.