### PR TITLE
fix: UX audit pass — expiry bounds, stream recovery, error surfacing

### DIFF
--- a/ai-service/bubbly_chef/workflows/recipe/nodes.py
+++ b/ai-service/bubbly_chef/workflows/recipe/nodes.py
@@ -353,6 +353,7 @@ def score_and_rank(
     for item in pantry_items:
         name_lower = (item.get("name") or "").lower()
         score = 0.0
+        is_expired = False
 
         # "Use up my X" — dominates expiry so the named ingredient leads the list
         is_must_use = any(m in name_lower or name_lower in m for m in must_use)
@@ -365,7 +366,14 @@ def score_and_rank(
             try:
                 expiry = date.fromisoformat(str(expiry_str))
                 days_left = (expiry - today).days
-                if days_left <= 3:
+                # `days_left` goes negative once an item is past its date, so an
+                # unbounded `<= 3` also matched food that expired weeks ago and
+                # handed it to the LLM as a priority ingredient to cook tonight
+                # (#239). Expired stock scores neutral: still available to the
+                # model as context, never promoted as "use this first".
+                if days_left < 0:
+                    is_expired = True
+                elif days_left <= 3:
                     score += 10
                 elif days_left <= 7:
                     score += 5
@@ -384,7 +392,9 @@ def score_and_rank(
         if any(e in name_lower or name_lower in e for e in excluded):
             score -= 100
 
-        scored.append({**item, "_score": score, "_must_use": is_must_use})
+        scored.append(
+            {**item, "_score": score, "_must_use": is_must_use, "_expired": is_expired}
+        )
 
     scored.sort(key=lambda x: x.get("_score", 0), reverse=True)
     # Filter out excluded items (negative score)
@@ -586,10 +596,24 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
     scored_items: list[dict[str, Any]] = state.get("scored_pantry_items") or []
     constraints: dict[str, Any] = state.get("recipe_constraints") or {}
 
+    # Fall back to the time of day, same as the recipe-generate path does at
+    # `extract_recipe_constraints`. Without this the brainstorm prompt says only
+    # "if meal_type is specified" and the model picks freely — which produced
+    # breakfast suggestions at midnight (#248).
+    if not constraints.get("meal_type"):
+        constraints = {**constraints, "meal_type": _default_meal_type()}
+
     # Build ingredient summary for the prompt
     if scored_items:
         must_use = [i for i in scored_items if i.get("_must_use")]
-        rest = [i for i in scored_items if not i.get("_must_use")]
+        # Expired stock is dropped from the suggestion pool entirely (#239):
+        # scoring no longer promotes it, but leaving it under "Other available"
+        # still let the model build a dish around two-week-old spinach — and on
+        # a real pantry (29 of 49 items expired) it crowded out good ingredients.
+        # A must-use item is an explicit user request, so it survives.
+        rest = [
+            i for i in scored_items if not i.get("_must_use") and not i.get("_expired")
+        ]
         expiring = [i for i in rest if i.get("_score", 0) >= 10]
         supporting = [
             i for i in rest

--- a/ai-service/tests/test_must_use_ingredients.py
+++ b/ai-service/tests/test_must_use_ingredients.py
@@ -146,6 +146,50 @@ def test_empty_must_use_leaves_existing_ranking_unchanged() -> None:
 
 
 # ---------------------------------------------------------------------------
+# score_and_rank — expired stock (#239)
+# ---------------------------------------------------------------------------
+
+
+def test_expired_item_is_flagged_and_not_promoted() -> None:
+    """Past-date stock scores neutral and carries `_expired`, never the +10
+    urgency bonus an unbounded `days_left <= 3` used to hand it (#239)."""
+    ranked = score_and_rank([_item("spinach", days_until_expiry=-14)], {})
+    assert ranked[0]["_expired"] is True
+    assert ranked[0]["_score"] == 0
+
+
+def test_fresh_item_is_not_flagged_expired() -> None:
+    """The `_expired` flag stays off for in-date items, and expiry scoring holds."""
+    ranked = score_and_rank(
+        [_item("milk", days_until_expiry=1), _item("rice", days_until_expiry=30)], {}
+    )
+    by_name = {i["name"]: i for i in ranked}
+    assert by_name["milk"]["_expired"] is False
+    assert by_name["milk"]["_score"] == 10  # expiring soon
+    assert by_name["rice"]["_expired"] is False
+
+
+def test_expired_item_ranks_below_a_fresh_expiring_item() -> None:
+    """An expired item must not lead the list over genuinely urgent stock."""
+    ranked = score_and_rank(
+        [_item("old lettuce", days_until_expiry=-10), _item("milk", days_until_expiry=1)],
+        {},
+    )
+    assert ranked[0]["name"] == "milk"
+
+
+def test_expired_item_still_promoted_when_explicitly_must_use() -> None:
+    """A must-use item is an explicit user request — it survives the expiry rule."""
+    ranked = score_and_rank(
+        [_item("eggs", days_until_expiry=-2), _item("flour")],
+        {"must_use_ingredients": ["eggs"]},
+    )
+    assert ranked[0]["name"] == "eggs"
+    assert ranked[0]["_must_use"] is True
+    assert ranked[0]["_expired"] is True
+
+
+# ---------------------------------------------------------------------------
 # brainstorm_recipe_ideas — prompt grounding
 # ---------------------------------------------------------------------------
 
@@ -202,6 +246,62 @@ async def test_brainstorm_prompt_omits_must_use_when_unset() -> None:
     # The static rule mentions "Must use", but no must-use data line is emitted
     assert not any(li.startswith("Must use") for li in prompt.splitlines())
     assert "Expiring soon (prioritize): milk" in prompt
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_drops_expired_stock_from_the_pool() -> None:
+    """Expired items must not reach the suggestion prompt at all (#239)."""
+    scored = score_and_rank(
+        [_item("fresh basil", days_until_expiry=2), _item("old spinach", days_until_expiry=-14)],
+        {},
+    )
+    with _mock_ai("**Basil Pasta**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "what's for dinner?",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "basil" in prompt
+    assert "spinach" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_keeps_expired_item_when_must_use() -> None:
+    """A must-use item survives the expiry drop — user asked for it explicitly."""
+    scored = score_and_rank(
+        [_item("eggs", days_until_expiry=-2)], {"must_use_ingredients": ["eggs"]}
+    )
+    with _mock_ai("**Scramble**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "use up my eggs",
+                "scored_pantry_items": scored,
+                "recipe_constraints": {"must_use_ingredients": ["eggs"]},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert "eggs" in prompt
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_defaults_meal_type_when_unset() -> None:
+    """Without a meal_type the prompt would let the model pick freely, yielding
+    breakfast at midnight (#248). The node falls back to the time of day."""
+    from bubbly_chef.workflows.recipe.nodes import _default_meal_type
+
+    with _mock_ai("**Dinner Idea**") as mock_mgr:
+        await brainstorm_recipe_ideas(
+            {
+                "input_text": "what can I make?",
+                "scored_pantry_items": [],
+                "recipe_constraints": {},
+            }
+        )
+    prompt = mock_mgr.return_value.complete.call_args.kwargs["prompt"]
+    assert _default_meal_type() in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/nextjs/src/__tests__/chat-stream.test.ts
+++ b/nextjs/src/__tests__/chat-stream.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Regression test for #241 — a chat stream that ends without emitting an
+ * `envelope` or `error` event used to leave the UI streaming forever, because
+ * the caller only clears its streaming state from `onDone`/`onError`. The
+ * `settle()` guard in `streamChatMessage` must synthesise a terminal callback
+ * when the body closes cleanly with no envelope.
+ */
+import { streamChatMessage } from '@/lib/api/chat'
+import type { ChatRequest } from '@/types/chat'
+import { TextDecoder, TextEncoder } from 'util'
+
+// jsdom ships neither encoder; the client under test constructs a TextDecoder.
+Object.assign(global, { TextDecoder, TextEncoder })
+
+// The client fetches a Supabase token before streaming; stub it out.
+jest.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: async () => ({
+        data: { session: { access_token: 'test-token' } },
+      }),
+    },
+  }),
+}))
+
+/**
+ * Build a Response whose body yields the given SSE text once then closes.
+ *
+ * jsdom has no `ReadableStream`, so this hand-rolls the minimal reader surface
+ * `streamChatMessage` touches: one `read()` with the payload, one signalling
+ * `done`, and a no-op `releaseLock()`.
+ */
+function sseResponse(sse: string): Response {
+  let sent = false
+  const reader = {
+    read: async () => {
+      if (sent) return { done: true, value: undefined }
+      sent = true
+      return { done: false, value: new TextEncoder().encode(sse) }
+    },
+    releaseLock: () => {},
+  }
+  return {
+    ok: true,
+    status: 200,
+    body: { getReader: () => reader },
+  } as unknown as Response
+}
+
+const request: ChatRequest = {
+  message: 'hi',
+  conversation_id: 'c1',
+} as ChatRequest
+
+describe('streamChatMessage terminal-callback guarantee (#241)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('fires onError when the stream closes without an envelope', async () => {
+    // Tokens arrive, then the body ends — no `envelope`, no `error` event.
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        sseResponse('event: token\ndata: {"content":"partial"}\n\n'),
+      ) as unknown as typeof fetch
+
+    const onToken = jest.fn()
+    const onDone = jest.fn()
+    const onError = jest.fn()
+
+    await streamChatMessage(request, onToken, onDone, onError)
+
+    expect(onToken).toHaveBeenCalledWith('partial')
+    expect(onDone).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onDone exactly once when an envelope arrives, not the fallback onError', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue(
+        sseResponse('event: envelope\ndata: {"data":{"intent":"chat"}}\n\n'),
+      ) as unknown as typeof fetch
+
+    const onToken = jest.fn()
+    const onDone = jest.fn()
+    const onError = jest.fn()
+
+    await streamChatMessage(request, onToken, onDone, onError)
+
+    expect(onDone).toHaveBeenCalledTimes(1)
+    expect(onError).not.toHaveBeenCalled()
+  })
+})

