### PR TITLE
R4-3: Route barcode/product ingest through the /ingest dispatcher

### DIFF
--- a/ai-service/bubbly_chef/api/ingest_dispatcher.py
+++ b/ai-service/bubbly_chef/api/ingest_dispatcher.py
@@ -13,14 +13,16 @@ Each entry:
 - provides an async ``extract`` callable
   ``(payload: IngestPayload) -> ProposalEnvelope[PantryProposal]``
 
-Modalities implemented in this ticket
---------------------------------------
+Modalities implemented here
+---------------------------
 - ``IngestModality.RECEIPT`` — OCR text (or raw image bytes handed off to
-  ``run_receipt_ingest``).  Receipt scanning migrated through this rail.
+  ``run_receipt_ingest``).
+- ``IngestModality.BARCODE`` — 8–14 digit barcode string (EAN/UPC) handed
+  off to ``run_product_ingest`` (#206).  Real lookup is a stub pending #191.
 
-Extension seam for #205 (URL) and #206 (barcode/product)
-----------------------------------------------------------
-Register a new extractor with:
+Extension seam for #205 (URL)
+------------------------------
+Register a URL extractor with:
 
     from bubbly_chef.api.ingest_dispatcher import dispatcher, ExtractorEntry, IngestModality
 
@@ -29,8 +31,7 @@ Register a new extractor with:
         extract=my_url_extractor,
     ))
 
-Or call ``dispatcher.register_url_extractor(fn)`` / ``register_barcode_extractor(fn)``
-for the convenience helpers.
+Or call ``dispatcher.register_url_extractor(fn)`` for the convenience helper.
 """
 
 from __future__ import annotations
@@ -290,3 +291,48 @@ async def _receipt_extractor(payload: IngestPayload) -> ProposalEnvelope[PantryP
 
 # Register the receipt extractor on module load
 dispatcher.register(ExtractorEntry(modality=IngestModality.RECEIPT, extract=_receipt_extractor))
+
+
+# ---------------------------------------------------------------------------
+# Built-in barcode/product extractor (#206)
+# ---------------------------------------------------------------------------
+
+
+async def _barcode_extractor(payload: IngestPayload) -> ProposalEnvelope[PantryProposal]:
+    """Barcode/product extractor: looks up a product by barcode or parses a description.
+
+    Input resolution (in priority order):
+    1. ``payload.barcode`` — an explicit barcode string (digits).
+    2. ``payload.text`` when it matches the barcode digit pattern — the
+       dispatcher's ``detect_modality`` already sniffed this; we re-use it
+       here as the barcode value.
+    3. ``payload.text`` that is NOT a barcode number — treated as a free-text
+       product description and passed to ``run_product_ingest`` as
+       ``description``.  Note: ``detect_modality`` classifies non-URL, non-digit
+       text as RECEIPT (OCR path), so free-text product descriptions do NOT
+       auto-route to this extractor in v1 — callers must supply a digit
+       barcode.  This branch handles the case where a caller explicitly builds
+       an ``IngestPayload(modality=BARCODE, text="Organic whole milk")``
+       without a numeric barcode.
+
+    Both barcode and description are optional in ``run_product_ingest``; if
+    neither resolves to a value the workflow raises downstream.
+    """
+    from bubbly_chef.workflows.product_ingest import run_product_ingest
+
+    barcode: str | None = payload.barcode
+
+    # If barcode field not set, check whether text looks like a digit string
+    if not barcode and payload.text and _BARCODE_RE.match(payload.text.strip()):
+        barcode = payload.text.strip()
+
+    # Any remaining text that is not a barcode number is a description
+    description: str | None = None
+    if payload.text and not (barcode and payload.text.strip() == barcode):
+        description = payload.text
+
+    return await run_product_ingest(barcode=barcode, description=description)
+
+
+# Register the barcode extractor on module load
+dispatcher.register(ExtractorEntry(modality=IngestModality.BARCODE, extract=_barcode_extractor))

--- a/ai-service/bubbly_chef/api/routes/ingest.py
+++ b/ai-service/bubbly_chef/api/routes/ingest.py
@@ -88,7 +88,7 @@ async def ingest_recipe_url(
 
 @router.post(
     "",
-    summary="Unified ingest dispatcher (receipt in v1; URL #205, barcode #206 coming)",
+    summary="Unified ingest dispatcher (receipt + barcode wired; URL #205 coming)",
     responses={
         200: {"description": "PantryProposal envelope"},
         400: {"description": "Could not detect modality or modality not yet supported"},
@@ -117,20 +117,21 @@ async def ingest(
 ) -> dict:
     """Unified entry point for all pantry ingest modalities.
 
