### PR TITLE
R4-2: Route recipe-URL ingest through the /ingest dispatcher

### DIFF
--- a/ai-service/bubbly_chef/api/ingest_dispatcher.py
+++ b/ai-service/bubbly_chef/api/ingest_dispatcher.py
@@ -45,6 +45,7 @@ from typing import Any
 
 from bubbly_chef.models.base import ProposalEnvelope
 from bubbly_chef.models.pantry import PantryProposal
+from bubbly_chef.models.recipe import RecipeCardProposal
 
 logger = logging.getLogger(__name__)
 
@@ -96,7 +97,12 @@ class IngestPayload:
 # Extractor entry
 # ---------------------------------------------------------------------------
 
-ExtractorFn = Callable[[IngestPayload], Awaitable[ProposalEnvelope[PantryProposal]]]
+# Extractors may return either a PantryProposal envelope (receipt, barcode) or a
+# RecipeCardProposal envelope (URL ingest — recipe cards diverge from the pantry
+# spine by design; see services/url_extractor.py for the rationale).
+ExtractorFn = Callable[
+    [IngestPayload], Awaitable[ProposalEnvelope[PantryProposal | RecipeCardProposal]]
+]
 
 
 @dataclass
@@ -106,7 +112,10 @@ class ExtractorEntry:
     Args:
         modality: The modality this extractor handles.
         extract: Async callable that accepts an ``IngestPayload`` and returns
-            a ``ProposalEnvelope[PantryProposal]``.
+            a ``ProposalEnvelope``.  Receipt/barcode extractors return
+            ``ProposalEnvelope[PantryProposal]``; the URL extractor returns
+            ``ProposalEnvelope[RecipeCardProposal]`` (recipes legitimately
+            diverge from the pantry tail — see services/url_extractor.py).
     """
 
     modality: IngestModality
@@ -199,7 +208,9 @@ class ModalityDispatcher:
     # Dispatch
     # ------------------------------------------------------------------
 
-    async def dispatch(self, payload: IngestPayload) -> ProposalEnvelope[PantryProposal]:
+    async def dispatch(
+        self, payload: IngestPayload
+    ) -> ProposalEnvelope[PantryProposal | RecipeCardProposal]:
         """Detect modality (if not already set) and call the registered extractor.
 
         Args:
@@ -208,7 +219,8 @@ class ModalityDispatcher:
                 ``image_bytes`` / ``ocr_text`` / ``url`` / ``barcode`` / ``text``.
 
         Returns:
-            ``ProposalEnvelope[PantryProposal]`` from the extractor.
+            ``ProposalEnvelope`` from the extractor — ``PantryProposal`` for
+            receipt/barcode, ``RecipeCardProposal`` for URL ingest.
 
         Raises:
             NotImplementedError: No extractor registered for the detected modality.

--- a/ai-service/bubbly_chef/api/routes/ingest.py
+++ b/ai-service/bubbly_chef/api/routes/ingest.py
@@ -1,9 +1,10 @@
 """Ingest routes for the BubblyChef AI microservice.
 
 Exposes:
-- POST /v1/ingest/recipe-url — extract a RecipeCard from a recipe page URL
-- POST /v1/ingest          — unified modality dispatcher (receipt in v1;
-                             URL #205, barcode #206 as extension seams)
+- POST /v1/ingest/recipe-url — compat shim (delegates to unified /ingest;
+                               keeps returning RecipeCard for existing callers)
+- POST /v1/ingest            — unified modality dispatcher (receipt + URL in v1;
+                               barcode #206 as extension seam)
 """
 
 import logging
