### PR TITLE
fix: intent-aware chat follow-up chips (#226)

### DIFF
--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -30,6 +30,42 @@ import type {
   PantryProposalData,
 } from '@/types/chat'
 import { getBrainstormIdeas } from '@/types/chat'
+import type { ChipConfig } from '@/components/chat/PostMessageChips'
+
+// ---------------------------------------------------------------------------
+// Intent-aware chip resolver
+// ---------------------------------------------------------------------------
+
+function resolveChips(intent: string | undefined): ChipConfig[] {
+  switch (intent) {
+    case 'recipe_generation':
+    case 'recipe_card':
+      return [
+        { label: 'Try another recipe', message: 'Give me a different recipe', tone: 'accent', emoji: '🔄' },
+        { label: 'Tell me more', message: 'Tell me more about that recipe', tone: 'primary', emoji: '💬' },
+      ]
+    case 'pantry_update':
+      return [
+        { label: 'Add more items', message: 'I have more items to add to my pantry', tone: 'fresh', emoji: '➕' },
+        { label: 'What expires soon?', message: 'What items in my pantry are expiring soon?', tone: 'expiring', emoji: '⏰' },
+      ]
+    case 'cooking_question':
+      return [
+        { label: 'Ask another question', message: 'I have another cooking question', tone: 'primary', emoji: '❓' },
+        { label: 'Tell me more', message: 'Tell me more about that', tone: 'accent', emoji: '💬' },
+      ]
+    case 'recipe_brainstorm':
+      return [
+        { label: 'Explore this idea', message: 'Tell me more about this recipe idea', tone: 'accent', emoji: '✨' },
+        { label: 'Try a different direction', message: 'Give me some different recipe ideas', tone: 'primary', emoji: '🔀' },
+      ]
+    default:
+      return [
+        { label: 'Try another', message: 'Give me a different answer', tone: 'accent', emoji: '🔄' },
+        { label: 'Tell me more', message: 'Tell me more about that', tone: 'primary', emoji: '💬' },
+      ]
+  }
+}
 
 const SUGGESTIONS = [
   'What can I make tonight? 🌙',
@@ -258,12 +294,8 @@ function ChatSurface() {
     }
   }
 
-  const handleTryAnother = () => {
-    sendMessage('Give me a different recipe')
-  }
-
-  const handleTellMore = () => {
-    sendMessage('Tell me more about that')
+  const handleChipTap = (message: string) => {
+    sendMessage(message)
   }
 
   const handlePickIdea = (idea: string) => {
@@ -372,8 +404,8 @@ function ChatSurface() {
                     : 'Recipe'
                   setCookTarget({ recipeId, recipeTitle: title })
                 }}
-                onTryAnother={handleTryAnother}
-                onTellMore={handleTellMore}
+                onTryAnother={handleChipTap.bind(null, 'Give me a different recipe')}
+                onChipTap={handleChipTap}
                 onPickIdea={handlePickIdea}
               />
             ))}
@@ -491,7 +523,8 @@ interface MessageRendererProps {
   /** Opens CookModal for the saved recipe. */
   onCook: (recipeId: string) => void
   onTryAnother: () => void
-  onTellMore: () => void
+  /** Called when the user taps a follow-up chip; sends the chip's message text. */
+  onChipTap: (message: string) => void
   /** Called when the user taps a brainstorm idea card; sends the name as the next message. */
   onPickIdea: (idea: string) => void
 }