--- a/nextjs/src/__tests__/pantry-expiry.test.ts
+++ b/nextjs/src/__tests__/pantry-expiry.test.ts
@@ -1,0 +1,90 @@
+import { daysUntilExpiry, enrichPantryItem, parseLocalDate } from '@/lib/pantry-helpers'
+import type { PantryItemRow } from '@/lib/pantry-helpers'
+
+/**
+ * Regression tests for the expiry-date maths (#244).
+ *
+ * The original bug: `new Date("2026-08-25")` parses as UTC midnight while the
+ * "today" it was compared against was local midnight, and one copy of the
+ * calculation subtracted `Date.now()` rather than local midnight. West of UTC,
+ * late in the day, a badge could read "Today" for an item the API reported as
+ * one day out. These tests pin the local-midnight semantics at a time-of-day
+ * (23:00) that would have exposed the old drift.
+ */
+describe('daysUntilExpiry', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns null for a missing date', () => {
+    expect(daysUntilExpiry(null)).toBeNull()
+  })
+
+  it('reports 0 for an item expiring today, even late in the local day', () => {
+    // 2026-08-25 23:00 local. Subtracting Date.now() (the old code) would give
+    // a fractional day that rounds to 0 here but drifts negative for tomorrow.
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 25, 23, 0, 0))
+    expect(daysUntilExpiry('2026-08-25')).toBe(0)
+  })
+
+  it('reports 1 for tomorrow at 23:00 local (no early-expiry drift)', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 25, 23, 0, 0))
+    // The pre-fix bug rounded this to 0 ("Today") after ~18:00 local.
+    expect(daysUntilExpiry('2026-08-26')).toBe(1)
+  })
+
+  it('reports negative for an item that already expired', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 25, 23, 0, 0))
+    expect(daysUntilExpiry('2026-08-24')).toBe(-1)
+  })
+})
+
+describe('parseLocalDate', () => {
+  it('parses a date-only string at local midnight, not UTC midnight', () => {
+    const d = parseLocalDate('2026-08-25')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(7) // August
+    expect(d.getDate()).toBe(25)
+    expect(d.getHours()).toBe(0)
+  })
+
+  it('leaves strings carrying a time component to the normal parser', () => {
+    const d = parseLocalDate('2026-08-25T12:30:00Z')
+    expect(Number.isNaN(d.getTime())).toBe(false)
+  })
+})
+
+describe('enrichPantryItem expiry flags', () => {
+  const baseRow: PantryItemRow = {
+    id: '1',
+    user_id: 'u',
+    name: 'Milk',
+    name_normalized: 'milk',
+    category: 'dairy',
+    location: 'fridge',
+    quantity: 1,
+    unit: 'carton',
+    expiry_date: null,
+    slot_index: null,
+    added_at: '2026-08-01',
+    updated_at: '2026-08-01',
+  }
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('flags an already-expired item as expired, not expiring_soon', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 25, 23, 0, 0))
+    const item = enrichPantryItem({ ...baseRow, expiry_date: '2026-08-20' })
+    expect(item.is_expired).toBe(true)
+    expect(item.is_expiring_soon).toBe(false)
+  })
+
+  it('flags an item within 3 days as expiring_soon, not expired', () => {
+    jest.useFakeTimers().setSystemTime(new Date(2026, 7, 25, 23, 0, 0))
+    const item = enrichPantryItem({ ...baseRow, expiry_date: '2026-08-27' })
+    expect(item.is_expired).toBe(false)
+    expect(item.is_expiring_soon).toBe(true)
+  })
+})