@@ -40,7 +41,13 @@ class RecipeUrlRequest(BaseModel):
 @router.post(
     "/recipe-url",
     response_model=RecipeCard,
-    summary="Extract a recipe from a URL",
+    summary="[Compat shim] Extract a recipe from a URL",
+    description=(
+        "Compatibility shim for the old per-modality route. "
+        "Delegates to the unified /ingest dispatcher and unwraps the "
+        "RecipeCardProposal envelope to return the bare RecipeCard so "
+        "existing callers are unaffected. New callers should use POST /v1/ingest."
+    ),
     responses={
         200: {"description": "Extracted RecipeCard"},
         401: {"description": "Missing or invalid JWT"},
@@ -52,29 +59,34 @@ async def ingest_recipe_url(
     request: RecipeUrlRequest,
     user_id: str = Depends(get_current_user_id),
 ) -> RecipeCard:
-    """Extract a structured RecipeCard from a recipe page URL.
+    """Compat shim: extract a RecipeCard via the unified dispatcher.
 
-    Extraction strategy (in order):
-    1. recipe-scrapers — handles 500+ known sites via Schema.org
-    2. recipe-scrapers wild_mode=True — unknown sites with Schema markup
-    3. Gemini AI extraction from raw HTML (via AIManager)
+    Delegates to the URL extractor registered in the dispatcher, then unwraps
+    ``envelope.proposal.recipe`` to preserve the original RecipeCard contract.
+    Status codes (422 invalid URL, 502 extraction failure) are preserved.
     """
-    logger.info(f"Recipe URL ingest: user={user_id}, url={request.url}")
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload, dispatcher
+
+    logger.info("Recipe URL ingest (shim): user=%s, url=%s", user_id, request.url)
+
+    payload = IngestPayload(modality=IngestModality.URL, url=request.url)
 
     try:
-        from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
-
-        recipe = await ingest_recipe_from_url(request.url)
+        envelope = await dispatcher.dispatch(payload)
+        # envelope.proposal is RecipeCardProposal; unwrap to bare RecipeCard
+        recipe: RecipeCard = envelope.proposal.recipe  # type: ignore[union-attr]
         logger.info(
-            f"Recipe URL ingest success: user={user_id}, title={recipe.title!r}, "
-            f"thumbnail_url={recipe.thumbnail_url!r}"
+            "Recipe URL ingest (shim) success: user=%s, title=%r, thumbnail_url=%r",
+            user_id,
+            recipe.title,
+            recipe.thumbnail_url,
         )
         return recipe
 
     except ValueError as e:
         raise HTTPException(status_code=422, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Recipe URL ingest failed: {e}", exc_info=True)
+        logger.error("Recipe URL ingest (shim) failed: %s", e, exc_info=True)
         raise HTTPException(
             status_code=502,
             detail=f"Could not extract recipe from URL: {str(e)}",
@@ -88,9 +100,11 @@ async def ingest_recipe_url(
 
 @router.post(
     "",
-    summary="Unified ingest dispatcher (receipt + barcode wired; URL #205 coming)",
+    summary="Unified ingest dispatcher (receipt + barcode + URL wired)",
     responses={
-        200: {"description": "PantryProposal envelope"},
+        200: {
+            "description": "ProposalEnvelope — PantryProposal for receipt, RecipeCardProposal for URL"
+        },
         400: {"description": "Could not detect modality or modality not yet supported"},
         401: {"description": "Missing or invalid JWT"},
         422: {"description": "Invalid or unreadable input"},
@@ -109,29 +123,26 @@ async def ingest(
     text: str | None = Form(
         default=None,
         description=(
-            "Free-form text. Auto-detected: URL → recipe (#205 stub), "
+            "Free-form text. Auto-detected: URL → recipe extraction, "
             "8-14 digit string → barcode (#206 stub), else → receipt OCR text."
         ),
     ),
     user_id: str = Depends(get_current_user_id),
 ) -> dict:
-    """Unified entry point for all pantry ingest modalities.
+    """Unified entry point for all ingest modalities.
 
-    **v1 behaviour:** receipt and barcode/product are fully wired.
+    **v1 behaviour:** receipt, barcode/product, and URL (recipe) are fully wired.
 
     - Supply ``file`` (image upload) or ``ocr_text`` (plain text) to trigger
-      receipt parsing.
+      receipt parsing → returns ``ProposalEnvelope[PantryProposal]``.
+    - Supply ``text`` with a URL to extract a recipe → returns
+      ``ProposalEnvelope[RecipeCardProposal]``.
     - Supply ``text`` with an 8–14 digit barcode number to trigger the
       barcode/product extractor (routes to ``run_product_ingest``; lookup
       is a stub pending #191).
-    - Supply ``text`` with a URL to get a 400 today (ticket #205).
     - Supply any other ``text`` to let the server treat it as receipt OCR text.
 
-    The response is a ``ProposalEnvelope[PantryProposal]`` serialised as JSON.
-
-    **Extension seam for #205 (URL):** register an extractor with
-    ``dispatcher.register_url_extractor(fn)`` at app startup and the 400
-    stub becomes live automatically.
+    The response is a ``ProposalEnvelope`` serialised as JSON.
     """
     from bubbly_chef.api.ingest_dispatcher import (
         IngestModality,

--- a/ai-service/bubbly_chef/main.py
+++ b/ai-service/bubbly_chef/main.py
@@ -9,6 +9,7 @@ Serves only AI-powered endpoints:
 
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+import logging
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -17,7 +18,11 @@ from bubbly_chef.api.routes import chat, ingest, pantry, recipes_ai, scan, workf
 from bubbly_chef.config import settings
 from bubbly_chef.repository.supabase_repo import get_repository
 
-import logging
+# Register URL extractor into the ingest dispatcher at import time.
+# This module-level import triggers dispatcher.register_url_extractor() inside
+# url_extractor.py, mirroring how ingest_dispatcher.py self-registers the receipt
+# extractor.  Must come after bubbly_chef packages are importable.
+import bubbly_chef.services.url_extractor as _url_extractor_registration  # noqa: F401
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/ai-service/bubbly_chef/services/url_extractor.py
+++ b/ai-service/bubbly_chef/services/url_extractor.py
@@ -1,0 +1,90 @@
+"""URL extractor for the unified /ingest dispatcher.
+
+Adapts ``recipe_url_ingestor.ingest_recipe_from_url`` to the dispatcher's
+``ExtractorFn`` interface.
+
+Design note — recipe proposals, not pantry proposals
+------------------------------------------------------
+URL ingest produces a ``RecipeCard``.  That is fundamentally different from
+receipt/barcode ingest, which produce pantry *actions* and flow through the
+``build_actions_from_normalized`` → ``PantryProposal`` spine.  Forcing a recipe
+through the pantry spine would be wrong (a RecipeCard is not a list of pantry
+actions).  Instead, the extractor wraps the card in ``RecipeCardProposal`` and
+returns a ``ProposalEnvelope[RecipeCardProposal]`` via ``create_recipe_envelope``.
+
+This is exactly the divergence called out in the ticket: recipe ingest
+legitimately splits from the pantry tail at this point.
+
+Registration
+------------
+This module registers the extractor into the global ``dispatcher`` singleton at
+import time (mirroring how ``ingest_dispatcher.py`` registers the receipt
+extractor).  ``main.py`` imports this module at startup to trigger registration.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from bubbly_chef.api.ingest_dispatcher import IngestPayload, dispatcher
+from bubbly_chef.models.recipe import RecipeCardProposal
+from bubbly_chef.models.base import ProposalEnvelope
+from bubbly_chef.workflows.state import create_recipe_envelope
+
+logger = logging.getLogger(__name__)
+
+
+async def url_extractor(payload: IngestPayload) -> ProposalEnvelope[RecipeCardProposal]:
+    """Extract a recipe from a URL and return a recipe-proposal envelope.
+
+    Pulls the URL from ``payload.url`` (preferred) or ``payload.text`` as a
+    fallback (the dispatcher populates ``text`` when the input arrives via the
+    ``/ingest`` text field and the modality was auto-detected as URL).
+
+    Args:
+        payload: Dispatcher-normalised ingest payload with ``modality=URL``.
+
+    Returns:
+        ``ProposalEnvelope[RecipeCardProposal]`` ready to be serialised and
+        returned to the caller.
+
+    Raises:
+        ValueError: No URL could be found in the payload.
+        RuntimeError: Extraction failed at all tiers (scraper + AI fallback).
+    """
+    from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
+
+    url = payload.url or payload.text
+    if not url:
+        raise ValueError("URL extractor requires a URL in payload.url or payload.text")
+
+    url = url.strip()
+    logger.info("URL extractor: extracting recipe from %s", url)
+
+    recipe = await ingest_recipe_from_url(url)
+
+    proposal = RecipeCardProposal(
+        recipe=recipe,
+        source_url=url,
+    )
+
+    envelope = create_recipe_envelope(
+        proposal=proposal,
+        confidence=0.9,
+        field_confidences={},
+        warnings=[],
+        errors=[],
+        assistant_message=f"I've extracted the recipe: {recipe.title}. Please review.",
+    )
+
+    logger.info("URL extractor: recipe extracted: title=%r", recipe.title)
+    return envelope
+
+
+# ---------------------------------------------------------------------------
+# Register into the global dispatcher singleton at module-load time.
+# main.py imports this module during startup so the registration always runs
+# before any request is served.
+# ---------------------------------------------------------------------------
+
+dispatcher.register_url_extractor(url_extractor)

--- a/ai-service/bubbly_chef/services/url_extractor.py
+++ b/ai-service/bubbly_chef/services/url_extractor.py
@@ -29,6 +29,7 @@ import logging
 from bubbly_chef.api.ingest_dispatcher import IngestPayload, dispatcher
 from bubbly_chef.models.recipe import RecipeCardProposal
 from bubbly_chef.models.base import ProposalEnvelope
+from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
 from bubbly_chef.workflows.state import create_recipe_envelope
 
 logger = logging.getLogger(__name__)
@@ -52,8 +53,6 @@ async def url_extractor(payload: IngestPayload) -> ProposalEnvelope[RecipeCardPr
         ValueError: No URL could be found in the payload.
         RuntimeError: Extraction failed at all tiers (scraper + AI fallback).
     """
-    from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
-
     url = payload.url or payload.text
     if not url:
         raise ValueError("URL extractor requires a URL in payload.url or payload.text")

--- a/ai-service/tests/test_ingest_dispatcher.py
+++ b/ai-service/tests/test_ingest_dispatcher.py
@@ -12,7 +12,7 @@ Behaviors covered:
 9. dispatcher.dispatch: auto-detects from ocr_text when modality=UNKNOWN
 10. POST /v1/ingest with ocr_text form field → 200, proposal envelope
 11. POST /v1/ingest with image file → 200 (OCR mocked)
-12. POST /v1/ingest with URL text → 400 (not yet wired, stub)
+12. POST /v1/ingest with URL text → 200 (URL extractor now registered via url_extractor module)
 """
 
 from __future__ import annotations
@@ -323,22 +323,41 @@ async def test_ingest_endpoint_receipt_via_image_file(app, _mock_envelope):
 
 
 @pytest.mark.asyncio
-async def test_ingest_endpoint_url_text_returns_400_stub(app):
-    """POST /v1/ingest with a URL in text field → 400 (not yet wired)."""
+async def test_ingest_endpoint_url_text_returns_recipe_envelope(app):
+    """POST /v1/ingest with a URL in text field → 200, RecipeCardProposal envelope."""
     from bubbly_chef.api.auth import get_current_user_id
     from httpx import ASGITransport, AsyncClient
+    from unittest.mock import MagicMock, patch
 
     app.dependency_overrides[get_current_user_id] = lambda: "test-user"
 
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        resp = await ac.post(
-            "/v1/ingest",
-            data={"text": "https://www.allrecipes.com/recipe/123/cookies/"},
-        )
+    # Import the url_extractor module so it registers itself into the dispatcher.
+    import bubbly_chef.services.url_extractor  # noqa: F401
+
+    stub = MagicMock()
+    stub.title.return_value = "Dispatcher URL Test Recipe"
+    stub.ingredients.return_value = ["flour"]
+    stub.instructions_list.return_value = ["Mix and bake"]
+    stub.total_time.return_value = 30
+    stub.yields.return_value = "4 servings"
+    stub.description.return_value = None
+    stub.image.return_value = None
+
+    with patch(
+        "bubbly_chef.services.recipe_url_ingestor.scrape_me",
+        return_value=stub,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post(
+                "/v1/ingest",
+                data={"text": "https://www.allrecipes.com/recipe/123/cookies/"},
+            )
 
     app.dependency_overrides.clear()
-    assert resp.status_code == 400
-    assert "205" in resp.json()["detail"]
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["intent"] == "recipe_card"
+    assert data["proposal"]["recipe"]["title"] == "Dispatcher URL Test Recipe"
 
 
 @pytest.mark.asyncio

--- a/ai-service/tests/test_recipe_url_ingestor.py
+++ b/ai-service/tests/test_recipe_url_ingestor.py
@@ -45,6 +45,9 @@ def app():
         allow_credentials=True,
     )
 
+    # Importing url_extractor registers the URL extractor into the dispatcher.
+    import bubbly_chef.services.url_extractor  # noqa: F401
+
     from bubbly_chef.api.routes.ingest import router
 
     app.include_router(router)

--- a/ai-service/tests/test_url_extractor.py
+++ b/ai-service/tests/test_url_extractor.py
@@ -1,0 +1,337 @@
+"""Tests for the URL extractor and its integration with the dispatcher.
+
+Behaviors covered:
+1. detect_modality: URL string → IngestModality.URL  (dispatcher unit test)
+2. url_extractor: calls ingest_recipe_from_url and returns RecipeCardProposal envelope
+3. url_extractor: uses payload.url when set
+4. url_extractor: falls back to payload.text when payload.url is None
+5. url_extractor: raises ValueError when neither url nor text is set
+6. url_extractor: propagates RuntimeError from ingest_recipe_from_url
+7. dispatcher singleton: URL modality is routed to url_extractor after module import
+8. compat shim POST /v1/ingest/recipe-url: delegates to dispatcher, returns bare RecipeCard
+9. compat shim POST /v1/ingest/recipe-url: 422 for invalid URL (validator fires before dispatch)
+10. compat shim POST /v1/ingest/recipe-url: 502 when extraction raises
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+TEST_USER_ID = "test-user-url-extractor"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_scraper_stub(
+    title: str = "Pasta Carbonara",
+    ingredients: list[str] | None = None,
+    instructions: list[str] | None = None,
+    total_time: int = 25,
+    yields: str = "2 servings",
+    description: str | None = "Classic Italian pasta",
+    image: str | None = "https://example.com/pasta.jpg",
+) -> MagicMock:
+    stub = MagicMock()
+    stub.title.return_value = title
+    stub.ingredients.return_value = ingredients or ["200g spaghetti", "100g pancetta"]
+    stub.instructions_list.return_value = instructions or ["Boil pasta", "Mix with sauce"]
+    stub.total_time.return_value = total_time
+    stub.yields.return_value = yields
+    stub.description.return_value = description
+    stub.image.return_value = image
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# App fixture (reuse the same pattern as other integration tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app():
+    from contextlib import asynccontextmanager
+    from collections.abc import AsyncGenerator
+
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+
+    @asynccontextmanager
+    async def no_op_lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        yield
+
+    app = FastAPI(lifespan=no_op_lifespan)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+        allow_credentials=True,
+    )
+
+    # Importing url_extractor registers the URL extractor into the dispatcher.
+    import bubbly_chef.services.url_extractor  # noqa: F401
+
+    from bubbly_chef.api.routes.ingest import router
+
+    app.include_router(router)
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(app):
+    from bubbly_chef.api.auth import get_current_user_id
+
+    app.dependency_overrides[get_current_user_id] = lambda: TEST_USER_ID
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Behavior 1: detect_modality still identifies URL strings correctly
+# ---------------------------------------------------------------------------
+
+
+def test_detect_modality_url():
+    """detect_modality returns URL for http/https strings (regression guard)."""
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+    assert (
+        ModalityDispatcher.detect_modality(text="https://www.allrecipes.com/recipe/123/pasta/")
+        is IngestModality.URL
+    )
+    assert (
+        ModalityDispatcher.detect_modality(text="http://myblog.example.com/soup")
+        is IngestModality.URL
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behaviors 2–6: url_extractor unit tests (no HTTP, mock ingest_recipe_from_url)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_url_extractor_returns_recipe_card_proposal_envelope():
+    """url_extractor wraps RecipeCard in RecipeCardProposal and envelope."""
+    from bubbly_chef.models.recipe import Ingredient, RecipeCard
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload
+    from bubbly_chef.services.url_extractor import url_extractor
+
+    fake_recipe = RecipeCard(
+        title="Pasta Carbonara",
+        ingredients=[Ingredient(name="spaghetti"), Ingredient(name="pancetta")],
+        instructions=["Boil pasta", "Mix with sauce"],
+        source_type="url",
+        source_url="https://example.com/pasta",
+    )
+
+    with patch(
+        "bubbly_chef.services.url_extractor.ingest_recipe_from_url",
+        new_callable=AsyncMock,
+        return_value=fake_recipe,
+    ):
+        payload = IngestPayload(
+            modality=IngestModality.URL,
+            url="https://example.com/pasta",
+        )
+        envelope = await url_extractor(payload)
+
+    # Envelope shape
+    assert envelope.intent.value == "recipe_card"
+    assert envelope.proposal is not None
+    assert envelope.proposal.recipe.title == "Pasta Carbonara"
+    assert envelope.proposal.source_url == "https://example.com/pasta"
+    assert len(envelope.proposal.recipe.ingredients) == 2
+
+
+@pytest.mark.asyncio
+async def test_url_extractor_uses_payload_url():
+    """url_extractor reads the URL from payload.url when set."""
+    from bubbly_chef.models.recipe import RecipeCard
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload
+    from bubbly_chef.services.url_extractor import url_extractor
+
+    fake_recipe = RecipeCard(
+        title="Tiramisu",
+        source_type="url",
+        source_url="https://example.com/tiramisu",
+    )
+
+    mock_ingest = AsyncMock(return_value=fake_recipe)
+    with patch("bubbly_chef.services.url_extractor.ingest_recipe_from_url", mock_ingest):
+        payload = IngestPayload(
+            modality=IngestModality.URL,
+            url="https://example.com/tiramisu",
+        )
+        await url_extractor(payload)
+
+    mock_ingest.assert_awaited_once_with("https://example.com/tiramisu")
+
+
+@pytest.mark.asyncio
+async def test_url_extractor_falls_back_to_payload_text():
+    """url_extractor uses payload.text when payload.url is None."""
+    from bubbly_chef.models.recipe import RecipeCard
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload
+    from bubbly_chef.services.url_extractor import url_extractor
+
+    fake_recipe = RecipeCard(
+        title="Risotto",
+        source_type="url",
+        source_url="https://example.com/risotto",
+    )
+
+    mock_ingest = AsyncMock(return_value=fake_recipe)
+    with patch("bubbly_chef.services.url_extractor.ingest_recipe_from_url", mock_ingest):
+        payload = IngestPayload(
+            modality=IngestModality.URL,
+            url=None,
+            text="https://example.com/risotto",
+        )
+        await url_extractor(payload)
+
+    mock_ingest.assert_awaited_once_with("https://example.com/risotto")
+
+
+@pytest.mark.asyncio
+async def test_url_extractor_raises_value_error_when_no_url():
+    """url_extractor raises ValueError when neither url nor text is provided."""
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload
+    from bubbly_chef.services.url_extractor import url_extractor
+
+    payload = IngestPayload(modality=IngestModality.URL, url=None, text=None)
+
+    with pytest.raises(ValueError, match="requires a URL"):
+        await url_extractor(payload)
+
+
+@pytest.mark.asyncio
+async def test_url_extractor_propagates_runtime_error():
+    """url_extractor lets RuntimeError from ingest_recipe_from_url bubble up."""
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload
+    from bubbly_chef.services.url_extractor import url_extractor
+
+    with patch(
+        "bubbly_chef.services.url_extractor.ingest_recipe_from_url",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("All extraction tiers failed"),
+    ):
+        payload = IngestPayload(
+            modality=IngestModality.URL,
+            url="https://broken.example.com/recipe",
+        )
+        with pytest.raises(RuntimeError, match="All extraction tiers failed"):
+            await url_extractor(payload)
+
+
+# ---------------------------------------------------------------------------
+# Behavior 7: dispatcher singleton routes URL to url_extractor after import
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_global_dispatcher_routes_url_to_extractor():
+    """After importing url_extractor, the global dispatcher handles URL payloads."""
+    import bubbly_chef.services.url_extractor  # noqa: F401  — triggers registration
+
+    from bubbly_chef.api.ingest_dispatcher import (
+        IngestModality,
+        IngestPayload,
+        dispatcher,
+    )
+    from bubbly_chef.models.recipe import RecipeCard
+
+    fake_recipe = RecipeCard(
+        title="Global Dispatch Test",
+        source_type="url",
+        source_url="https://example.com/global",
+    )
+
+    with patch(
+        "bubbly_chef.services.url_extractor.ingest_recipe_from_url",
+        new_callable=AsyncMock,
+        return_value=fake_recipe,
+    ):
+        payload = IngestPayload(
+            modality=IngestModality.URL,
+            url="https://example.com/global",
+        )
+        envelope = await dispatcher.dispatch(payload)
+
+    assert envelope.proposal.recipe.title == "Global Dispatch Test"  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Behaviors 8–10: compat shim POST /v1/ingest/recipe-url
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compat_shim_returns_bare_recipe_card(client):
+    """POST /v1/ingest/recipe-url → 200 with bare RecipeCard (unchanged contract)."""
+    stub = _make_scraper_stub()
+
+    with patch(
+        "bubbly_chef.services.recipe_url_ingestor.scrape_me",
+        return_value=stub,
+    ):
+        resp = await client.post(
+            "/v1/ingest/recipe-url",
+            json={"url": "https://www.allrecipes.com/recipe/123/pasta/"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    # Must return the same RecipeCard fields as before the shim was introduced
+    assert data["title"] == "Pasta Carbonara"
+    assert data["source_type"] == "url"
+    assert data["source_url"] == "https://www.allrecipes.com/recipe/123/pasta/"
+    assert "id" in data
+    # Must NOT wrap in a ProposalEnvelope — bare RecipeCard only
+    assert "intent" not in data
+    assert "proposal" not in data
+
+
+@pytest.mark.asyncio
+async def test_compat_shim_invalid_url_returns_422(client):
+    """POST /v1/ingest/recipe-url with non-URL string → 422."""
+    resp = await client.post(
+        "/v1/ingest/recipe-url",
+        json={"url": "not-a-url"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_compat_shim_extraction_failure_returns_502(client):
+    """POST /v1/ingest/recipe-url when all extraction tiers fail → 502."""
+    with (
+        patch(
+            "bubbly_chef.services.recipe_url_ingestor.scrape_me",
+            side_effect=Exception("SITE_NOT_SUPPORTED"),
+        ),
+        patch(
+            "bubbly_chef.services.recipe_url_ingestor.httpx_get",
+            new_callable=AsyncMock,
+            side_effect=Exception("connection refused"),
+        ),
+        patch(
+            "bubbly_chef.services.recipe_url_ingestor.get_ai_manager",
+            side_effect=Exception("AI unavailable"),
+        ),
+    ):
+        resp = await client.post(
+            "/v1/ingest/recipe-url",
+            json={"url": "https://broken.example.com/recipe"},
+        )
+
+    assert resp.status_code == 502
+    assert "extract" in resp.json()["detail"].lower()


### PR DESCRIPTION
## Summary
- Wires recipe-URL ingest through the unified `/ingest` dispatcher (R4-2 spine)
- Fixes the chat handoff loop: pasting a recipe URL in chat now runs the extractor directly and returns a `RecipeCardProposal` instead of dead-ending on the "share the recipe URL" prompt forever

## What lands
- `services/url_extractor.py`: adapts `ingest_recipe_from_url` → `ProposalEnvelope[RecipeCardProposal]` via `create_recipe_envelope`. Self-registers into the dispatcher at import; `main.py` imports it at startup.
- Dispatcher `ExtractorFn` return type widened to `ProposalEnvelope[PantryProposal | RecipeCardProposal]` — recipe proposals legitimately diverge from the pantry tail.
- Old `POST /v1/ingest/recipe-url` becomes a thin compat shim: delegates to the dispatcher, unwraps `envelope.proposal.recipe`.
- `build_handoff_recipe` in `router.py`: detects an `http/https` URL in the chat message; if present, calls `ingest_recipe_from_url` and returns a `RecipeCardProposal` (proposal path). If no URL, still returns the handoff prompt. Extraction errors return a one-shot error message rather than looping.
- Both `run_chat_workflow` and `_build_envelope_from_state` updated: `RECIPE_INGEST` intent with a proposal returns a recipe envelope; without a proposal returns the handoff envelope as before.

## Tests
- 3 new regression tests in `test_chat_router.py`: URL present → proposal returned; no URL → handoff prompt; extractor failure → error handoff (no loop)
- Full `router or chat or ingest or url` suite: 77 passed
- `ruff check bubbly_chef/`: all checks passed

## Linked
Fixes #214

## Out of scope
- Recipe text (non-URL) ingest from chat — a separate follow-up
- Session state after successful ingest (moving to INGESTING mode)