### PR TITLE
fix: dashboard expiry count dedup + time-aware suggestion (#170, #169)

### DIFF
--- a/nextjs/src/components/dashboard/HeroHome.tsx
+++ b/nextjs/src/components/dashboard/HeroHome.tsx
@@ -156,15 +156,26 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
   const tip = tips[(clockReady ? new Date().getDay() : 0) % tips.length]
   const { totalCount, expiringCount, urgentItem, recipe } = data
 
+  // Derive a time-of-day word from the already-computed greeting so we don't
+  // add a second new Date() call. SSR renders 'Hello' → mealTimeWord stays
+  // empty until clockReady flips, which avoids a hydration mismatch.
+  const mealTimeWord = clockReady
+    ? greeting.includes('morning')
+      ? 'this morning'
+      : greeting.includes('afternoon')
+        ? 'this afternoon'
+        : 'tonight'
+    : ''
+
   // Compute the single hero message (most important)
   const heroMessage = urgentItem
     ? `Your ${titleCase(urgentItem.name)} expires ${urgentItem.days_until_expiry === 0 ? 'today' : 'tomorrow'}! Let's cook it up.`
     : totalCount === 0
       ? "Your pantry is empty — let's stock up!"
       : recipe
-        ? `How about ${recipe.title} tonight?${recipe.total_time_minutes ? ` Only ${recipe.total_time_minutes} min!` : ''}`
+        ? `How about ${recipe.title}${mealTimeWord ? ` ${mealTimeWord}` : ''}?${recipe.total_time_minutes ? ` Only ${recipe.total_time_minutes} min!` : ''}`
         : expiringCount > 0
-          ? `${expiringCount} item${expiringCount > 1 ? 's' : ''} expiring soon — time to cook!`
+          ? "Check the 'Use Soon' tile — some items need your attention!"
           : 'Your kitchen is looking great!'
 
   // The urgent-item CTA deep-links into a chat seeded with that ingredient
@@ -315,9 +326,6 @@ export default function HeroHome({ displayName }: HeroHomeProps) {
             ) : (
               <p className="text-xs text-[var(--color-muted)]">
                 🧺 {totalCount} item{totalCount !== 1 ? 's' : ''} in pantry
-                {expiringCount > 0 && (
-                  <span> · <span style={{ color: 'var(--color-primary)' }}>{expiringCount} expiring</span></span>
-                )}
               </p>
             )}
           </div>


### PR DESCRIPTION
## Summary

Two small polish fixes to the dashboard hero in `HeroHome.tsx`.

## What lands

**#170 — Remove duplicate expiry count**
- `expiringCount` was shown in three places: the hero message, the Use Soon action tile, and the pantry status bar. The Use Soon tile is the canonical place for this number.
- The hero fallback message (shown when there's no urgent item or recipe, but items are expiring) now reads `"Check the 'Use Soon' tile — some items need your attention!"` instead of restating the count.
- The pantry status bar footer dropped the `· X expiring` sub-count; it now shows only the total item count.

**#169 — Time-aware hero suggestion**
- `"How about <recipe> tonight?"` hardcoded "tonight" regardless of time of day.
- The fix derives a meal-time word (`this morning` / `this afternoon` / `tonight`) from the already-computed `greeting` string — no second `new Date()` call added.
- Guarded by the existing `clockReady` state so SSR and hydration remain mismatch-free. Before `clockReady` flips, `mealTimeWord` is `''` and the interpolation is skipped, producing `"How about <recipe>?"` on the first paint.

## Tests

This is a worktree without an installed node_modules. Manual test note for the primary checkout:

```bash
git checkout fix/issue-170-169-dashboard-expiry-dedup-time-aware
cd nextjs && npx tsc --noEmit   # must pass
npm run dev                      # visit http://localhost:3000
```

Verify:
- Dashboard hero at morning / afternoon / evening hours shows the correct time-of-day phrase in recipe suggestions.
- When only expiring items exist (no recipe saved), the hero message does NOT restate the count — it points to the tile.
- The pantry status bar shows `🧺 N items in pantry` with no expiring sub-count.
- The Use Soon tile still shows `X items` as the canonical expiry count.

## Out of scope

- Removing `expiringCount` from the `HomeData` state shape — it's still needed for the Use Soon tile detail and the hero action routing logic.