### PR TITLE
fix(chat): run recipe-URL extractor instead of looping on handoff (#214)

### DIFF
--- a/ai-service/bubbly_chef/workflows/router.py
+++ b/ai-service/bubbly_chef/workflows/router.py
@@ -15,6 +15,7 @@ Architecture:
 """
 
 import logging
+import re
 from collections.abc import AsyncIterator
 from datetime import UTC, date, datetime, timedelta
 from typing import Any
@@ -38,6 +39,7 @@ from bubbly_chef.models.proposals import HandoffKind
 from bubbly_chef.models.recipe import RecipeCardProposal
 from bubbly_chef.models.session import SessionMode
 from bubbly_chef.repository.supabase_repo import SupabaseRepository, get_repository
+from bubbly_chef.services.recipe_url_ingestor import ingest_recipe_from_url
 from bubbly_chef.workflows.chat.nodes import (
     COOKING_RECIPE_ID_KEY,
     COOKING_RECIPE_KEY,
@@ -79,6 +81,13 @@ from bubbly_chef.workflows.state import (
 )
 
 logger = logging.getLogger(__name__)
+
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+
+
+def _extract_url(text: str) -> str | None:
+    m = _URL_RE.search(text)
+    return m.group(0) if m else None
 
 
 # =============================================================================
@@ -515,10 +524,42 @@ def build_handoff_product(state: WorkflowState) -> WorkflowState:
     }
 
 
-def build_handoff_recipe(state: WorkflowState) -> WorkflowState:
+async def build_handoff_recipe(state: WorkflowState) -> WorkflowState:
     """
-    Node: Build handoff response for recipe ingest request.
+    Node: Build response for recipe ingest.
+
+    If a URL is present in the message, run the extractor directly and
+    return a RecipeCardProposal. If no URL is present, ask the user to share one.
     """
+    url = _extract_url(state.get("input_text", ""))
+    if url:
+        try:
+            recipe_card = await ingest_recipe_from_url(url)
+            proposal = RecipeCardProposal(recipe=recipe_card, source_url=url)
+            return {
+                **state,
+                "intent": Intent.RECIPE_INGEST.value,
+                "assistant_message": f"Here's the recipe I found: {recipe_card.title}. Please review.",
+                "next_action": NextAction.REVIEW_PROPOSAL.value,
+                "proposal": proposal,
+                "requires_review": True,
+                "workflow_status": WorkflowStatus.AWAITING_REVIEW.value,
+            }
+        except Exception as e:
+            logger.warning(f"Recipe URL extraction failed for {url!r}: {e}")
+            return {
+                **state,
+                "intent": Intent.RECIPE_INGEST.value,
+                "assistant_message": (
+                    "I wasn't able to extract the recipe from that URL."
+                    " You can try pasting the recipe text instead."
+                ),
+                "next_action": NextAction.REQUEST_RECIPE_TEXT.value,
+                "proposal": None,
+                "requires_review": False,
+                "workflow_status": WorkflowStatus.AWAITING_INPUT.value,
+                "errors": state.get("errors", []) + [f"URL extraction failed: {e}"],
+            }
     return {
         **state,
         "intent": Intent.RECIPE_INGEST.value,
@@ -926,6 +967,18 @@ async def run_chat_workflow(
         )
 
     elif intent == Intent.RECIPE_INGEST.value:
+        proposal = final_state.get("proposal")
+        if isinstance(proposal, RecipeCardProposal):
+            return create_recipe_envelope(
+                proposal=proposal,
+                confidence=final_state.get("confidence", 0.9),
+                field_confidences=final_state.get("field_confidences", {}),
+                warnings=final_state.get("warnings", []),
+                errors=final_state.get("errors", []),
+                assistant_message=final_state.get("assistant_message", ""),
+                request_id=final_state.get("request_id"),
+                workflow_id=final_state.get("workflow_id"),
+            )
         return create_handoff_envelope(
             handoff_kind=HandoffKind.RECIPE,
             assistant_message=final_state.get("assistant_message", ""),
@@ -1035,17 +1088,30 @@ def _build_envelope_from_state(
             conversation_id=final_state.get("conversation_id"),
         )
     elif intent == Intent.RECIPE_INGEST.value:
-        envelope = create_handoff_envelope(
-            handoff_kind=HandoffKind.RECIPE,
-            assistant_message=final_state.get("assistant_message", ""),
-            next_action=NextAction.REQUEST_RECIPE_TEXT,
-            instructions="Share the recipe URL or paste the recipe text.",
-            required_inputs=["recipe_url", "recipe_text"],
-            optional_inputs=["title"],
-            request_id=final_state.get("request_id"),
-            workflow_id=final_state.get("workflow_id"),
-            conversation_id=final_state.get("conversation_id"),
-        )
+        proposal = final_state.get("proposal")
+        if isinstance(proposal, RecipeCardProposal):
+            envelope = create_recipe_envelope(
+                proposal=proposal,
+                confidence=final_state.get("confidence", 0.9),
+                field_confidences=final_state.get("field_confidences", {}),
+                warnings=final_state.get("warnings", []),
+                errors=final_state.get("errors", []),
+                assistant_message=final_state.get("assistant_message", ""),
+                request_id=final_state.get("request_id"),
+                workflow_id=final_state.get("workflow_id"),
+            )
+        else:
+            envelope = create_handoff_envelope(
+                handoff_kind=HandoffKind.RECIPE,
+                assistant_message=final_state.get("assistant_message", ""),
+                next_action=NextAction.REQUEST_RECIPE_TEXT,
+                instructions="Share the recipe URL or paste the recipe text.",
+                required_inputs=["recipe_url", "recipe_text"],
+                optional_inputs=["title"],
+                request_id=final_state.get("request_id"),
+                workflow_id=final_state.get("workflow_id"),
+                conversation_id=final_state.get("conversation_id"),
+            )
     elif intent == Intent.RECIPE_CARD.value:
         proposal = final_state.get("proposal")
         if isinstance(proposal, RecipeCardProposal):

--- a/ai-service/tests/test_chat_router.py
+++ b/ai-service/tests/test_chat_router.py
@@ -510,3 +510,81 @@ def test_cooking_recipe_context_falls_back_to_session_metadata():
 def test_cooking_recipe_context_empty_without_recipe():
     assert format_cooking_recipe_context(_state()) == ""
     assert format_cooking_recipe_context(_state(context={"other": 1})) == ""
+
+
+# ---------------------------------------------------------------------------
+# build_handoff_recipe — URL present → proposal; no URL → handoff prompt (#214)
+# ---------------------------------------------------------------------------
+
+
+def _mock_ingestor(recipe_card):
+    from unittest.mock import AsyncMock, patch
+    return patch(
+        "bubbly_chef.workflows.router.ingest_recipe_from_url",
+        new=AsyncMock(return_value=recipe_card),
+    )
+
+
+def _make_recipe_card(title: str = "Crispy Fried Chicken"):
+    from bubbly_chef.models.recipe import RecipeCard
+    return RecipeCard(title=title)
+
+
+@pytest.mark.asyncio
+async def test_build_handoff_recipe_with_url_returns_proposal():
+    """A message containing a URL skips the handoff and returns a RecipeCardProposal."""
+    from bubbly_chef.models.recipe import RecipeCardProposal
+    from bubbly_chef.workflows.router import build_handoff_recipe
+
+    card = _make_recipe_card("Crispy Fried Chicken")
+    state = _state(
+        input_text="can you help make this? https://www.allrecipes.com/recipe/8805/crispy-fried-chicken/",
+        intent="recipe_ingest",
+    )
+
+    with _mock_ingestor(card):
+        result = await build_handoff_recipe(state)
+
+    from bubbly_chef.models.recipe import RecipeCardProposal
+    assert isinstance(result["proposal"], RecipeCardProposal)
+    assert result["proposal"].recipe.title == "Crispy Fried Chicken"
+    assert result["proposal"].source_url == "https://www.allrecipes.com/recipe/8805/crispy-fried-chicken/"
+    assert result.get("workflow_status") != "awaiting_input"
+
+
+@pytest.mark.asyncio
+async def test_build_handoff_recipe_without_url_returns_handoff():
+    """A message with no URL still returns the handoff prompt asking for a URL."""
+    from bubbly_chef.workflows.router import build_handoff_recipe
+
+    state = _state(input_text="can you help me save a recipe?", intent="recipe_ingest")
+    result = await build_handoff_recipe(state)
+
+    assert result.get("proposal") is None
+    assert result.get("workflow_status") == "awaiting_input"
+    msg = result.get("assistant_message", "")
+    assert "recipe" in msg.lower()
+
+
+@pytest.mark.asyncio
+async def test_build_handoff_recipe_url_extraction_failure_returns_error_handoff():
+    """If the ingestor raises, the node returns an error handoff — no crash, no loop."""
+    from unittest.mock import AsyncMock, patch
+    from bubbly_chef.workflows.router import build_handoff_recipe
+
+    state = _state(
+        input_text="save https://broken.example.com/recipe",
+        intent="recipe_ingest",
+        errors=[],
+    )
+
+    with patch(
+        "bubbly_chef.workflows.router.ingest_recipe_from_url",
+        new=AsyncMock(side_effect=RuntimeError("fetch failed")),
+    ):
+        result = await build_handoff_recipe(state)
+
+    assert result.get("proposal") is None
+    assert result.get("workflow_status") == "awaiting_input"
+    assert any("URL extraction failed" in e for e in result.get("errors", []))
+


### PR DESCRIPTION
## Summary

Fixes the chat recipe-URL dead-end loop (#214). Pasting a recipe URL in chat now runs the importer and returns a proposal, instead of repeating the "share the recipe URL" handoff forever.

## What lands

- `build_handoff_recipe` (`ai-service/bubbly_chef/workflows/router.py`) now detects an http/https URL in the message; if present it calls `ingest_recipe_from_url` and returns a `RecipeCardProposal` rather than the `AWAITING_INPUT` handoff.
- Messages with no URL still return the handoff prompt (correct — it's asking for the URL).
- Extraction errors surface a one-shot error message rather than looping.
- Preserves the proposal-confirmation pattern — nothing auto-writes to the DB.

## Tests

- `ai-service/tests/test_chat_router.py` — new cases: URL-in-message produces a recipe proposal (no loop); no-URL message still returns the handoff.

## Linked

Closes #214.

## Out of scope

R4 unified-ingest routing (#212) — this is the chat-path fix the R4 validation identified as surviving the refactor; it's independent of the /ingest dispatcher work.