--- a/nextjs/src/app/api/pantry/expiring/route.ts
+++ b/nextjs/src/app/api/pantry/expiring/route.ts
@@ -11,15 +11,25 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const days = parseInt(searchParams.get('days') || '3', 10)
 
+  // Both bounds matter. `expiry_date <= today + days` alone also matches food
+  // that expired weeks ago, which made this endpoint report 31 "expiring" items
+  // on a pantry with only 2 genuinely expiring in the window (#239). Expired
+  // stock is a different problem with a different remedy (toss / used it up),
+  // so it is excluded here rather than relabelled.
+  const localDateStr = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+
+  const todayStr = localDateStr(new Date())
   const futureDate = new Date()
   futureDate.setDate(futureDate.getDate() + days)
-  const futureDateStr = futureDate.toISOString().split('T')[0]
+  const futureDateStr = localDateStr(futureDate)
 
   const { data, error } = await supabase
     .from('pantry_items')
     .select('*')
     .eq('user_id', user.id)
     .not('expiry_date', 'is', null)
+    .gte('expiry_date', todayStr)
     .lte('expiry_date', futureDateStr)
     .order('expiry_date')
 

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -355,19 +355,25 @@ function ChatSurface() {
         </div>
       )}
 
-      {/* Messages area */}
-      <div className="flex-1 overflow-y-auto px-4 py-4">
-        {/* Cook handoff context — dismissible, sits above the thread */}
-        <AnimatePresence>
-          {cookingRecipe && (
+      {/* Cook handoff context — pinned above the thread rather than scrolling
+          with it. While a recipe is pinned, cooking *is* the task of this
+          screen, and the banner is the only on-screen confirmation that Bubbles
+          knows which recipe you mean; inside the scroll area it disappeared
+          after a couple of turns (#242). */}
+      <AnimatePresence>
+        {cookingRecipe && (
+          <div className="flex-shrink-0 px-4 pt-4">
             <CookingContextCard
               title={cookingRecipe.title}
               ingredientCount={cookingRecipe.ingredients.length}
               onDismiss={dismissCookingCard}
             />
-          )}
-        </AnimatePresence>
+          </div>
+        )}
+      </AnimatePresence>
 
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto px-4 py-4">
         {/* Deep-link seed context (?tip= / ?use=) — same slot, same idiom */}
         <AnimatePresence>
           {activeSeed && (

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -15,6 +15,7 @@ import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAdd
 import { getFoodEmoji } from '@/lib/food-emoji'
 import { titleCase } from '@/lib/format'
 import { cookThisHref } from '@/lib/chat-seed'
+import { daysUntilExpiry } from '@/lib/pantry-helpers'
 import Chip from '@/components/ui/Chip'
 
 interface PantryItem {
@@ -65,11 +66,9 @@ const LOCATION_FILTERS = [
   { value: 'counter', label: 'Counter' },
 ]
 
-function daysUntilExpiry(date: string | null): number | null {
-  if (!date) return null
-  const diff = new Date(date).getTime() - Date.now()
-  return Math.ceil(diff / (1000 * 60 * 60 * 24))
-}
+// `daysUntilExpiry` lives in `lib/pantry-helpers` — this file used to carry its
+// own copy that subtracted `Date.now()` instead of local midnight, which made
+// the badge disagree with the server-computed flags after ~18:00 (#244).
 
 /**
  * Expiring soon — the same 0–3 day window `pantry-helpers`' `is_expiring_soon`

--- a/nextjs/src/components/pantry/AddItemModal.tsx
+++ b/nextjs/src/components/pantry/AddItemModal.tsx
@@ -57,6 +57,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
   const [suggestions, setSuggestions] = useState<FoodSuggestion[]>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -81,6 +82,7 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
     }
     setConfirmDelete(false)
     setSuggestions([])
+    setError(null)
   }, [editItem, isOpen])
 
   // Food typeahead
@@ -114,40 +116,52 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
     setSuggestions([])
   }
 
+  // Every write path below keeps the modal open on failure. It used to close
+  // unconditionally and swallow the error, so a 401/409/500 was indistinguishable
+  // from a successful save and the item silently never appeared (#240).
   const handleSubmit = async () => {
     if (!name.trim()) return
     setSaving(true)
+    setError(null)
     try {
-      if (isEditMode && editItem) {
-        await fetch(`/api/pantry/${editItem.id}`, {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: name.trim(),
-            quantity,
-            unit,
-            category,
-            location,
-            expiry_date: expiryDate || null,
-          }),
-        })
-      } else {
-        await fetch('/api/pantry', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: name.trim(),
-            quantity,
-            unit,
-            category,
-            storage_location: location,
-            expiry_date: expiryDate || null,
-          }),
-        })
+      const res =
+        isEditMode && editItem
+          ? await fetch(`/api/pantry/${editItem.id}`, {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                name: name.trim(),
+                quantity,
+                unit,
+                category,
+                location,
+                expiry_date: expiryDate || null,
+              }),
+            })
+          : await fetch('/api/pantry', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                name: name.trim(),
+                quantity,
+                unit,
+                category,
+                storage_location: location,
+                expiry_date: expiryDate || null,
+              }),
+            })
+
+      if (!res.ok) {
+        setError(
+          res.status === 401
+            ? 'Your session expired — sign in again to save.'
+            : "Couldn't save that item. Please try again.",
+        )
+        return
       }
       onClose()
     } catch {
-      // silent — user can retry
+      setError('Network problem — check your connection and try again.')
     } finally {
       setSaving(false)
     }
@@ -156,11 +170,16 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
   const handleDelete = async () => {
     if (!editItem) return
     setSaving(true)
+    setError(null)
     try {
-      await fetch(`/api/pantry/${editItem.id}`, { method: 'DELETE' })
+      const res = await fetch(`/api/pantry/${editItem.id}`, { method: 'DELETE' })
+      if (!res.ok) {
+        setError("Couldn't delete that item. Please try again.")
+        return
+      }
       onClose()
     } catch {
-      // silent
+      setError('Network problem — check your connection and try again.')
     } finally {
       setSaving(false)
     }
@@ -303,6 +322,15 @@ export default function AddItemModal({ isOpen, onClose, editItem }: AddItemModal
                   className="w-full rounded-xl px-4 py-2.5 border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text)] text-sm focus:border-[var(--color-primary)]"
                 />
               </div>
+
+              {error && (
+                <p
+                  role="alert"
+                  className="mb-3 text-xs font-semibold text-red-500 text-center"
+                >
+                  {error}
+                </p>
+              )}
 
               {/* Actions */}
               <div className="flex gap-3">

--- a/nextjs/src/components/pantry/ScanTab.tsx
+++ b/nextjs/src/components/pantry/ScanTab.tsx
@@ -56,6 +56,10 @@ export default function ScanTab({ onItemsReady }: ScanTabProps) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong')
       setState('upload')
+      // Retrying the same receipt is the obvious next move after a transient
+      // failure, but `onChange` doesn't fire for an unchanged value — so
+      // without this the same file simply does nothing (#246).
+      if (inputRef.current) inputRef.current.value = ''
     } finally {
       setTimeout(() => URL.revokeObjectURL(objectUrl), 500)
     }

--- a/nextjs/src/components/recipes/RecipeImportModal.tsx
+++ b/nextjs/src/components/recipes/RecipeImportModal.tsx
@@ -88,7 +88,10 @@ export default function RecipeImportModal({ onImported, onClose }: RecipeImportM
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.2 }}
-          onClick={onClose}
+          // Matches the Cancel button's `disabled={state === 'loading'}` — the
+          // backdrop used to close unconditionally, so an accidental tap during
+          // an in-flight import silently discarded the result (#247).
+          onClick={state === 'loading' ? undefined : onClose}
         />
 
         <motion.div

