### PR TITLE
docs: ADR 0003 — piece vs package units are incommensurable

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -177,6 +177,16 @@ Items with 1–3 days until expiry are flagged as "expiring soon" and prioritize
 ### Unit Normalization
 Pantry accepts units: oz, g, ml, l, cup, tsp, tbsp, count. Recipe generation uses compatible units only.
 
+### Piece vs Package Units
+A **piece unit** (slice, leaf, clove, sprig, stick) counts pieces *of* an ingredient. A **package unit** (item, loaf, bunch, head, bag, can, package, bottle, jar, box, container) counts packages *containing* an unknown number of pieces. They are incommensurable: the pantry does not record slices per loaf.
+
+`count` is neither — it is a genuine tally, so `6 count garlic` still deducts normally. The distinction is read from a pantry row's **raw display unit**, before `normalize_unit` collapses `item` into `count`.
+
+### Imprecise (cook match status)
+A cook-proposal ingredient status alongside `ready` / `substitute` / `shortfall` / `unit_conflict`. Means "you have this, we cannot quantify how much the recipe uses" — a piece-unit request against a package-unit row. Counts as **satisfied** for cook-readiness and deducts **nothing**; the pantry row is stamped with the recipe and time that consumed it imprecisely, so the deliberate drift is visible where the user would correct it.
+
+Genuine conversion is always tried first — a piece against a row with a real mass base resolves through conventional piece weights (`2 slices cheese` vs `500 g cheese` → 42 g). See `docs/adr/0003-piece-vs-package-units-are-incommensurable.md`.
+
 ### Confidence Thresholds
 - ≥ 0.8: Ready-to-add (no user review needed)
 - 0.5–0.8: Needs review (user edits before add)

--- a/docs/adr/0003-piece-vs-package-units-are-incommensurable.md
+++ b/docs/adr/0003-piece-vs-package-units-are-incommensurable.md
@@ -1,0 +1,25 @@
+# Piece units and package units are incommensurable, and the cook flow says so rather than guessing
+
+A recipe asks for `4 slices bread`. The pantry holds `1 item bread`. Both sides normalize into the `count` dimension, so they compare — and the comparison says the user is three short and deducts the entire loaf. The same happens for `8 leaves basil` against `1 bunch basil` and `2 cloves garlic` against `1 head garlic`.
+
+The comparison is wrong because the two counts count different things. A recipe's piece unit counts pieces *of* an ingredient; a pantry row's package unit counts packages *containing* an unknown number of those pieces. Mapping both to `count` at 1.0 is what makes them match at all, and it is exactly what makes the match meaningless. The pantry does not record slices per loaf or leaves per bunch, and there is no conventional figure to supply: a sandwich loaf is 20 slices and a sourdough boule is 12, a bunch of basil is whatever the shop tied together.
+
+The cook flow therefore reports a distinct `imprecise` status for this case: the ingredient counts as satisfied, nothing is deducted, and the pantry row is stamped with the recipe and time that consumed it imprecisely.
+
+Three things drive that shape.
+
+**Under-deducting is recoverable; destroying a package is not.** A pantry count that drifts low is corrected by editing one number. A loaf deleted because a recipe wanted four slices is gone, and the user has to notice it happened, work out why, and re-add the item. Given the system genuinely cannot know the true amount, it should err toward the failure the user can undo.
+
+**`shortfall` was an active lie.** It told a user holding a full loaf of bread that they were short of bread. The proposal is reviewed before anything is written, so the deduction was never silent — but a status that misdescribes the pantry is worse than one that admits ignorance, because the user reasonably trusts it and confirms.
+
+**The alternative was inventing data.** Estimating a loaf at 500 g to deduct `4 slices ≈ 112 g` would work, and it would be a fabrication. `domain/density.py` already commits to the opposite rule — "correctness over coverage", every entry a real citable figure, anything else deliberately absent so the lookup returns None and the caller refuses. Piece-per-package counts have no citable figure, so they stay absent and the caller refuses in the same way. This ADR is that existing rule applied to a second kind of missing data, not a new principle.
+
+Genuine conversion still comes first. When a pantry row has a real mass base, `PIECE_WEIGHTS_G` resolves the piece honestly — `2 slices cheese` against `500 g cheese` deducts 42 g, and `1 stick butter` against a gram row deducts 113 g. `imprecise` is the fallback for package-shaped rows only, never a shortcut past a conversion that would have worked.
+
+The distinction rests on the pantry row's **raw display unit**, read before `normalize_unit` collapses `item` into `count`. That collapse discards the thing this check needs: `1 item bread` is a package the user is holding, while `6 count garlic` is a genuine tally of cloves and must keep deducting normally. Anything reading the normalized unit here would either miss the reported bug or break the working case.
+
+Note that this reclassifies `head` and `bunch`, which `_TO_COUNT` groups under "pieces of an ingredient". A head of garlic and a bunch of basil are things you buy, not things you use — they belong with `loaf` and `bag`.
+
+The real fix for the general case is data the pantry does not collect: an optional pieces-per-package count on the row, captured at add time. That remains worth doing and would let these deductions become exact. This decision is what the system does until then, and it should be revisited rather than worked around if that field ever lands.
+
+Recorded from the triage of #222, following the unit-conversion work in #221. Related: #6 (unit conversion), #209 (cook-flow conflict UX), #224 (base units unpopulated on write).


### PR DESCRIPTION
## Summary

Cherry-picks `c9c7b57` from `claude/triage-5001e6` onto `main`. Docs only, no code.

## What lands

The ADR and CONTEXT.md vocabulary that #222's implementation brief tells the reader to consult first — currently that file only exists on a side branch nobody starting from `main` would find. Records the design: a recipe's piece unit (slice, leaf, clove) counts pieces of an ingredient; a pantry row's package unit (item, loaf, bunch) counts packages holding an unknown number of them. Both normalize to `count` today, so they compare, and the comparison deducts the whole loaf for a recipe wanting four slices. The fix is a distinct `imprecise` match status — satisfied, deducts nothing, stamps the row — rather than guessing a pieces-per-package ratio.

## Tests

Docs-only; no code changed, no gates apply.

## Demo

n/a

## Linked issue

Unblocks #222 (piece-unit deductions over-deduct).

## Out of scope

No implementation — #222 carries that work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8Xs73WomYqa8icmBkD5GW)_