@@ -509,7 +542,7 @@ function MessageRenderer({
   savedRecipeId,
   onCook,
   onTryAnother,
-  onTellMore,
+  onChipTap,
   onPickIdea,
 }: MessageRendererProps) {
   // User messages — simple bubble
@@ -632,7 +665,7 @@ function MessageRenderer({
       {/* Follow-up affordances — only under the last settled assistant reply.
           Recipe-card and pantry-proposal messages carry their own actions. */}
       {isLastSettledAssistant && (
-        <PostMessageChips onTryAnother={onTryAnother} onTellMore={onTellMore} />
+        <PostMessageChips chips={resolveChips(intent)} onChipTap={onChipTap} />
       )}
     </motion.div>
   )

--- a/nextjs/src/components/chat/PostMessageChips.tsx
+++ b/nextjs/src/components/chat/PostMessageChips.tsx
@@ -1,46 +1,41 @@
 'use client'
 
 import Chip from '@/components/ui/Chip'
+import type { ChipTone } from '@/components/ui/Chip'
+
+export interface ChipConfig {
+  label: string
+  /** The text sent to the AI when the chip is tapped. */
+  message: string
+  tone?: ChipTone
+  emoji?: string
+}
 
 export interface PostMessageChipsProps {
-  /** Ask for a different answer to the same question. */
-  onTryAnother?: () => void
-  /** Ask Bubbles to expand on the last answer. */
-  onTellMore?: () => void
+  chips: ChipConfig[]
+  onChipTap: (message: string) => void
 }
 
 /**
  * Contextual follow-up affordances rendered under the last settled assistant
  * message. Indentation matches the 36px mascot + gap-2 gutter beside the bubble.
  */
-export default function PostMessageChips({
-  onTryAnother,
-  onTellMore,
-}: PostMessageChipsProps) {
-  if (!onTryAnother && !onTellMore) return null
+export default function PostMessageChips({ chips, onChipTap }: PostMessageChipsProps) {
+  if (chips.length === 0) return null
 
   return (
     <div className="flex flex-wrap gap-2 mt-2 ml-11">
-      {onTryAnother && (
+      {chips.map((chip) => (
         <Chip
-          tone="accent"
-          emoji="🔄"
-          onClick={onTryAnother}
-          ariaLabel="Ask for another answer"
+          key={chip.label}
+          tone={chip.tone ?? 'muted'}
+          emoji={chip.emoji}
+          onClick={() => onChipTap(chip.message)}
+          ariaLabel={chip.label}
         >
-          Try another
+          {chip.label}
         </Chip>
-      )}
-      {onTellMore && (
-        <Chip
-          tone="primary"
-          emoji="💬"
-          onClick={onTellMore}
-          ariaLabel="Ask Bubbles to explain further"
-        >
-          Tell me more
-        </Chip>
-      )}
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Every non-card chat reply previously showed the same two chips ("Try another" / "Tell me more"), and "Try another" always sent "Give me a different recipe" regardless of what the conversation was about. This PR makes the chips contextual.

## What lands

- **`PostMessageChips`** — refactored from two optional `() => void` callbacks to a `chips: ChipConfig[]` + `onChipTap: (message: string) => void` interface. Each chip carries its own `label`, `message`, `tone`, and `emoji`.
- **`resolveChips(intent)`** — co-located helper in `chat/page.tsx` that maps the already-resolved `intent` string to the appropriate chip set:
  - `recipe_generation` / `recipe_card`: "Try another recipe" / "Tell me more"
  - `pantry_update`: "Add more items" / "What expires soon?"
  - `cooking_question`: "Ask another question" / "Tell me more"
  - `recipe_brainstorm`: "Explore this idea" / "Try a different direction"
  - Fallback (unknown): generic "Try another" / "Tell me more" (preserves previous behavior)
- `handleTryAnother` / `handleTellMore` replaced by a single `handleChipTap(message: string)`.
- `onTryAnother: () => void` retained on `MessageRendererProps` so `ChatRecipeCard`'s own "Try Another" button is unaffected.

## Tests

- `tsc --noEmit` passes (exit 0) against the main checkout's installed dev environment.

## Out of scope

- Chips are not yet shown after `recipe_brainstorm` messages that render the idea-card path (those messages return early before reaching `PostMessageChips`). A follow-on ticket could add chips there.
- No visual regression test; manual verification is in the test plan below.

**Manual test plan:**
1. `git checkout fix/issue-226-intent-aware-chips` in the primary repo, `cd nextjs && npm run dev`.
2. Ask for a recipe — last assistant reply should show "Try another recipe" / "Tell me more" chips.
3. Ask a cooking question — chips should read "Ask another question" / "Tell me more".
4. Ask to add something to your pantry — chips should read "Add more items" / "What expires soon?".
5. Ask for brainstorm ideas then pick one (falls through to text reply) — chips should read "Explore this idea" / "Try a different direction".