-    **v1 behaviour (this ticket):** only receipt is fully wired.
+    **v1 behaviour:** receipt and barcode/product are fully wired.
 
     - Supply ``file`` (image upload) or ``ocr_text`` (plain text) to trigger
       receipt parsing.
-    - Supply ``text`` to let the server auto-detect the modality:
-      URL → NotImplemented (ticket #205); barcode digits → NotImplemented
-      (#206); anything else → treated as receipt OCR text.
+    - Supply ``text`` with an 8–14 digit barcode number to trigger the
+      barcode/product extractor (routes to ``run_product_ingest``; lookup
+      is a stub pending #191).
+    - Supply ``text`` with a URL to get a 400 today (ticket #205).
+    - Supply any other ``text`` to let the server treat it as receipt OCR text.
 
     The response is a ``ProposalEnvelope[PantryProposal]`` serialised as JSON.
 
-    **Extension seam for #205 / #206:** register an extractor with
-    ``dispatcher.register_url_extractor(fn)`` or
-    ``dispatcher.register_barcode_extractor(fn)`` at app startup and the 501
-    stubs become live automatically.
+    **Extension seam for #205 (URL):** register an extractor with
+    ``dispatcher.register_url_extractor(fn)`` at app startup and the 400
+    stub becomes live automatically.
     """
     from bubbly_chef.api.ingest_dispatcher import (
         IngestModality,

--- a/ai-service/tests/test_ingest_dispatcher.py
+++ b/ai-service/tests/test_ingest_dispatcher.py
@@ -357,3 +357,169 @@ async def test_ingest_endpoint_non_image_file_returns_422(app):
 
     app.dependency_overrides.clear()
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Barcode extractor unit tests (#206)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_barcode_extractor_registered_on_module_load():
+    """_barcode_extractor is registered in the singleton dispatcher at import time."""
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, dispatcher
+
+    assert IngestModality.BARCODE in dispatcher._registry
+
+
+@pytest.mark.asyncio
+async def test_barcode_extractor_uses_payload_barcode_field():
+    """Extractor reads barcode from payload.barcode and passes it to run_product_ingest."""
+    from unittest.mock import AsyncMock, patch
+
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload, dispatcher
+
+    mock_envelope = MagicMock()
+    with patch(
+        "bubbly_chef.workflows.product_ingest.run_product_ingest",
+        new_callable=AsyncMock,
+        return_value=mock_envelope,
+    ) as mock_run:
+        payload = IngestPayload(modality=IngestModality.BARCODE, barcode="0012345678905")
+        result = await dispatcher.dispatch(payload)
+
+    mock_run.assert_awaited_once_with(barcode="0012345678905", description=None)
+    assert result is mock_envelope
+
+
+@pytest.mark.asyncio
+async def test_barcode_extractor_falls_back_to_text_digit_string():
+    """When payload.barcode is None but payload.text is a digit string, text is used as barcode."""
+    from unittest.mock import AsyncMock, patch
+
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload, dispatcher
+
+    mock_envelope = MagicMock()
+    with patch(
+        "bubbly_chef.workflows.product_ingest.run_product_ingest",
+        new_callable=AsyncMock,
+        return_value=mock_envelope,
+    ) as mock_run:
+        # barcode=None; the digit-string is in text (how detect_modality routes it)
+        payload = IngestPayload(modality=IngestModality.BARCODE, barcode=None, text="12345678901")
+        result = await dispatcher.dispatch(payload)
+
+    mock_run.assert_awaited_once_with(barcode="12345678901", description=None)
+    assert result is mock_envelope
+
+
+@pytest.mark.asyncio
+async def test_barcode_extractor_passes_description_when_text_not_digits():
+    """Explicit BARCODE payload with non-digit text treats text as description."""
+    from unittest.mock import AsyncMock, patch
+
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload, dispatcher
+
+    mock_envelope = MagicMock()
+    with patch(
+        "bubbly_chef.workflows.product_ingest.run_product_ingest",
+        new_callable=AsyncMock,
+        return_value=mock_envelope,
+    ) as mock_run:
+        payload = IngestPayload(
+            modality=IngestModality.BARCODE,
+            barcode=None,
+            text="Organic whole milk",
+        )
+        result = await dispatcher.dispatch(payload)
+
+    mock_run.assert_awaited_once_with(barcode=None, description="Organic whole milk")
+    assert result is mock_envelope
+
+
+@pytest.mark.asyncio
+async def test_barcode_extractor_barcode_and_description_together():
+    """When barcode field is set AND text is a non-barcode string, both are forwarded."""
+    from unittest.mock import AsyncMock, patch
+
+    from bubbly_chef.api.ingest_dispatcher import IngestModality, IngestPayload, dispatcher
+
+    mock_envelope = MagicMock()
+    with patch(
+        "bubbly_chef.workflows.product_ingest.run_product_ingest",
+        new_callable=AsyncMock,
+        return_value=mock_envelope,
+    ) as mock_run:
+        payload = IngestPayload(
+            modality=IngestModality.BARCODE,
+            barcode="0041130006006",
+            text="Whole Milk 1 gallon",
+        )
+        result = await dispatcher.dispatch(payload)
+
+    mock_run.assert_awaited_once_with(barcode="0041130006006", description="Whole Milk 1 gallon")
+    assert result is mock_envelope
+
+
+class TestDetectModalityBarcode:
+    """Barcode detection edge cases (augments existing TestDetectModality class)."""
+
+    def test_url_string_is_not_barcode(self):
+        """A URL string does NOT route to BARCODE."""
+        from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+        result = ModalityDispatcher.detect_modality(text="https://example.com/product/123")
+        assert result is IngestModality.URL
+        assert result is not IngestModality.BARCODE
+
+    def test_fourteen_digit_barcode(self):
+        """14-digit string (EAN-14 / ITF-14) routes to BARCODE."""
+        from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+        assert ModalityDispatcher.detect_modality(text="12345678901234") is IngestModality.BARCODE
+
+    def test_seven_digit_string_is_not_barcode(self):
+        """7-digit string is below EAN-8 minimum — not detected as BARCODE."""
+        from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+        result = ModalityDispatcher.detect_modality(text="1234567")
+        assert result is not IngestModality.BARCODE
+
+    def test_fifteen_digit_string_is_not_barcode(self):
+        """15-digit string exceeds EAN-14 maximum — not detected as BARCODE."""
+        from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+        result = ModalityDispatcher.detect_modality(text="123456789012345")
+        assert result is not IngestModality.BARCODE
+
+    def test_mixed_alphanumeric_is_not_barcode(self):
+        """Alphanumeric strings (e.g. SKU codes) are not barcodes."""
+        from bubbly_chef.api.ingest_dispatcher import IngestModality, ModalityDispatcher
+
+        result = ModalityDispatcher.detect_modality(text="ABC1234567")
+        assert result is not IngestModality.BARCODE
+
+
+@pytest.mark.asyncio
+async def test_ingest_endpoint_barcode_text_routes_to_product_extractor(app, _mock_envelope):
+    """POST /v1/ingest with a barcode digit-string in text → 200, product envelope."""
+    from bubbly_chef.api.auth import get_current_user_id
+    from httpx import ASGITransport, AsyncClient
+
+    app.dependency_overrides[get_current_user_id] = lambda: "test-user"
+
+    with patch(
+        "bubbly_chef.workflows.product_ingest.run_product_ingest",
+        new_callable=AsyncMock,
+        return_value=_mock_envelope,
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            resp = await ac.post(
+                "/v1/ingest",
+                data={"text": "0012345678905"},
+            )
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "proposal" in data


### PR DESCRIPTION
## Summary
Wires the barcode/product extractor behind the unified `/ingest` dispatcher. `product_ingest` had a graph but no HTTP caller — this gives it one.

## What lands
- `_barcode_extractor` registered in the dispatcher at import: pulls barcode from `payload.barcode` (or a digit-string `payload.text`), treats other text as a product description, calls `run_product_ingest(...)`.
- Dispatcher detects an 8–14 digit barcode number and routes it here.
- Product ingest reuses the shared spine tail (merged in the foundation slice).

## Tests
- Adds product-dispatch + extractor tests to `tests/test_ingest_dispatcher.py`.
- Not yet run live: `cd ai-service && python -m pytest tests/test_ingest_dispatcher.py -q` + `ruff check ai-service`.

## Linked
R4 epic; spec `docs/plans/2026-07-29-r4-unified-ingest.md`. Stacked on the foundation PR (shared spine + dispatcher). The real OpenFoodFacts barcode lookup remains a stub — tracked separately; this PR wires the path only, and does not modify the lookup.

## Out of scope
Real barcode lookup. Free-text product descriptions do not auto-route in v1 (a barcode number is the auto-detected product signal); explicit-modality only.

> Base is the foundation branch, not `main` — rebase onto `main` after that merges.