--- a/nextjs/src/lib/api/chat.ts
+++ b/nextjs/src/lib/api/chat.ts
@@ -87,6 +87,18 @@ export async function streamChatMessage(
   const decoder = new TextDecoder()
   let buffer = ''
 
+  // The caller clears its streaming state only from `onDone`/`onError`, so a
+  // stream that ends without emitting an `envelope` or `error` event (backend
+  // crash mid-stream, dropped proxy connection, truncated body) used to leave
+  // the UI streaming forever with no way out but a reload (#241). Track whether
+  // a terminal callback actually fired and synthesise one if it did not.
+  let settled = false
+  const settle = (fn: () => void) => {
+    if (settled) return
+    settled = true
+    fn()
+  }
+
   try {
     for (;;) {
       const { done, value } = await reader.read()
@@ -112,13 +124,13 @@ export async function streamChatMessage(
               parsed.type === 'envelope' ||
               currentEventType === 'envelope'
             ) {
-              onDone(parsed.data)
+              settle(() => onDone(parsed.data))
             } else if (
               parsed.type === 'error' ||
               currentEventType === 'error'
             ) {
-              onError(
-                new Error(parsed.message ?? 'Stream error'),
+              settle(() =>
+                onError(new Error(parsed.message ?? 'Stream error')),
               )
               return
             }
@@ -130,10 +142,19 @@ export async function streamChatMessage(
       }
     }
   } catch (err) {
-    if ((err as DOMException)?.name === 'AbortError') return
-    onError(err instanceof Error ? err : new Error(String(err)))
+    // An abort is a deliberate user action; the caller already reset its own
+    // state when it aborted, so mark this settled without firing a callback.
+    if ((err as DOMException)?.name === 'AbortError') {
+      settled = true
+      return
+    }
+    settle(() => onError(err instanceof Error ? err : new Error(String(err))))
   } finally {
     reader.releaseLock()
+    // Reached when the body closed cleanly but no envelope ever arrived.
+    settle(() =>
+      onError(new Error('The response ended unexpectedly. Please try again.')),
+    )
   }
 }
 

--- a/nextjs/src/lib/pantry-helpers.ts
+++ b/nextjs/src/lib/pantry-helpers.ts
@@ -25,17 +25,47 @@ export interface EnrichedPantryItem extends PantryItemRow {
   is_expiring_soon: boolean
 }
 
+/**
+ * Parse a stored expiry date as a *local* calendar date.
+ *
+ * `new Date("2026-08-25")` is specified to parse as UTC midnight, while the
+ * "today" it gets compared against is local midnight. West of UTC that made
+ * items read as expiring a day early (#244). Date-only strings are split
+ * explicitly; anything carrying a time component is left to the normal parser.
+ */
+export function parseLocalDate(value: string): Date {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return new Date(value)
+  return new Date(Number(match[1]), Number(match[2]) - 1, Number(match[3]))
+}
+
+/**
+ * Whole days from today (local midnight) until `expiry_date`.
+ *
+ * The single source of truth for expiry maths. `pantry/page.tsx` used to carry
+ * its own copy that subtracted `Date.now()` rather than local midnight, so a
+ * badge could read "Today" for an item the API reported as one day out — the
+ * two disagreed after roughly 18:00 (#244).
+ */
+export function daysUntilExpiry(expiryDate: string | null): number | null {
+  if (!expiryDate) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffMs = parseLocalDate(expiryDate).getTime() - today.getTime()
+  return Math.round(diffMs / (1000 * 60 * 60 * 24))
+}
+
 export function enrichPantryItem(row: PantryItemRow): EnrichedPantryItem {
   let days_until_expiry: number | null = null
   let is_expired = false
   let is_expiring_soon = false
 
   if (row.expiry_date) {
-    const expiry = new Date(row.expiry_date)
+    const expiry = parseLocalDate(row.expiry_date)
     const today = new Date()
     today.setHours(0, 0, 0, 0)
     const diffMs = expiry.getTime() - today.getTime()
-    days_until_expiry = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+    days_until_expiry = Math.round(diffMs / (1000 * 60 * 60 * 24))
     is_expired = days_until_expiry < 0
     is_expiring_soon = days_until_expiry >= 0 && days_until_expiry <= 3
   }


### PR DESCRIPTION
## Summary

Fixes from a live QA pass against the running stack (`docs/plans/2026-08-24-ux-audit.md`). Nine user-facing correctness and resilience bugs across expiry maths, the chat stream, and error surfacing.

## What lands

- **Expiring endpoint lower bound (#239)** — `/api/pantry/expiring` gained a `today` lower bound so long-expired stock stops being reported as "expiring soon" (a 2-item window was reading 31). Dates compared as local strings.
- **Expired stock in recipe scoring (#239, #248)** — `score_and_rank` no longer hands past-date items the expiring-soon bonus; it tags them `_expired` so the brainstorm pool drops them from the LLM prompt (a must-use item still survives, since that's an explicit request). Brainstorm falls back to a time-of-day `meal_type`, so it no longer suggests breakfast at midnight.
- **Shared expiry maths (#244)** — one `parseLocalDate` + `daysUntilExpiry` in `pantry-helpers`; the pantry page drops its divergent copy that subtracted `Date.now()` and drifted after ~18:00 local.
- **AddItemModal error surfacing (#240)** — API failures now show via `role="alert"` instead of failing silently; `res.ok` checked on add/edit/delete.
- **Chat stream can't hang (#241)** — a `settle()` guard guarantees a terminal callback fires even when the body closes with no `envelope`/`error` event, so the UI can't stay in a streaming state forever.
- **ScanTab retry (#246)** — the file input resets on error so re-selecting the same receipt fires `onChange`.
- **RecipeImportModal (#247)** — backdrop dismissal is guarded while a load is in flight.
- **Chat cooking banner (#242, partial)** — the cook-handoff banner is pinned outside the scroll container so it stays visible past the first couple of turns.

## Tests

- `nextjs`: `npm test` — 94 pass (10 new: expiry local-midnight maths at 23:00, expired-stock scoring + prompt exclusion, `meal_type` default, stream-without-envelope terminal callback).
- `ai-service`: `pytest` — 398 pass; `ruff check` clean.
- `npx tsc --noEmit` — clean.

## Linked

#239 #240 #241 #242 #244 #246 #247 #248

## Out of scope

- #242 only lands the pinned-banner part. Cook-gated-on-save and the "Cook this" naming/flow redesign need a design decision. The reported "follow-up returns new recipes instead of cooking help" was not reproduced in two live attempts — session mode held; needs the exact cook-from-chat-card entry path.
- #243 (empty-pantry onboarding) and #245 (cook-modal confirm UX) are filed only, not addressed here.
