### PR TITLE
test: live test isolation + must-use ingredient live tests (#208, #145)

### DIFF
--- a/ai-service/tests/conftest.py
+++ b/ai-service/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Test configuration and shared fixtures for ai-service tests.
+
+Fix #208: The `_ai_manager` singleton in `bubbly_chef.api.deps` holds an httpx
+client that is bound to the event loop created at first construction.
+pytest-asyncio gives each test its own event loop, so test 2+ would receive a
+closed client.  The autouse fixture below resets the singleton before and after
+every test so each test constructs a fresh manager on the current loop.
+"""
+
+import pytest
+
+from bubbly_chef.api import deps
+
+
+@pytest.fixture(autouse=True)
+def reset_ai_manager() -> None:
+    """Reset the AIManager singleton between tests (#208).
+
+    Prevents httpx clients bound to a stale event loop from leaking across
+    test boundaries when pytest-asyncio assigns a fresh loop per test.
+    """
+    deps._ai_manager = None
+    yield  # type: ignore[misc]
+    deps._ai_manager = None

--- a/ai-service/tests/test_intent_live.py
+++ b/ai-service/tests/test_intent_live.py
@@ -122,3 +122,54 @@ async def test_live_exit_phrase_breaks_cooking_session() -> None:
     )
     assert result["intent"] == Intent.GENERAL_CHAT.value
     assert result.get("_exit_mode") is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #145: must-use ingredient extraction via the ?use= deep-link seed
+# ---------------------------------------------------------------------------
+# The exact phrasing below comes from chat-seed.ts:94 ingredientSeedMessage().
+# The backend prompt was tuned against "What can I make with my <name> before
+# they go bad?" — do not reword without re-tuning recipe/nodes.py.
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_live_use_seed_intent_is_recipe_brainstorm_or_generation() -> None:
+    """?use=eggs seed → live model classifies as recipe_brainstorm or recipe_generation."""
+    # Exact text produced by ingredientSeedMessage("eggs") in chat-seed.ts:94
+    message = "What can I make with my eggs before they go bad?"
+    result = await classify_intent(_state(input_text=message))
+    assert result["intent"] in (
+        Intent.RECIPE_BRAINSTORM.value,
+        Intent.RECIPE_GENERATION.value,
+    ), f"Expected recipe intent, got {result['intent']!r}"
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_live_use_seed_extract_constraints_populates_must_use() -> None:
+    """?use=bananas seed → extract_recipe_constraints returns bananas in must_use_ingredients."""
+    from bubbly_chef.workflows.recipe.nodes import extract_recipe_constraints
+
+    # Exact text produced by ingredientSeedMessage("bananas") in chat-seed.ts:94
+    message = "What can I make with my bananas before they go bad?"
+    result = await extract_recipe_constraints({"input_text": message})
+    must_use: list[str] = result.get("recipe_constraints", {}).get(
+        "must_use_ingredients", []
+    )
+    assert any(
+        "banana" in ingredient.lower() for ingredient in must_use
+    ), f"Expected 'banana' in must_use_ingredients, got {must_use!r}"
+
+
+@_SKIP
+@pytest.mark.asyncio
+async def test_live_use_seed_different_ingredient_also_classified_correctly() -> None:
+    """?use=spinach seed → live model classifies as recipe_brainstorm or recipe_generation."""
+    # Exact text produced by ingredientSeedMessage("spinach") in chat-seed.ts:94
+    message = "What can I make with my spinach before they go bad?"
+    result = await classify_intent(_state(input_text=message))
+    assert result["intent"] in (
+        Intent.RECIPE_BRAINSTORM.value,
+        Intent.RECIPE_GENERATION.value,
+    ), f"Expected recipe intent, got {result['intent']!r}"


### PR DESCRIPTION
## Summary

- Fixes live intent tests breaking each other in batch runs (#208)
- Adds live coverage for the `?use=` deep-link seed → must-use ingredient extraction chain (#145)

## What lands

**`ai-service/tests/conftest.py`** (new)
- Adds an `autouse` fixture `reset_ai_manager` that clears `deps._ai_manager` to `None` before and after every test. This ensures each test constructs a fresh `AIManager` (and its httpx client) on its own event loop, eliminating the "closed client" failure that caused tests 2+ to fail when run as a batch.

**`ai-service/tests/test_intent_live.py`** (modified)
Three new live test cases guarded by `@_SKIP` (same as existing tests):
- `test_live_use_seed_intent_is_recipe_brainstorm_or_generation` — sends the exact text from `ingredientSeedMessage("eggs")` in `chat-seed.ts:94` and asserts the live model classifies it as `recipe_brainstorm` or `recipe_generation`.
- `test_live_use_seed_extract_constraints_populates_must_use` — sends the bananas variant, calls `extract_recipe_constraints` directly, and asserts `must_use_ingredients` contains "banana".
- `test_live_use_seed_different_ingredient_also_classified_correctly` — sends the spinach variant to confirm the classification is stable across ingredient names.

## Tests

All three new tests are `@_SKIP` (only run with `BUBBLY_RUN_LIVE_TESTS=1`) so they do not affect the default suite. Both files pass AST syntax validation. Full quality gates require the primary repo venv — manual verification steps:

```bash
# In the primary repo (has the dev env):
cd ai-service
pytest --tb=no -q  # should pass unchanged — new tests are skipped
BUBBLY_RUN_LIVE_TESTS=1 pytest tests/test_intent_live.py -v  # all tests, all pass as batch
```

## Out of scope

- Enabling the `live` marker as a pytest `-m` filter (the file uses `@_SKIP` via `skipif` — a separate cleanup could unify them under `@pytest.mark.live`)
- Any changes to `recipe/nodes.py` or the prompt tuning; that is tracked separately

Closes #208, #145