### PR TITLE
fix(receipt): unify receipt categorization onto catalog-backed resolver (#215)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/pantry.py
+++ b/ai-service/bubbly_chef/api/routes/pantry.py
@@ -17,8 +17,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
 from bubbly_chef.api.auth import get_current_user_id
-from bubbly_chef.domain.catalog import categorize
-from bubbly_chef.domain.normalizer import detect_category
+from bubbly_chef.domain.normalizer import resolve_category
 from bubbly_chef.models.pantry import FoodCategory, StorageLocation
 from bubbly_chef.tools.expiry import get_expiry_heuristics
 
@@ -108,14 +107,8 @@ async def estimate_category(
 ) -> EstimateCategoryResponse:
     """Infer a food category from an item name.
 
-    Uses the same two-stage logic as the receipt parser for consistency (#177):
-    1. Keyword matching via ``detect_category`` (normalizer) — high priority,
-       handles common items like "yogurt", "milk", "chicken" immediately.
-    2. Catalog fuzzy match via ``categorize`` (catalog, threshold=95) — covers
-       USDA-backed items not in the keyword list.
-
-    Returns null when neither stage has a confident match. Callers should fall
-    back to 'other' on null so that a failed estimate never blocks the add.
+    Uses keyword matching then catalog fuzzy match (threshold=95).
+    Returns null when neither has a confident match — callers should
+    fall back to 'other' so a failed estimate never blocks the add.
     """
-    category = detect_category(request.name) or categorize(request.name)
-    return EstimateCategoryResponse(category=category)
+    return EstimateCategoryResponse(category=resolve_category(request.name))

--- a/ai-service/bubbly_chef/domain/normalizer.py
+++ b/ai-service/bubbly_chef/domain/normalizer.py
@@ -236,6 +236,17 @@ def normalize_food_name(name: str) -> str:
     return cleaned
 
 
+def resolve_category(name: str) -> str | None:
+    """Return the best deterministic category for *name*, or None.
+
+    Tries keyword matching first (``detect_category``), then the food
+    catalog (``catalog_categorize``).  This is the single shared helper
+    used by both the manual-add path and the receipt ingest path so the
+    two paths can never drift.
+    """
+    return detect_category(name) or catalog_categorize(name) or None
+
+
 def detect_category(name: str) -> str | None:
     """
     Detect food category from name using keyword matching.

--- a/ai-service/bubbly_chef/workflows/receipt_ingest.py
+++ b/ai-service/bubbly_chef/workflows/receipt_ingest.py
@@ -20,7 +20,7 @@ from bubbly_chef.models.pantry import (
     PantryProposal,
     PantryUpsertAction,
 )
-from bubbly_chef.domain.normalizer import normalize_to_base_unit
+from bubbly_chef.domain.normalizer import normalize_to_base_unit, resolve_category
 from bubbly_chef.tools.expiry import get_expiry_heuristics
 from bubbly_chef.tools.normalizer import get_normalizer
 from bubbly_chef.workflows.state import (
@@ -231,12 +231,17 @@ def normalize_receipt_items(state: WorkflowState) -> WorkflowState:
         # Normalize name
         normalized_name = normalizer.normalize(name)
 
-        # Get category
+        # Get category: prefer deterministic catalog/keyword answer over the
+        # noisy LLM string (which produces compounds like "dairy & eggs" that
+        # map_category can't match exactly).
         llm_category = item.get("category")
-        if llm_category and llm_category.lower() != "other":
+        resolved = resolve_category(normalized_name)
+        if resolved:
+            category = map_category(resolved)
+        elif llm_category and llm_category.lower() != "other":
             category = map_category(llm_category)
         else:
-            category = normalizer.get_category(normalized_name)
+            category = map_category(None)
 
         # Get storage location
         storage = expiry.get_default_storage(category)

--- a/ai-service/bubbly_chef/workflows/shared_state.py
+++ b/ai-service/bubbly_chef/workflows/shared_state.py
@@ -289,6 +289,8 @@ def map_category(category_str: str | None) -> FoodCategory:
         "dairy": FoodCategory.DAIRY,
         "milk": FoodCategory.DAIRY,
         "cheese": FoodCategory.DAIRY,
+        "egg": FoodCategory.DAIRY,
+        "eggs": FoodCategory.DAIRY,
         "meat": FoodCategory.MEAT,
         "poultry": FoodCategory.MEAT,
         "beef": FoodCategory.MEAT,
@@ -314,7 +316,17 @@ def map_category(category_str: str | None) -> FoodCategory:
         "bread": FoodCategory.BAKERY,
     }
 
-    return mapping.get(category_lower, FoodCategory.OTHER)
+    exact = mapping.get(category_lower)
+    if exact is not None:
+        return exact
+
+    # Fuzzy/substring fallback: if any known key is a token within the input
+    # (e.g. "dairy & eggs" → dairy, "produce/vegetables" → produce).
+    for key, food_category in mapping.items():
+        if key in category_lower:
+            return food_category
+
+    return FoodCategory.OTHER
 
 
 def map_action_type(action_str: str) -> ActionType:

--- a/ai-service/tests/test_issue_215_receipt_categorize.py
+++ b/ai-service/tests/test_issue_215_receipt_categorize.py
@@ -97,46 +97,48 @@ def _make_normalizer_stub(normalized_name: str) -> MagicMock:
     return stub
 
 
-def _run_normalize(items: list[dict]) -> list[dict]:
-    """Call normalize_receipt_items with minimal stubs for non-category deps."""
-    from bubbly_chef.workflows.receipt_ingest import normalize_receipt_items
+def _run_normalize(item: dict) -> dict:
+    """Run the real normalize_receipt_items node over a single parsed item.
+
+    Builds a WorkflowState dict (the node's actual input) and patches the
+    module-level ``get_normalizer``/``get_expiry_heuristics`` seams so the test
+    exercises the node's own category-resolution branch — not just the helpers.
+    """
+    import datetime
+
+    from bubbly_chef.workflows import receipt_ingest
 
     fake_expiry = MagicMock()
     fake_expiry.get_default_storage.return_value = MagicMock(value="refrigerator")
-    fake_expiry.estimate_expiry.return_value = (
-        __import__("datetime").date(2026, 8, 14),
-        True,
-    )
+    fake_expiry.estimate_expiry.return_value = (datetime.date(2026, 8, 14), True)
 
-    results = []
-    for item in items:
-        stub_normalizer = _make_normalizer_stub(item["name"])
-        result = normalize_receipt_items(
-            [item],
-            normalizer=stub_normalizer,
-            expiry=fake_expiry,
-        )
-        results.extend(result)
-    return results
+    # Identity normalizer: the node passes the raw name straight to resolve_category.
+    stub_normalizer = _make_normalizer_stub(item["name"])
+
+    with (
+        patch.object(receipt_ingest, "get_normalizer", return_value=stub_normalizer),
+        patch.object(receipt_ingest, "get_expiry_heuristics", return_value=fake_expiry),
+    ):
+        state: dict = {"parsed_items": [item]}
+        result = receipt_ingest.normalize_receipt_items(state)
+
+    return result["normalized_items"][0]
 
 
 @pytest.mark.parametrize(
     "item,expected_category",
     [
-        # Eggs: LLM returned "other" — keyword path must catch it
+        # Eggs: LLM returned "other" — keyword/catalog path must catch it
         ({"name": "eggs", "category": "other", "quantity": 1.0, "unit": "dozen"}, "dairy"),
         # Milk: LLM returned compound label that exact-match dropped to OTHER
         ({"name": "milk", "category": "dairy & eggs", "quantity": 1.0, "unit": "gallon"}, "dairy"),
     ],
 )
-def test_normalize_receipt_items_dairy(
-    item: dict, expected_category: str
-) -> None:
-    """Direct regression: eggs/milk receipt items must resolve to dairy."""
-    try:
-        results = _run_normalize([item])
-        assert results[0]["category"] == expected_category
-    except TypeError:
-        # normalize_receipt_items signature may differ — fall back to calling
-        # resolve_category + map_category directly, which is the core fix.
-        assert map_category(resolve_category(item["name"])).value == expected_category
+def test_normalize_receipt_items_dairy(item: dict, expected_category: str) -> None:
+    """Direct regression: eggs/milk receipt items must resolve to dairy.
+
+    Exercises the real node end-to-end (state in → normalized_items out), so a
+    future signature or branch-precedence change is caught here.
+    """
+    normalized = _run_normalize(item)
+    assert normalized["category"] == expected_category

--- a/ai-service/tests/test_issue_215_receipt_categorize.py
+++ b/ai-service/tests/test_issue_215_receipt_categorize.py
@@ -1,0 +1,142 @@
+"""Regression tests for issue #215: receipt eggs/milk categorize as 'other'.
+
+Covers:
+- resolve_category returns correct strings for eggs, milk, unknown
+- map_category handles compound LLM labels and 'egg'/'eggs' keys
+- normalize_receipt_items produces 'dairy' for both bug scenarios
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bubbly_chef.domain.normalizer import resolve_category
+from bubbly_chef.models.pantry import FoodCategory
+from bubbly_chef.workflows.shared_state import map_category
+
+
+# ---------------------------------------------------------------------------
+# resolve_category
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_category_eggs() -> None:
+    assert resolve_category("eggs") == "dairy"
+
+
+def test_resolve_category_egg() -> None:
+    assert resolve_category("egg") == "dairy"
+
+
+def test_resolve_category_milk() -> None:
+    result = resolve_category("milk")
+    assert result == "dairy"
+
+
+def test_resolve_category_whole_milk() -> None:
+    result = resolve_category("whole milk")
+    assert result == "dairy"
+
+
+def test_resolve_category_greek_yogurt() -> None:
+    result = resolve_category("greek yogurt")
+    assert result == "dairy"
+
+
+def test_resolve_category_unknown_returns_none() -> None:
+    assert resolve_category("xyzunknownitem99999") is None
+
+
+# ---------------------------------------------------------------------------
+# map_category — compound labels and new egg keys
+# ---------------------------------------------------------------------------
+
+
+def test_map_category_dairy_and_eggs() -> None:
+    """LLM compound label 'dairy & eggs' must map to DAIRY, not OTHER."""
+    assert map_category("dairy & eggs") == FoodCategory.DAIRY
+
+
+def test_map_category_egg() -> None:
+    assert map_category("egg") == FoodCategory.DAIRY
+
+
+def test_map_category_eggs() -> None:
+    assert map_category("eggs") == FoodCategory.DAIRY
+
+
+def test_map_category_produce_slash_vegetables() -> None:
+    assert map_category("produce/vegetables") == FoodCategory.PRODUCE
+
+
+def test_map_category_exact_matches_unchanged() -> None:
+    """Existing exact matches must still resolve correctly."""
+    assert map_category("dairy") == FoodCategory.DAIRY
+    assert map_category("produce") == FoodCategory.PRODUCE
+    assert map_category("meat") == FoodCategory.MEAT
+    assert map_category("seafood") == FoodCategory.SEAFOOD
+    assert map_category("bakery") == FoodCategory.BAKERY
+
+
+def test_map_category_other_for_unknown() -> None:
+    assert map_category("unknowncategoryxyz") == FoodCategory.OTHER
+
+
+def test_map_category_none_returns_other() -> None:
+    assert map_category(None) == FoodCategory.OTHER
+
+
+# ---------------------------------------------------------------------------
+# normalize_receipt_items — direct regression for the reported bug
+# ---------------------------------------------------------------------------
+
+
+def _make_normalizer_stub(normalized_name: str) -> MagicMock:
+    stub = MagicMock()
+    stub.normalize.return_value = normalized_name
+    return stub
+
+
+def _run_normalize(items: list[dict]) -> list[dict]:
+    """Call normalize_receipt_items with minimal stubs for non-category deps."""
+    from bubbly_chef.workflows.receipt_ingest import normalize_receipt_items
+
+    fake_expiry = MagicMock()
+    fake_expiry.get_default_storage.return_value = MagicMock(value="refrigerator")
+    fake_expiry.estimate_expiry.return_value = (
+        __import__("datetime").date(2026, 8, 14),
+        True,
+    )
+
+    results = []
+    for item in items:
+        stub_normalizer = _make_normalizer_stub(item["name"])
+        result = normalize_receipt_items(
+            [item],
+            normalizer=stub_normalizer,
+            expiry=fake_expiry,
+        )
+        results.extend(result)
+    return results
+
+
+@pytest.mark.parametrize(
+    "item,expected_category",
+    [
+        # Eggs: LLM returned "other" — keyword path must catch it
+        ({"name": "eggs", "category": "other", "quantity": 1.0, "unit": "dozen"}, "dairy"),
+        # Milk: LLM returned compound label that exact-match dropped to OTHER
+        ({"name": "milk", "category": "dairy & eggs", "quantity": 1.0, "unit": "gallon"}, "dairy"),
+    ],
+)
+def test_normalize_receipt_items_dairy(
+    item: dict, expected_category: str
+) -> None:
+    """Direct regression: eggs/milk receipt items must resolve to dairy."""
+    try:
+        results = _run_normalize([item])
+        assert results[0]["category"] == expected_category
+    except TypeError:
+        # normalize_receipt_items signature may differ — fall back to calling
+        # resolve_category + map_category directly, which is the core fix.
+        assert map_category(resolve_category(item["name"])).value == expected_category


### PR DESCRIPTION
## Summary

Receipt-scanned items were categorizing as **other** when the catalog already knew their category. Eggs and milk both showed 88% confidence with correct names/emojis but wrong category. Root cause: the receipt ingest path used a strict exact-match dict + a keyword list with no egg entries, while the manual-add path (which worked) consulted the food catalog.

## What lands

- **`domain/normalizer.py`** — new `resolve_category(name)` helper wrapping `detect_category` + `catalog_categorize`; single shared seam so both paths can never drift again
- **`api/routes/pantry.py`** — `estimate_category` routes through `resolve_category` (no behavior change, removes inline duplication)
- **`workflows/receipt_ingest.py`** — receipt category block now prefers the deterministic catalog/keyword answer over the noisy LLM string; falls back to LLM hint, then OTHER
- **`workflows/shared_state.py`** — `map_category` gains `"egg"`/`"eggs"` → DAIRY keys and a substring fallback so compound LLM labels like `"dairy & eggs"` resolve correctly instead of silently becoming OTHER
- **`tests/test_issue_215_receipt_categorize.py`** — regression tests covering `resolve_category`, `map_category` compounds, and the direct receipt-items scenario from the bug report

## Tests

```
61 passed, 207 deselected in 0.60s   (pytest -k "categor or normaliz or receipt or pantry")
ruff check bubbly_chef/  →  All checks passed!
```

Quick-check output (all dairy, as expected):
```
eggs -> dairy
egg -> dairy
milk -> dairy
whole milk -> dairy
2% milk -> dairy
greek yogurt -> dairy
```

## Linked

Fixes #215

## Out of scope

- New `FoodCategory.EGGS` enum member — cross-cutting change (DB enum, UI chips, expiry heuristics); eggs = dairy is the established catalog convention
- Full consolidation of `tools/normalizer.py` vs `domain/normalizer.py` — larger tech-debt refactor; this fix makes the *category* answer consistent, which is the user-visible bug
