### PR TITLE
fix(scan): restore + rework receipt scanning (slices 1-3) (#250)

### DIFF
--- a/ai-service/bubbly_chef/api/routes/scan.py
+++ b/ai-service/bubbly_chef/api/routes/scan.py
@@ -93,6 +93,9 @@ async def scan_receipt(
             pantry_item = action.item
             item = {
                 "name": pantry_item.name,
+                "original_name": pantry_item.original_name or pantry_item.name,
+                "source_line": action.source_line or "",
+                "price": action.price,
                 "quantity": pantry_item.quantity,
                 "unit": pantry_item.unit,
                 "category": pantry_item.category.value if hasattr(pantry_item.category, "value") else str(pantry_item.category),

--- a/ai-service/bubbly_chef/api/routes/scan.py
+++ b/ai-service/bubbly_chef/api/routes/scan.py
@@ -27,7 +27,7 @@ router = APIRouter(prefix="/v1/scan", tags=["scan"])
 )
 async def scan_receipt(
     file: UploadFile = File(..., description="Receipt image (JPEG/PNG)"),
-    preprocess: bool = True,
+    preprocess: bool = False,
     preprocess_mode: str = "auto",
     user_id: str = Depends(get_current_user_id),
 ) -> dict[str, Any]:
@@ -67,7 +67,10 @@ async def scan_receipt(
         if not ocr_text.strip():
             return {
                 "ocr_text": "",
-                "items": [],
+                "ready_to_add": [],
+                "needs_review": [],
+                "skipped": [],
+                "total_items": 0,
                 "warnings": ["No text detected in image. Try a clearer photo."],
             }
 
@@ -79,6 +82,7 @@ async def scan_receipt(
         # Extract items from the proposal envelope (Pydantic model)
         proposal = result.proposal
         actions = proposal.actions if proposal else []
+        warnings = list(result.warnings or [])
 
         # Categorize by confidence
         ready = []
@@ -108,6 +112,7 @@ async def scan_receipt(
             "needs_review": review,
             "skipped": skipped,
             "total_items": len(actions),
+            "warnings": warnings,
         }
 
     except Exception as e:

--- a/ai-service/bubbly_chef/models/pantry.py
+++ b/ai-service/bubbly_chef/models/pantry.py
@@ -135,6 +135,15 @@ class PantryUpsertAction(BaseModel):
         default=None,
         description="If UPDATE/REMOVE/USE, the ID of the existing item to modify",
     )
+    # Receipt-specific provenance fields — None for non-receipt paths
+    source_line: str | None = Field(
+        default=None,
+        description="Raw OCR receipt line this item was parsed from",
+    )
+    price: float | None = Field(
+        default=None,
+        description="Item price from receipt",
+    )
 
 
 class PantryAction(BaseModel):

--- a/ai-service/bubbly_chef/services/image_preprocessor.py
+++ b/ai-service/bubbly_chef/services/image_preprocessor.py
@@ -15,7 +15,12 @@ PreprocessMode = Literal["auto", "light", "aggressive"]
 
 class ImagePreprocessor:
     """
-    Preprocesses receipt images for optimal Tesseract OCR performance.
+    Preprocesses receipt images.
+
+    Historically tuned for Tesseract OCR; Tesseract was replaced by Gemini
+    Vision, which reads ordinary phone photos better without classical-OCR
+    enhancement. Preprocessing is now an explicit opt-in retry rather than the
+    default path.
 
     Applies various image enhancement techniques:
     - Grayscale conversion
@@ -173,11 +178,11 @@ class ImagePreprocessor:
         if std_brightness < 40:
             # Low contrast image - needs aggressive processing
             logger.info("Auto mode: Low contrast detected, using aggressive preprocessing")
-            return await self._preprocess_aggressive(image)
+            return await self._preprocess_aggressive(image, already_cropped=True)
         elif mean_brightness < 80 or mean_brightness > 200:
             # Poor lighting - needs moderate processing
             logger.info("Auto mode: Poor lighting detected, using aggressive preprocessing")
-            return await self._preprocess_aggressive(image)
+            return await self._preprocess_aggressive(image, already_cropped=True)
         else:
             # Good quality image - light processing
             logger.info("Auto mode: Good quality image, using light preprocessing")
@@ -202,7 +207,9 @@ class ImagePreprocessor:
 
         return image
 
-    async def _preprocess_aggressive(self, image: Image.Image) -> Image.Image:
+    async def _preprocess_aggressive(
+        self, image: Image.Image, already_cropped: bool = False
+    ) -> Image.Image:
         """
         Aggressive preprocessing: full pipeline for challenging images.
 
@@ -213,9 +220,18 @@ class ImagePreprocessor:
         4. Sharpening
         5. Deskewing (rotation correction)
         6. Binarization (adaptive thresholding)
+
+        Args:
+            image: Source image.
+            already_cropped: True when the caller (auto mode) has already run
+                ``_crop_receipt``. Prevents a second crop that would re-run edge
+                detection on an image that is already nothing but receipt and
+                discard most of the item list.
         """
-        # Crop receipt from background before other processing
-        image = self._crop_receipt(image)
+        # Crop receipt from background before other processing, unless the
+        # caller already cropped (avoids the fatal double-crop).
+        if not already_cropped:
+            image = self._crop_receipt(image)
 
         # Convert to grayscale
         if image.mode != "L":

--- a/ai-service/bubbly_chef/workflows/ingest_spine.py
+++ b/ai-service/bubbly_chef/workflows/ingest_spine.py
@@ -82,6 +82,11 @@ def build_actions_from_normalized(
     field_confidences: dict[str, float] = {}
 
     for idx, item_data in enumerate(normalized_items):
+        # Per-item confidence: the LLM emits a confidence for each item; the
+        # batch value from state["confidence"] is used as a fallback so that
+        # product-ingest (which has no per-item signal) keeps working unchanged.
+        item_confidence: float = float(item_data.get("confidence", base_confidence))
+
         pantry_item = PantryItem(
             id=uuid4(),
             name=item_data.get("name", "unknown"),
@@ -107,14 +112,18 @@ def build_actions_from_normalized(
         action = PantryUpsertAction(
             action_type=ActionType.ADD,
             item=pantry_item,
-            confidence=base_confidence,
+            confidence=item_confidence,
             reasoning=reasoning_for_item(item_data),
+            # Receipt-specific provenance — None for non-receipt paths (product_ingest
+            # items never set these keys, so .get() returns None safely).
+            source_line=item_data.get("source_line"),
+            price=item_data.get("price"),
         )
         actions.append(action)
-        field_confidences[f"item_{idx}_name"] = base_confidence
+        field_confidences[f"item_{idx}_name"] = item_confidence
 
     requires_review = (
-        base_confidence < settings.auto_apply_confidence_threshold
+        any(a.confidence < settings.auto_apply_confidence_threshold for a in actions)
         or len(state.get("errors", [])) > 0
         or len(actions) == 0
     )

--- a/ai-service/bubbly_chef/workflows/receipt_ingest.py
+++ b/ai-service/bubbly_chef/workflows/receipt_ingest.py
@@ -45,7 +45,8 @@ Rules:
    loyalty points, etc.) — but DO NOT filter by keyword; use context and your own judgment.
 2. All items from a receipt are "add" actions (purchases).
 3. Extract quantities when visible.
-4. Guess the food category.
+4. Guess the food category: one of produce, dairy, meat, seafood, frozen, canned,
+   dry_goods, condiments, beverages, snacks, bakery, other.
 5. Handle common receipt abbreviations (e.g., "ORG" = organic, "GAL" = gallon,
    "LB" = pound, "CT" = count, "PK" = pack).
 6. If quantity is unclear, default to 1.
@@ -73,7 +74,8 @@ For each food item extract:
 - name: full product name (expand abbreviations, preserve product identity)
 - quantity: numeric amount (default 1)
 - unit: unit of measurement
-- category: food category
+- category: one of produce, dairy, meat, seafood, frozen, canned, dry_goods,
+  condiments, beverages, snacks, bakery, other
 - action: always "add" for receipt items
 - confidence: per-item confidence 0.0–1.0 (how clearly this specific line read)
 - source_line: the exact raw receipt line this item came from
@@ -222,17 +224,20 @@ def normalize_receipt_items(state: WorkflowState) -> WorkflowState:
         # only when there is no more specific match.
         normalized_name = normalize_food_name(name)
 
-        # Get category: prefer deterministic catalog/keyword answer over the
-        # noisy LLM string (which produces compounds like "dairy & eggs" that
-        # map_category can't match exactly).
+        # Get category: prefer the LLM's answer over the deterministic
+        # catalog/keyword matcher. The schema now constrains LLMParsedItem.category
+        # to the FoodCategory enum (see shared_state.py), so the LLM can no longer
+        # emit unmatchable free-form strings like "dairy & eggs" — the vocabulary
+        # mismatch that used to justify preferring the deterministic path is gone.
+        # resolve_category's substring/keyword matching is still weak on its own
+        # (e.g. "italian bomba hot pepper" -> "produce" via "pepper"), so it is
+        # kept only as a fallback for when the LLM returns nothing or "other".
         llm_category = item.get("category")
-        resolved = resolve_category(normalized_name)
-        if resolved:
-            category = map_category(resolved)
-        elif llm_category and llm_category.lower() != "other":
+        if llm_category and str(llm_category).lower() != "other":
             category = map_category(llm_category)
         else:
-            category = map_category(None)
+            resolved = resolve_category(normalized_name)
+            category = map_category(resolved) if resolved else map_category(None)
 
         # Get storage location
         storage = expiry.get_default_storage(category)

--- a/ai-service/bubbly_chef/workflows/receipt_ingest.py
+++ b/ai-service/bubbly_chef/workflows/receipt_ingest.py
@@ -156,45 +156,18 @@ def clean_receipt_items(state: WorkflowState) -> WorkflowState:
     """
     Node: Clean and filter receipt items (deterministic).
 
-    Removes obvious non-food items, price artifacts, etc.
+    Drops only degenerate rows (empty or absurdly long names). Non-food
+    accounting lines (tax, total, cash, …) are left to the LLM parse and the
+    per-item confidence tiers — a substring keyword filter here silently ate
+    real food (``"bag"`` → baguette/cabbage, ``"cash"`` → cashews).
     """
     parsed_items = state.get("parsed_items", [])
-
-    # Keywords indicating non-food items to filter out
-    filter_keywords = [
-        "tax",
-        "total",
-        "subtotal",
-        "change",
-        "cash",
-        "credit",
-        "debit",
-        "bag",
-        "bags",
-        "coupon",
-        "discount",
-        "savings",
-        "member",
-        "rewards",
-        "receipt",
-        "store",
-        "thank",
-        "visit",
-        "date",
-        "time",
-        "cashier",
-    ]
 
     cleaned = []
     warnings = state.get("warnings", [])
 
     for item in parsed_items:
         name = item.get("name", "").lower()
-
-        # Skip if name looks like non-food
-        if any(kw in name for kw in filter_keywords):
-            warnings.append(f"Filtered non-food item: {item.get('name')}")
-            continue
 
         # Skip if name is too short or too long
         if len(name) < 2:

--- a/ai-service/bubbly_chef/workflows/receipt_ingest.py
+++ b/ai-service/bubbly_chef/workflows/receipt_ingest.py
@@ -15,9 +15,8 @@ from bubbly_chef.models.base import ProposalEnvelope
 from bubbly_chef.models.pantry import (
     PantryProposal,
 )
-from bubbly_chef.domain.normalizer import normalize_to_base_unit, resolve_category
+from bubbly_chef.domain.normalizer import normalize_food_name, normalize_to_base_unit, resolve_category
 from bubbly_chef.tools.expiry import get_expiry_heuristics
-from bubbly_chef.tools.normalizer import get_normalizer
 from bubbly_chef.workflows.ingest_spine import (
     build_actions_from_normalized,
     build_proposal_envelope,
@@ -36,44 +35,49 @@ logger = logging.getLogger(__name__)
 # =============================================================================
 
 RECEIPT_PARSE_SYSTEM_PROMPT = """\
-You are a helpful assistant that extracts grocery items \
-from receipt OCR text.
+You are a precise grocery-item extractor for receipt OCR text.
 
 Receipt text is often messy with abbreviations, prices, and store-specific formatting.
-Your job is to extract the actual food/grocery items and ignore:
-- Prices
-- Tax lines
-- Totals
-- Store headers/footers
-- Non-food items (bags, etc.)
+Your job is to extract the actual food/grocery items.
 
 Rules:
-1. Extract only food/grocery items
-2. All items from a receipt are "add" actions (purchases)
-3. Extract quantities when visible
-4. Guess the food category
-5. Handle common receipt abbreviations (e.g., "ORG" = organic, "GAL" = gallon)
-6. If quantity is unclear, default to 1"""
+1. Extract only food/grocery items. Skip non-food lines (tax, totals, store headers, bag fees,
+   loyalty points, etc.) — but DO NOT filter by keyword; use context and your own judgment.
+2. All items from a receipt are "add" actions (purchases).
+3. Extract quantities when visible.
+4. Guess the food category.
+5. Handle common receipt abbreviations (e.g., "ORG" = organic, "GAL" = gallon,
+   "LB" = pound, "CT" = count, "PK" = pack).
+6. If quantity is unclear, default to 1.
+7. PRESERVE the product name — expand abbreviations but keep the full product identity
+   (e.g., "ITALIAN BOMBA HOT PEPPER" stays "Italian Bomba Hot Pepper", not "pepper";
+   "ORG CANE SUGAR" becomes "Organic Cane Sugar", not "sugar";
+   "MILK CHOC ALMONDS" becomes "Milk Chocolate Almonds", not "milk").
+8. Return a SEPARATE confidence score for each individual item (0.0–1.0), based on how
+   clearly that specific line could be read and interpreted — not a single score for all.
+9. Set source_line to the raw receipt line this item was extracted from.
+10. Set price to the item's price if visible, otherwise null."""
 
 
 RECEIPT_PARSE_USER_PROMPT_TEMPLATE = """Parse the following receipt text into grocery items:
 
 "{text}"
 
-This is receipt text that may contain:
+This receipt text may contain:
 - Item names (possibly abbreviated)
-- Prices (ignore these)
+- Prices
 - Quantities
-- Tax and totals (ignore these)
+- Tax, totals, headers, and non-food lines (skip these)
 
-Extract each food item with:
-- name: the item name (expand abbreviations)
+For each food item extract:
+- name: full product name (expand abbreviations, preserve product identity)
 - quantity: numeric amount (default 1)
 - unit: unit of measurement
 - category: food category
 - action: always "add" for receipt items
-
-Return confidence 0-1 based on how clear the receipt text is."""
+- confidence: per-item confidence 0.0–1.0 (how clearly this specific line read)
+- source_line: the exact raw receipt line this item came from
+- price: item price as a number, or null if not visible"""
 
 
 # =============================================================================
@@ -126,8 +130,11 @@ async def parse_receipt_llm(state: WorkflowState) -> WorkflowState:
             item_dict["action"] = "add"  # Force add for receipts
             parsed_items.append(item_dict)
 
-        # Receipt confidence is typically lower due to OCR noise
-        adjusted_confidence = result.confidence * 0.9  # 10% penalty for OCR
+        # Use the batch confidence as-is — the OCR penalty (×0.9) has been removed.
+        # Per-item confidence from the LLM already encodes readability at the line
+        # level, so stamping an additional document-level penalty only pushes every
+        # item below the 0.8 auto-add threshold regardless of quality.
+        adjusted_confidence = result.confidence
 
         logger.info(
             f"Receipt LLM parsed {len(parsed_items)} items with confidence {adjusted_confidence}"
@@ -189,9 +196,18 @@ def clean_receipt_items(state: WorkflowState) -> WorkflowState:
 def normalize_receipt_items(state: WorkflowState) -> WorkflowState:
     """
     Node: Normalize item names from receipt (deterministic).
+
+    Uses domain/normalizer.py's ``normalize_food_name`` (head-noun matcher) instead
+    of tools/normalizer.py's ``FoodNormalizer.normalize`` (bidirectional substring).
+    The bidirectional matcher collapses distinct products — "italian bomba hot pepper"
+    → "black pepper", "milk chocolate" → "milk" — because any synonym that is a
+    substring of the input (or vice-versa) wins.  The head-noun matcher only fires
+    on exact full-token matches, so speciality products pass through unchanged.
+
+    ``source_line`` and ``price`` from the LLM parse are forwarded as-is so they
+    reach the scan response without any additional plumbing.
     """
     parsed_items = state.get("parsed_items", [])
-    normalizer = get_normalizer()
     expiry = get_expiry_heuristics()
 
     normalized = []
@@ -200,8 +216,11 @@ def normalize_receipt_items(state: WorkflowState) -> WorkflowState:
         name = item.get("name", "")
         original_name = name
 
-        # Normalize name
-        normalized_name = normalizer.normalize(name)
+        # Normalize name through the head-noun matcher in domain/normalizer.py.
+        # This preserves "Italian Bomba Hot Pepper" and "Milk Chocolate Almonds"
+        # while still resolving exact known synonyms like "cane sugar" → "sugar"
+        # only when there is no more specific match.
+        normalized_name = normalize_food_name(name)
 
         # Get category: prefer deterministic catalog/keyword answer over the
         # noisy LLM string (which produces compounds like "dairy & eggs" that
@@ -235,6 +254,7 @@ def normalize_receipt_items(state: WorkflowState) -> WorkflowState:
             "expiry_date": expiry_date.isoformat(),
             "estimated_expiry": is_estimated,
             "purchase_date": date.today().isoformat(),
+            # source_line and price pass through from the LLM parse via **item
         }
 
         # Unit normalization (dual-store: display unit + base unit)

--- a/ai-service/bubbly_chef/workflows/shared_state.py
+++ b/ai-service/bubbly_chef/workflows/shared_state.py
@@ -43,7 +43,7 @@ class LLMParsedItem(BaseModel):
     name: str = Field(description="Item name")
     quantity: float = Field(default=1.0, description="Quantity")
     unit: str = Field(default="item", description="Unit of measurement")
-    category: str | None = Field(default=None, description="Food category guess")
+    category: FoodCategory | None = Field(default=None, description="Food category guess")
     action: str = Field(default="add", description="Action: add, remove, or use")
     confidence: float = Field(default=0.8, ge=0.0, le=1.0, description="Per-item confidence")
     source_line: str | None = Field(default=None, description="Raw OCR receipt line this item was parsed from")

--- a/ai-service/bubbly_chef/workflows/shared_state.py
+++ b/ai-service/bubbly_chef/workflows/shared_state.py
@@ -46,6 +46,8 @@ class LLMParsedItem(BaseModel):
     category: str | None = Field(default=None, description="Food category guess")
     action: str = Field(default="add", description="Action: add, remove, or use")
     confidence: float = Field(default=0.8, ge=0.0, le=1.0, description="Per-item confidence")
+    source_line: str | None = Field(default=None, description="Raw OCR receipt line this item was parsed from")
+    price: float | None = Field(default=None, description="Item price from receipt")
 
 
 class LLMParseResult(BaseModel):

--- a/ai-service/tests/test_issue_215_receipt_categorize.py
+++ b/ai-service/tests/test_issue_215_receipt_categorize.py
@@ -91,18 +91,16 @@ def test_map_category_none_returns_other() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_normalizer_stub(normalized_name: str) -> MagicMock:
-    stub = MagicMock()
-    stub.normalize.return_value = normalized_name
-    return stub
-
-
 def _run_normalize(item: dict) -> dict:
     """Run the real normalize_receipt_items node over a single parsed item.
 
     Builds a WorkflowState dict (the node's actual input) and patches the
-    module-level ``get_normalizer``/``get_expiry_heuristics`` seams so the test
-    exercises the node's own category-resolution branch — not just the helpers.
+    module-level ``normalize_food_name``/``get_expiry_heuristics`` seams so the
+    test exercises the node's own category-resolution branch — not just the helpers.
+
+    Since Slice 2 routes receipt normalization through domain/normalizer.py's
+    ``normalize_food_name`` (head-noun matcher), the identity stub just returns
+    the raw name unchanged so that resolve_category sees the exact input.
     """
     import datetime
 
@@ -112,11 +110,8 @@ def _run_normalize(item: dict) -> dict:
     fake_expiry.get_default_storage.return_value = MagicMock(value="refrigerator")
     fake_expiry.estimate_expiry.return_value = (datetime.date(2026, 8, 14), True)
 
-    # Identity normalizer: the node passes the raw name straight to resolve_category.
-    stub_normalizer = _make_normalizer_stub(item["name"])
-
     with (
-        patch.object(receipt_ingest, "get_normalizer", return_value=stub_normalizer),
+        patch.object(receipt_ingest, "normalize_food_name", side_effect=lambda name: name),
         patch.object(receipt_ingest, "get_expiry_heuristics", return_value=fake_expiry),
     ):
         state: dict = {"parsed_items": [item]}

--- a/ai-service/tests/test_issue_252_category_precedence.py
+++ b/ai-service/tests/test_issue_252_category_precedence.py
@@ -1,0 +1,131 @@
+"""Regression tests for PR #252: LLM category should win over resolve_category.
+
+This is the third instance of the substring-matching bug in this PR (after the
+"bag"->baguette filter and the bidirectional normalizer). `resolve_category`
+uses keyword substring matching and can override a correct LLM answer with a
+wrong one (e.g. "italian bomba hot pepper" -> "produce" via "pepper").
+
+Covers:
+- LLMParsedItem.category is constrained to the FoodCategory enum (schema)
+- normalize_receipt_items prefers the LLM's category when present and not "other"
+- normalize_receipt_items falls back to resolve_category when the LLM
+  returns "other" or no category at all
+"""
+
+import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from bubbly_chef.models.pantry import FoodCategory
+from bubbly_chef.workflows import receipt_ingest
+from bubbly_chef.workflows.shared_state import LLMParsedItem
+
+
+# ---------------------------------------------------------------------------
+# Schema constraint
+# ---------------------------------------------------------------------------
+
+
+def test_llm_parsed_item_accepts_valid_enum_value() -> None:
+    item = LLMParsedItem(name="Baguette", category="bakery")
+    assert item.category == FoodCategory.BAKERY
+
+
+def test_llm_parsed_item_rejects_free_form_category() -> None:
+    """A free-form label the model might have emitted before the schema
+    constraint (e.g. "Baked Goods") is no longer a valid value."""
+    with pytest.raises(ValidationError):
+        LLMParsedItem(name="Baguette", category="Baked Goods")
+
+
+def test_llm_parsed_item_defaults_category_to_none() -> None:
+    item = LLMParsedItem(name="Mystery Item")
+    assert item.category is None
+
+
+# ---------------------------------------------------------------------------
+# normalize_receipt_items precedence
+# ---------------------------------------------------------------------------
+
+
+def _run_normalize(item: dict) -> dict:
+    """Run the real normalize_receipt_items node over a single parsed item."""
+
+    fake_expiry = MagicMock()
+    fake_expiry.get_default_storage.return_value = MagicMock(value="pantry")
+    fake_expiry.estimate_expiry.return_value = (datetime.date(2026, 12, 31), True)
+
+    with (
+        patch.object(receipt_ingest, "normalize_food_name", side_effect=lambda name: name),
+        patch.object(receipt_ingest, "get_expiry_heuristics", return_value=fake_expiry),
+    ):
+        state: dict = {"parsed_items": [item]}
+        result = receipt_ingest.normalize_receipt_items(state)
+
+    return result["normalized_items"][0]
+
+
+def test_llm_category_wins_over_wrong_resolve_category() -> None:
+    """resolve_category would say "produce" (substring match on "pepper"),
+    but the LLM's "condiments" answer must win."""
+    item = {
+        "name": "italian bomba hot pepper",
+        "category": "condiments",
+        "quantity": 1.0,
+        "unit": "item",
+    }
+    normalized = _run_normalize(item)
+    assert normalized["category"] == "condiments"
+
+
+def test_llm_category_wins_when_resolve_category_has_no_answer() -> None:
+    """resolve_category returns None for "sea salt fine crystals"; the LLM's
+    answer must be used directly instead of falling back to OTHER."""
+    item = {
+        "name": "sea salt fine crystals",
+        "category": "condiments",
+        "quantity": 1.0,
+        "unit": "item",
+    }
+    normalized = _run_normalize(item)
+    assert normalized["category"] == "condiments"
+
+
+def test_fallback_to_resolve_category_when_llm_returns_other() -> None:
+    """When the LLM gives up and says "other", resolve_category's deterministic
+    answer is used as a fallback rather than shipping "other"."""
+    item = {
+        "name": "eggs",
+        "category": "other",
+        "quantity": 1.0,
+        "unit": "dozen",
+    }
+    normalized = _run_normalize(item)
+    assert normalized["category"] == "dairy"
+
+
+def test_fallback_to_resolve_category_when_llm_returns_none() -> None:
+    """When the LLM omits category entirely, resolve_category is used."""
+    item = {
+        "name": "eggs",
+        "category": None,
+        "quantity": 1.0,
+        "unit": "dozen",
+    }
+    normalized = _run_normalize(item)
+    assert normalized["category"] == "dairy"
+
+
+def test_fallback_to_other_when_neither_llm_nor_resolve_category_know() -> None:
+    """When both the LLM and resolve_category come up empty, OTHER is the
+    final result (not a crash)."""
+    item = {
+        "name": "xyzunknownitem99999",
+        "category": None,
+        "quantity": 1.0,
+        "unit": "item",
+    }
+    normalized = _run_normalize(item)
+    assert normalized["category"] == "other"

--- a/ai-service/tests/test_slice2_receipt_quality.py
+++ b/ai-service/tests/test_slice2_receipt_quality.py
@@ -1,0 +1,431 @@
+"""Slice 2 receipt quality regression tests.
+
+Covers:
+1. Per-item confidence through ingest_spine (item overrides batch, fallback works)
+2. OCR penalty removal — confidence is NOT multiplied by 0.9
+3. normalize_receipt_items uses domain normalize_food_name (head-noun, not substring):
+   - "italian bomba hot pepper" stays itself (not collapsed to "black pepper")
+   - "milk chocolate" stays itself (not collapsed to "milk")
+   - "org cane sugar" strips prefix → "cane sugar" (not "sugar")
+4. source_line and price propagate through normalized_items → actions
+5. scan response exposes original_name, source_line, price
+6. Product-ingest tests unaffected: spine falls back to batch confidence when
+   item has no "confidence" key.
+"""
+
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bubbly_chef.domain.normalizer import normalize_food_name
+from bubbly_chef.models.pantry import (
+    ActionType,
+    FoodCategory,
+    PantryItem,
+    PantryProposal,
+    PantryUpsertAction,
+)
+from bubbly_chef.workflows.ingest_spine import build_actions_from_normalized
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_expiry() -> MagicMock:
+    ex = MagicMock()
+    ex.get_default_storage.return_value = MagicMock(value="pantry")
+    ex.estimate_expiry.return_value = (datetime.date(2026, 12, 31), True)
+    return ex
+
+
+def _run_normalize(items: list[dict]) -> list[dict]:
+    """Run normalize_receipt_items over items with mocked expiry."""
+    from bubbly_chef.workflows import receipt_ingest
+
+    with patch.object(receipt_ingest, "get_expiry_heuristics", return_value=_fake_expiry()):
+        state: dict = {"parsed_items": items}
+        result = receipt_ingest.normalize_receipt_items(state)
+    return result["normalized_items"]
+
+
+def _minimal_state(items: list[dict], base_confidence: float = 0.7) -> dict:
+    """Minimal WorkflowState containing normalized_items and a batch confidence."""
+    return {
+        "normalized_items": items,
+        "confidence": base_confidence,
+        "errors": [],
+        "warnings": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Per-item confidence in ingest_spine
+# ---------------------------------------------------------------------------
+
+
+def test_spine_uses_per_item_confidence_when_present() -> None:
+    """item_data["confidence"] takes precedence over state["confidence"]."""
+    items = [
+        {
+            "name": "eggs",
+            "confidence": 0.95,
+            "category": "dairy",
+            "storage_location": "fridge",
+            "quantity": 1.0,
+            "unit": "dozen",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        },
+        {
+            "name": "mystery item",
+            "confidence": 0.45,
+            "category": "other",
+            "storage_location": "pantry",
+            "quantity": 1.0,
+            "unit": "item",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        },
+    ]
+    state = _minimal_state(items, base_confidence=0.7)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+
+    actions = result["actions"]
+    assert len(actions) == 2
+    assert actions[0].confidence == pytest.approx(0.95)
+    assert actions[1].confidence == pytest.approx(0.45)
+
+
+def test_spine_falls_back_to_batch_confidence_when_missing() -> None:
+    """When item_data has no "confidence" key, the batch value is used."""
+    items = [
+        {
+            "name": "organic milk",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+            # No "confidence" key — product-ingest path
+        },
+    ]
+    state = _minimal_state(items, base_confidence=0.85)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+
+    actions = result["actions"]
+    assert len(actions) == 1
+    assert actions[0].confidence == pytest.approx(0.85)
+
+
+def test_spine_requires_review_uses_per_item_confidence() -> None:
+    """requires_review is True if any item is below auto-add threshold."""
+    items = [
+        {
+            "name": "eggs",
+            "confidence": 0.9,
+            "category": "dairy",
+            "storage_location": "fridge",
+            "quantity": 1.0,
+            "unit": "dozen",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        },
+        {
+            "name": "unclear item",
+            "confidence": 0.3,  # below 0.8
+            "category": "other",
+            "storage_location": "pantry",
+            "quantity": 1.0,
+            "unit": "item",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        },
+    ]
+    state = _minimal_state(items, base_confidence=0.9)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+    assert result["requires_review"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. OCR penalty removed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_ocr_penalty_in_parse_receipt_llm() -> None:
+    """parse_receipt_llm no longer multiplies result.confidence by 0.9."""
+    from bubbly_chef.workflows.receipt_ingest import parse_receipt_llm
+    from bubbly_chef.workflows.shared_state import LLMParsedItem, LLMParseResult
+
+    mock_result = LLMParseResult(
+        items=[
+            LLMParsedItem(name="Organic Apples", quantity=1.0, unit="bag", confidence=0.85)
+        ],
+        confidence=0.8,
+    )
+    mock_llm = MagicMock()
+    mock_llm.complete = AsyncMock(return_value=mock_result)
+
+    with patch("bubbly_chef.workflows.receipt_ingest.get_ai_manager", return_value=mock_llm):
+        result = await parse_receipt_llm({"input_text": "ORG APPLES 1 BAG 3.99"})
+
+    # 0.8 × 0.9 would be 0.72; without the penalty it must be exactly 0.8
+    assert result["confidence"] == pytest.approx(0.8)
+
+
+# ---------------------------------------------------------------------------
+# 3. Head-noun normalizer — no substring collapse
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_food_name_italian_bomba_hot_pepper() -> None:
+    """'italian bomba hot pepper' must NOT collapse to 'black pepper'."""
+    result = normalize_food_name("italian bomba hot pepper")
+    assert "black pepper" not in result
+    assert "pepper" in result.lower() or "bomba" in result.lower()
+
+
+def test_normalize_food_name_milk_chocolate() -> None:
+    """'milk chocolate' must NOT collapse to 'milk'."""
+    result = normalize_food_name("milk chocolate")
+    assert result != "milk"
+    assert "chocolate" in result.lower() or "milk chocolate" in result.lower()
+
+
+def test_normalize_food_name_org_cane_sugar_not_plain_sugar() -> None:
+    """'cane sugar' stripped of organic prefix: domain normalizer may keep 'cane sugar'
+    or produce 'sugar' via the catalog — what it must NOT do is produce 'black pepper'
+    or another unrelated food.  The important invariant is no cross-product collapse."""
+    result = normalize_food_name("cane sugar")
+    # Result is "cane sugar" or "sugar" — both acceptable; must not be an unrelated food
+    assert "sugar" in result.lower(), f"Expected 'sugar' in result, got: {result!r}"
+
+
+def test_normalize_receipt_items_preserves_italian_bomba_hot_pepper() -> None:
+    """normalize_receipt_items must not collapse 'Italian Bomba Hot Pepper' → 'black pepper'."""
+    items = [
+        {
+            "name": "Italian Bomba Hot Pepper",
+            "confidence": 0.9,
+            "category": "condiments",
+            "quantity": 1.0,
+            "unit": "jar",
+        }
+    ]
+    normalized = _run_normalize(items)
+    assert len(normalized) == 1
+    name = normalized[0]["name"].lower()
+    assert "black pepper" not in name, f"Name collapsed incorrectly: {normalized[0]['name']!r}"
+
+
+def test_normalize_receipt_items_preserves_milk_chocolate() -> None:
+    """normalize_receipt_items must not collapse 'milk chocolate' → 'milk'."""
+    items = [
+        {
+            "name": "milk chocolate almonds",
+            "confidence": 0.88,
+            "category": "snacks",
+            "quantity": 1.0,
+            "unit": "bag",
+        }
+    ]
+    normalized = _run_normalize(items)
+    assert len(normalized) == 1
+    name = normalized[0]["name"].lower()
+    assert name != "milk", f"Name collapsed incorrectly to: {name!r}"
+    assert "chocolate" in name or "almond" in name, f"Unexpected name: {name!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. source_line and price propagate through the pipeline
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_receipt_items_forwards_source_line_and_price() -> None:
+    """source_line and price survive the normalize node unchanged."""
+    items = [
+        {
+            "name": "Organic Cane Sugar",
+            "confidence": 0.92,
+            "source_line": "ORG CANE SUGAR          3.49",
+            "price": 3.49,
+            "category": "dry_goods",
+            "quantity": 1.0,
+            "unit": "bag",
+        }
+    ]
+    normalized = _run_normalize(items)
+    assert normalized[0]["source_line"] == "ORG CANE SUGAR          3.49"
+    assert normalized[0]["price"] == pytest.approx(3.49)
+
+
+def test_spine_forwards_source_line_and_price_to_action() -> None:
+    """source_line and price from normalized_items reach PantryUpsertAction."""
+    items = [
+        {
+            "name": "Organic Cane Sugar",
+            "confidence": 0.92,
+            "source_line": "ORG CANE SUGAR 3.49",
+            "price": 3.49,
+            "category": "dry_goods",
+            "storage_location": "pantry",
+            "quantity": 1.0,
+            "unit": "bag",
+            "expiry_date": "2027-01-01",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        }
+    ]
+    state = _minimal_state(items, base_confidence=0.7)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+    action = result["actions"][0]
+    assert action.source_line == "ORG CANE SUGAR 3.49"
+    assert action.price == pytest.approx(3.49)
+
+
+def test_spine_sets_none_source_line_and_price_for_product_items() -> None:
+    """Product items (no source_line/price keys) get None for both fields."""
+    items = [
+        {
+            "name": "organic milk",
+            "category": "dairy",
+            "storage_location": "fridge",
+            "quantity": 1.0,
+            "unit": "gallon",
+            "expiry_date": "2026-12-31",
+            "estimated_expiry": True,
+            "purchase_date": "2026-08-25",
+        }
+    ]
+    state = _minimal_state(items, base_confidence=0.85)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+    action = result["actions"][0]
+    assert action.source_line is None
+    assert action.price is None
+
+
+# ---------------------------------------------------------------------------
+# 5. scan response shape (unit test over the response-building code path)
+# ---------------------------------------------------------------------------
+
+
+def _build_scan_item_from_action(action: PantryUpsertAction) -> dict:
+    """Mirror the dict-building logic in scan.py so we can test it without HTTP."""
+    pantry_item = action.item
+    return {
+        "name": pantry_item.name,
+        "original_name": pantry_item.original_name or pantry_item.name,
+        "source_line": action.source_line or "",
+        "price": action.price,
+        "quantity": pantry_item.quantity,
+        "unit": pantry_item.unit,
+        "category": pantry_item.category.value if hasattr(pantry_item.category, "value") else str(pantry_item.category),
+        "location": str(pantry_item.storage_location),
+        "confidence": action.confidence,
+    }
+
+
+def test_scan_response_includes_original_name_source_line_price() -> None:
+    """Scan response dict carries original_name, source_line, and price per item."""
+    import uuid
+
+    pantry_item = PantryItem(
+        id=uuid.uuid4(),
+        name="cane sugar",
+        original_name="Organic Cane Sugar",
+        category=FoodCategory.DRY_GOODS,
+    )
+    action = PantryUpsertAction(
+        action_type=ActionType.ADD,
+        item=pantry_item,
+        confidence=0.92,
+        source_line="ORG CANE SUGAR 3.49",
+        price=3.49,
+    )
+
+    item_dict = _build_scan_item_from_action(action)
+
+    assert item_dict["name"] == "cane sugar"
+    assert item_dict["original_name"] == "Organic Cane Sugar"
+    assert item_dict["source_line"] == "ORG CANE SUGAR 3.49"
+    assert item_dict["price"] == pytest.approx(3.49)
+    assert item_dict["confidence"] == pytest.approx(0.92)
+
+
+def test_scan_response_has_empty_source_line_when_none() -> None:
+    """source_line defaults to empty string when action.source_line is None."""
+    import uuid
+
+    pantry_item = PantryItem(
+        id=uuid.uuid4(),
+        name="milk",
+        original_name="Organic Whole Milk",
+        category=FoodCategory.DAIRY,
+    )
+    action = PantryUpsertAction(
+        action_type=ActionType.ADD,
+        item=pantry_item,
+        confidence=0.88,
+        source_line=None,
+        price=None,
+    )
+    item_dict = _build_scan_item_from_action(action)
+    assert item_dict["source_line"] == ""
+    assert item_dict["price"] is None
+
+
+# ---------------------------------------------------------------------------
+# 6. Varying confidence tiers (six-item scenario)
+# ---------------------------------------------------------------------------
+
+
+def test_six_items_produce_varying_confidences() -> None:
+    """Six items with different per-item confidences are tiered independently."""
+    items = [
+        {"name": "eggs", "confidence": 0.95, "category": "dairy",
+         "storage_location": "fridge", "quantity": 1.0, "unit": "dozen",
+         "expiry_date": "2026-12-31", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+        {"name": "Organic Cane Sugar", "confidence": 0.90, "category": "dry_goods",
+         "storage_location": "pantry", "quantity": 1.0, "unit": "bag",
+         "expiry_date": "2027-06-30", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+        {"name": "Italian Bomba Hot Pepper", "confidence": 0.82, "category": "condiments",
+         "storage_location": "pantry", "quantity": 1.0, "unit": "jar",
+         "expiry_date": "2027-01-01", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+        {"name": "Milk Chocolate Almonds", "confidence": 0.75, "category": "snacks",
+         "storage_location": "pantry", "quantity": 1.0, "unit": "bag",
+         "expiry_date": "2026-12-01", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+        {"name": "baguette", "confidence": 0.65, "category": "bakery",
+         "storage_location": "counter", "quantity": 1.0, "unit": "loaf",
+         "expiry_date": "2026-08-28", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+        {"name": "T Premium Filler Assorted", "confidence": 0.40, "category": "other",
+         "storage_location": "pantry", "quantity": 1.0, "unit": "item",
+         "expiry_date": "2026-12-31", "estimated_expiry": True, "purchase_date": "2026-08-25"},
+    ]
+    state = _minimal_state(items, base_confidence=0.7)
+    result = build_actions_from_normalized(state, reasoning_for_item=lambda d: "test")
+    actions = result["actions"]
+
+    assert len(actions) == 6
+    confidences = [a.confidence for a in actions]
+    # Confidences must vary — not all the same batch value
+    assert len(set(confidences)) > 1
+
+    # Tiers as the scan route would compute them
+    ready = [a for a in actions if a.confidence >= 0.8]
+    review = [a for a in actions if 0.5 <= a.confidence < 0.8]
+    skipped = [a for a in actions if a.confidence < 0.5]
+
+    assert len(ready) == 3    # 0.95, 0.90, 0.82
+    assert len(review) == 2   # 0.75, 0.65
+    assert len(skipped) == 1  # 0.40

--- a/docs/plans/2026-08-19-receipt-scan-rework.md
+++ b/docs/plans/2026-08-19-receipt-scan-rework.md
@@ -1,0 +1,290 @@
+# Receipt Scan Rework
+
+**Date:** 2026-08-19
+**Status:** Approved, ready to build
+**Baseline:** `main` @ `7c7e8b1`
+**Rendered version:** https://claude.ai/code/artifact/5c31019a-8a0e-46d1-a258-c58584f7a01e
+
+A real six-item Trader Joe's receipt scanned cleanly, reached Gemini Vision, and
+returned zero items. Six independent causes sit behind that zero. Two are fixed
+by deleting code.
+
+---
+
+## Headline
+
+`ai-service/bubbly_chef/services/image_preprocessor.py` still describes itself as
+*"Preprocesses receipt images for optimal **Tesseract** OCR performance."*
+Tesseract was replaced by Gemini Vision in `21af234`. The pipeline stayed, and
+stayed on by default. Binarization, aggressive contrast, denoising, deskewing and
+edge-detection cropping are classical-OCR techniques for an engine that is no
+longer in this codebase — and a vision model reads an ordinary phone photo better
+without any of them.
+
+## What happened
+
+`_preprocess_auto` crops the receipt, then delegates to `_preprocess_aggressive`,
+which crops **again** — re-running edge detection on an image that is already
+nothing but receipt.
+
+| Stage | Height | Retained |
+|---|---|---|
+| Original | 3419 px | — |
+| After crop #1 | 1944 px | 57% |
+| After crop #2 | 992 px | **29%** |
+
+The surviving 29% is the store header. The item list begins below that line and
+never reached the model. Gemini behaved correctly on an image containing no
+items and logged `parsed 0 items with confidence 0.0`. The `-15°` deskew applied
+to a straight-on photo is the same bug's second symptom — the angle is computed
+from a mis-cropped fragment.
+
+---
+
+## The six causes
+
+### 1. Double crop discards the item list — FATAL
+
+Two `_crop_receipt` calls on one image in the auto→aggressive path.
+
+`image_preprocessor.py:159` (auto) → `:217` (aggressive)
+
+### 2. The non-food filter eats real food — silent data loss
+
+Substring matching against a keyword list:
+
+```python
+if any(kw in name for kw in filter_keywords):
+```
+
+`"bag"` kills **baguette**, **bagel**, **cabbage**. `"cash"` kills **cashews**.
+`"date"` kills **dates**. It runs *after* the LLM, which the prompt already
+instructs to skip non-food — so the cruder filter silently overrides the smarter
+one.
+
+`receipt_ingest.py:194`
+
+### 3. The normalizer collapses distinct foods together — quality
+
+Same disease, different file. `FoodNormalizer.normalize` does **bidirectional
+substring** matching against the synonym table and returns the first dict hit,
+so the result also depends on insertion order:
+
+```python
+for synonym, normalized in self._reverse_synonyms.items():
+    if synonym in cleaned or cleaned in synonym:
+        return normalized
+```
+
+Measured:
+
+| Input | Output |
+|---|---|
+| `italian bomba hot pepper` | **black pepper** |
+| `milk chocolate` | **milk** |
+| `red pepper flakes` | **bell pepper** |
+| `org cane sugar` | **sugar** |
+| `cream cheese` | **cheese** |
+
+`tools/normalizer.py:343` — used by receipt **and** product ingest.
+
+**The codebase already solved this once.** `domain/normalizer.py`, written during
+the #221 density work, uses head-noun matching precisely so `almond milk`
+inherits milk's density while `milk chocolate` and `flour tortilla` resolve to
+nothing. There are two normalizers with opposite philosophies and the receipt
+path uses the naive one. The fix is to route through the careful matcher, not to
+patch the substring loop.
+
+### 4. Per-item confidence exists and is thrown away — design
+
+`LLMParsedItem.confidence` is already in the schema, documented "Per-item
+confidence", and survives `model_dump()` into the item dict. The shared spine
+ignores it and stamps one batch-level number onto every action, so the three
+tiers can never separate two items on one receipt.
+
+`shared_state.py:48` defines it · `ingest_spine.py:71,110` discards it
+
+### 5. The OCR penalty puts auto-add out of reach — design
+
+`result.confidence * 0.9` means the model must return ≥ 0.889 to clear the 0.8
+auto-add threshold. Gemini returned a sensible 0.8 → 0.72 → everything lands in
+"needs review", every time.
+
+`receipt_ingest.py:130`
+
+### 6. The prompt never asks to keep the product — quality
+
+It says "expand abbreviations" but never *preserve the product name*, and asks
+for one confidence "based on how clear the receipt text is" — a document-level
+number by construction. It also never carries the raw receipt line forward.
+
+`receipt_ingest.py:38` `RECEIPT_PARSE_SYSTEM_PROMPT`
+
+---
+
+## The pipeline, after
+
+| Stage | Today | Proposed |
+|---|---|---|
+| preprocess | on by default, crops twice | off by default; opt-in retry, single crop |
+| OCR | Gemini Vision | unchanged |
+| LLM parse | one confidence; genericizes; drops raw line | per-item confidence; keeps product; carries `source_line` |
+| clean | substring non-food filter | deleted — the model does this with context |
+| normalize | bidirectional substring collapse | head-noun matcher from `domain/normalizer.py` |
+| tiering | batch × 0.9 → one tier for all | per-item → tiers actually separate |
+
+---
+
+## Review screen
+
+Confident items arrive **pre-checked but still behind the Add button** — nothing
+is written on sight, which keeps the proposal pattern intact. Uncertain items
+arrive unchecked. Every card carries an **eye icon-button** that toggles a raw
+face open *beneath* the parsed fields, so the guess and its evidence read
+together.
+
+- Tooltip and `aria-label`: **"See raw frame data"** / **"Hide raw frame data"**
+- Raw face shows: receipt line, price, parsed-as name
+- Reuse `Chip` tone tokens so scan review matches the chat surface
+
+This matters most for a line like `T PREMIUM FILLER ASST.`, where the parsed name
+is meaningless alone and the receipt line is the only thing that lets the user
+judge it.
+
+**Non-food is handled without asking.** The receipt contained actual flowers —
+`T PREMIUM FILLER ASST.` is floral filler, and the model filed it as `dry_goods`.
+Non-food detection stays entirely in the prompt, where the model has context, and
+never becomes a user decision. A wrong call lands an odd item in the
+low-confidence tier, which is exactly where the raw line makes it obvious and one
+tap removes it.
+
+---
+
+## Pinned API contract
+
+Frozen so the frontend slice can be built in parallel with the backend slice.
+**Any change to this shape needs both agents notified.**
+
+```ts
+// nextjs/src/types/scan.ts
+export interface ScannedItem {
+  name:          string   // normalized display name  → "Italian Bomba Hot Pepper Spread"
+  original_name: string   // LLM parse, pre-normalize → "italian bomba hot pepper"
+  source_line:   string   // raw OCR receipt line     → "ITALIAN BOMBA HOT PEPPER"
+  price:         number | null
+  quantity:      number
+  unit:          string
+  category:      string
+  location:      string
+  confidence:    number   // PER ITEM — 0..1
+}
+
+export interface ScanResult {
+  ocr_text:      string
+  ready_to_add:  ScannedItem[]   // confidence >= 0.8  → pre-checked
+  needs_review:  ScannedItem[]   // 0.5 .. 0.8         → unchecked
+  skipped:       ScannedItem[]   // < 0.5              → unchecked, collapsed
+  total_items:   number
+  warnings:      string[]        // always present, may be empty
+}
+```
+
+Two notes:
+
+- `warnings` becomes part of the normal shape. Today the empty-OCR path returns a
+  *different* object (`{ocr_text, items, warnings}`) that `ScanResult` never
+  declared, so `ScanTab.tsx:51-53` sets three arrays to `undefined` and the
+  message explaining why is never shown.
+- `original_name` **already travels the whole pipeline** — `normalize_receipt_items`
+  records it, `PantryItem.original_name` holds it, `ingest_spine` populates it. It
+  is dropped only when `scan.py` hand-builds the response dict.
+
+---
+
+## Build plan
+
+Wave 2's two slices touch disjoint trees (`ai-service/` vs `nextjs/`) and both
+code to the pinned contract, so they run in parallel.
+
+### Slice 1 — Restore the flow (wave 1, backend)
+
+- Default `preprocess` to **false** in the scan route; keep the pipeline
+  reachable as an explicit opt-in retry
+- Remove the duplicate `_crop_receipt` call so the opt-in path is not broken either
+- Delete `clean_receipt_items`'s substring filter entirely
+- Make the empty-OCR path return the normal `ScanResult` shape with populated `warnings`
+
+Files: `api/routes/scan.py` · `services/image_preprocessor.py` · `workflows/receipt_ingest.py`
+
+**Acceptance:** the Trader Joe's fixture returns its six items, baguette included.
+A deliberately blank image returns an empty `ScanResult` with a warning, not
+undefined arrays.
+
+### Slice 2 — Parse and normalize quality (wave 2, backend)
+
+- Read `item["confidence"]` in `build_actions_from_normalized`, falling back to the batch value
+- Re-tune or drop the `× 0.9` penalty so the top tier is reachable
+- Prompt: emit confidence *per item*, preserve the product name, return `source_line` and `price`
+- Route receipt normalization through `domain/normalizer.py`'s head-noun matcher
+- Expose `original_name`, `source_line`, `price` in the scan response
+
+Files: `workflows/ingest_spine.py` · `workflows/receipt_ingest.py` · `tools/normalizer.py` · `domain/normalizer.py` · `api/routes/scan.py`
+
+**Acceptance:** six items with *varying* confidence; `ORG CANE SUGAR` stays cane
+sugar; `ITALIAN BOMBA HOT PEPPER` is not black pepper; `milk chocolate` does not
+become milk. Product-ingest tests still pass — the spine is shared.
+
+### Slice 3 — Review screen (wave 2, frontend)
+
+- Tier sections with header pills; confident items pre-checked, others unchecked
+- One consistent item card; eye icon-button toggling the raw face open beneath the fields
+- Tooltip + `aria-label`: "See raw frame data" / "Hide raw frame data"
+- Reuse `Chip` tone tokens
+
+Files: `components/scan/ScanResults.tsx` · `components/pantry/ScanTab.tsx` · `types/scan.ts`
+
+**Acceptance:** against a stubbed `ScanResult` matching the pinned contract —
+tiers render, confident rows start checked, the eye toggles the raw face,
+keyboard focus is visible, and the Add button count tracks the checked set.
+
+### Slice 4 — Fixture corpus + regression tests (wave 3)
+
+- Receipts committed with an expected-items JSON beside each
+- Deterministic tests at the parse seam so the suite stays CI-safe
+- The Trader Joe's receipt is fixture #1 and pins every case above
+
+Files: `nextjs/e2e/fixtures/receipts/` · `ai-service/tests/`
+
+**Acceptance:** each fixture's parse output matches its expected JSON within a
+tolerance for confidence values. Blocked on receipt collection.
+
+---
+
+## Deliberately not doing
+
+- **Deleting the preprocessor outright.** Demoted, not removed. A genuinely dark
+  or skewed photo may still benefit, and an explicit "didn't work? try enhanced"
+  retry costs nothing once it stops running by default.
+- **Writing items to the pantry on high confidence.** Pre-checked, not
+  auto-written. `CLAUDE.md`'s rule that nothing reaches the database without
+  explicit confirmation stands.
+- **Unifying the two normalizers.** Slice 2 routes the receipt path to the good
+  matcher. Actually merging `tools/normalizer.py` into `domain/normalizer.py`
+  touches the chat and product paths too and deserves its own issue.
+- **Routing receipts through the `/ingest` dispatcher.** Unrelated to this
+  failure, tracked under the R4 issues (#204/#207/#188). Nothing here depends on it.
+
+---
+
+## Provenance
+
+Every claim was reproduced against `main` @ `7c7e8b1`:
+
+- Crop ratios from the production Railway logs for the failing scan
+- Parse and normalizer behavior by replaying the receipt through
+  `run_receipt_ingest` and `FoodNormalizer.normalize` with the live Gemini key
+- Filter collisions by running the keyword list against real food names
+
+Corrected since the first draft: an earlier version stated the normalizer was
+innocent. That came from testing `domain/normalizer.py` when the workflow
+actually calls `tools/normalizer.py`.

--- a/nextjs/src/__tests__/scan-review.test.tsx
+++ b/nextjs/src/__tests__/scan-review.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Slice 3 — Review screen tests
+ *
+ * Tests cover: tier rendering, pre-checked state for ready_to_add, unchecked state
+ * for needs_review/skipped, eye-toggle raw face, Add button count tracking,
+ * warnings banner, and keyboard accessibility.
+ *
+ * The ScanResult stub matches the pinned contract exactly from
+ * docs/plans/2026-08-19-receipt-scan-rework.md.
+ */
+
+import React from 'react'
+import { render, screen, within, fireEvent, waitFor } from '@testing-library/react'
+import ScanResults from '@/components/scan/ScanResults'
+import ScannedItemCard from '@/components/scan/ScannedItemCard'
+import type { ScannedItem, ScanResult } from '@/types/scan'
+
+// ─── Test stub matching the pinned contract ───────────────────────────────────
+
+const READY_ITEM: ScannedItem = {
+  name: 'Italian Bomba Hot Pepper Spread',
+  original_name: 'italian bomba hot pepper',
+  source_line: 'ITALIAN BOMBA HOT PEPPER',
+  price: 3.99,
+  quantity: 1,
+  unit: 'jar',
+  category: 'condiments',
+  location: 'pantry',
+  confidence: 0.92,
+}
+
+const REVIEW_ITEM: ScannedItem = {
+  name: 'Organic Cane Sugar',
+  original_name: 'org cane sugar',
+  source_line: 'ORG CANE SUGAR',
+  price: 2.49,
+  quantity: 1,
+  unit: 'bag',
+  category: 'dry_goods',
+  location: 'pantry',
+  confidence: 0.65,
+}
+
+const SKIPPED_ITEM: ScannedItem = {
+  name: 'T Premium Filler Assortment',
+  original_name: 't premium filler asst',
+  source_line: 'T PREMIUM FILLER ASST.',
+  price: 8.99,
+  quantity: 1,
+  unit: 'bunch',
+  category: 'dry_goods',
+  location: 'pantry',
+  confidence: 0.35,
+}
+
+const STUB_RESULT: ScanResult = {
+  ocr_text: 'TRADER JOES\nITALIAN BOMBA HOT PEPPER 3.99\nORG CANE SUGAR 2.49\nT PREMIUM FILLER ASST. 8.99',
+  ready_to_add: [READY_ITEM],
+  needs_review: [REVIEW_ITEM],
+  skipped: [SKIPPED_ITEM],
+  total_items: 3,
+  warnings: [],
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function noop() {}
+
+function renderResults(overrides: Partial<{
+  readyToAdd: ScannedItem[]
+  needsReview: ScannedItem[]
+  skipped: ScannedItem[]
+  warnings: string[]
+  hideConfirmButton: boolean
+  isSubmitting: boolean
+  onConfirm: (items: ScannedItem[]) => void
+}> = {}) {
+  const props = {
+    readyToAdd: STUB_RESULT.ready_to_add,
+    needsReview: STUB_RESULT.needs_review,
+    skipped: STUB_RESULT.skipped,
+    warnings: STUB_RESULT.warnings,
+    onReadyChange: noop,
+    onReviewChange: noop,
+    onSkippedChange: noop,
+    onConfirm: noop,
+    isSubmitting: false,
+    ...overrides,
+  }
+  return render(<ScanResults {...props} />)
+}
+
+// ─── 1. Tier sections render ──────────────────────────────────────────────────
+
+it('renders all three tier section headers', () => {
+  renderResults()
+  expect(screen.getByText(/Ready to Add/)).toBeInTheDocument()
+  expect(screen.getByText(/Needs Review/)).toBeInTheDocument()
+  expect(screen.getByText(/Skipped/)).toBeInTheDocument()
+})
+
+it('shows item counts in tier headers', () => {
+  renderResults()
+  expect(screen.getByText(/Ready to Add \(1\)/)).toBeInTheDocument()
+  expect(screen.getByText(/Needs Review \(1\)/)).toBeInTheDocument()
+  expect(screen.getByText(/Skipped \(1\)/)).toBeInTheDocument()
+})
+
+// ─── 2. Pre-checked state ─────────────────────────────────────────────────────
+
+it('ready_to_add items start pre-checked', () => {
+  renderResults()
+  const checkbox = screen.getByRole('checkbox', {
+    name: new RegExp(`Include ${READY_ITEM.name}`, 'i'),
+  })
+  expect(checkbox).toBeChecked()
+})
+
+it('needs_review items start unchecked', () => {
+  renderResults()
+  const checkbox = screen.getByRole('checkbox', {
+    name: new RegExp(`Include ${REVIEW_ITEM.name}`, 'i'),
+  })
+  expect(checkbox).not.toBeChecked()
+})
+
+// ─── 3. Add button count tracks the checked set ───────────────────────────────
+
+it('Add button shows count of checked items (1 ready pre-checked, 0 review)', () => {
+  renderResults({ hideConfirmButton: false })
+  // Only the one ready item is pre-checked
+  expect(screen.getByRole('button', { name: /Add 1 Item to Pantry/i })).toBeInTheDocument()
+})
+
+it('Add button count increases when a review item is checked', () => {
+  renderResults({ hideConfirmButton: false })
+  const reviewCheckbox = screen.getByRole('checkbox', {
+    name: new RegExp(`Include ${REVIEW_ITEM.name}`, 'i'),
+  })
+  fireEvent.click(reviewCheckbox)
+  expect(screen.getByRole('button', { name: /Add 2 Items to Pantry/i })).toBeInTheDocument()
+})
+
+it('Add button count decreases when a ready item is unchecked', () => {
+  renderResults({ hideConfirmButton: false })
+  const readyCheckbox = screen.getByRole('checkbox', {
+    name: new RegExp(`Include ${READY_ITEM.name}`, 'i'),
+  })
+  fireEvent.click(readyCheckbox)
+  expect(screen.getByRole('button', { name: /No items selected/i })).toBeInTheDocument()
+})
+
+it('Add button is disabled when no items are checked', () => {
+  renderResults({ readyToAdd: [], needsReview: [], skipped: [], hideConfirmButton: false })
+  const btn = screen.getByRole('button', { name: /No items selected/i })
+  expect(btn).toBeDisabled()
+})
+
+it('onConfirm is called with only the checked items', () => {
+  const onConfirm = jest.fn()
+  renderResults({ hideConfirmButton: false, onConfirm })
+
+  // Only ready item is pre-checked; click confirm
+  fireEvent.click(screen.getByRole('button', { name: /Add 1 Item to Pantry/i }))
+  expect(onConfirm).toHaveBeenCalledTimes(1)
+  const called: ScannedItem[] = onConfirm.mock.calls[0][0]
+  expect(called).toHaveLength(1)
+  expect(called[0].name).toBe(READY_ITEM.name)
+})
+
+// ─── 4. Eye toggle ────────────────────────────────────────────────────────────
+
+it('eye button has correct aria-label before toggle', () => {
+  render(
+    <ScannedItemCard
+      item={READY_ITEM}
+      index={0}
+      checked
+      onChange={noop}
+      onDismiss={noop}
+      onCheckedChange={noop}
+    />,
+  )
+  expect(screen.getByRole('button', { name: 'See raw frame data' })).toBeInTheDocument()
+})
+
+it('eye toggle reveals raw face with source_line and original_name', () => {
+  render(
+    <ScannedItemCard
+      item={READY_ITEM}
+      index={0}
+      checked
+      onChange={noop}
+      onDismiss={noop}
+      onCheckedChange={noop}
+    />,
+  )
+  const eyeBtn = screen.getByRole('button', { name: 'See raw frame data' })
+  fireEvent.click(eyeBtn)
+
+  expect(screen.getByText('ITALIAN BOMBA HOT PEPPER')).toBeInTheDocument()
+  expect(screen.getByText('italian bomba hot pepper')).toBeInTheDocument()
+  expect(screen.getByText('$3.99')).toBeInTheDocument()
+})
+
+it('eye button label changes to "Hide raw frame data" after toggle', () => {
+  render(
+    <ScannedItemCard
+      item={READY_ITEM}
+      index={0}
+      checked
+      onChange={noop}
+      onDismiss={noop}
+      onCheckedChange={noop}
+    />,
+  )
+  const eyeBtn = screen.getByRole('button', { name: 'See raw frame data' })
+  fireEvent.click(eyeBtn)
+  expect(screen.getByRole('button', { name: 'Hide raw frame data' })).toBeInTheDocument()
+})
+
+it('eye toggle closes the raw face on second click', async () => {
+  render(
+    <ScannedItemCard
+      item={READY_ITEM}
+      index={0}
+      checked
+      onChange={noop}
+      onDismiss={noop}
+      onCheckedChange={noop}
+    />,
+  )
+  const eyeBtn = screen.getByRole('button', { name: 'See raw frame data' })
+  fireEvent.click(eyeBtn)
+  fireEvent.click(screen.getByRole('button', { name: 'Hide raw frame data' }))
+  // AnimatePresence exit animation keeps element briefly; wait for removal
+  await waitFor(() =>
+    expect(screen.queryByText('ITALIAN BOMBA HOT PEPPER')).not.toBeInTheDocument(),
+  )
+})
+
+it('null price renders as dash in raw face', () => {
+  const noPrice = { ...READY_ITEM, price: null }
+  render(
+    <ScannedItemCard
+      item={noPrice}
+      index={0}
+      checked
+      onChange={noop}
+      onDismiss={noop}
+      onCheckedChange={noop}
+    />,
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'See raw frame data' }))
+  // Should display '—' for missing price
+  const rawSection = screen.getByText('Raw frame data').closest('div')!
+  expect(within(rawSection).getAllByText('—').length).toBeGreaterThan(0)
+})
+
+// ─── 5. Warnings banner ───────────────────────────────────────────────────────
+
+it('renders warnings when present', () => {
+  renderResults({ warnings: ['No items found on receipt.', 'Image quality was low.'] })
+  expect(screen.getByText('No items found on receipt.')).toBeInTheDocument()
+  expect(screen.getByText('Image quality was low.')).toBeInTheDocument()
+})
+
+it('does not render warnings banner when warnings array is empty', () => {
+  const { container } = renderResults({ warnings: [] })
+  // The yellow warning box should not be present
+  expect(container.querySelector('.bg-yellow-50')).toBeNull()
+})
+
+// ─── 6. ScannedItem contract shape ────────────────────────────────────────────
+// Ensure the pinned fields are accepted without TypeScript errors (compile-time
+// mostly, but we double-check the shape at runtime here too).
+
+it('ScannedItem has all pinned contract fields', () => {
+  const item: ScannedItem = READY_ITEM
+  expect(typeof item.name).toBe('string')
+  expect(typeof item.original_name).toBe('string')
+  expect(typeof item.source_line).toBe('string')
+  expect(typeof item.price === 'number' || item.price === null).toBe(true)
+  expect(typeof item.quantity).toBe('number')
+  expect(typeof item.unit).toBe('string')
+  expect(typeof item.category).toBe('string')
+  expect(typeof item.location).toBe('string')
+  expect(typeof item.confidence).toBe('number')
+})
+
+it('ScanResult has all pinned contract fields', () => {
+  const result: ScanResult = STUB_RESULT
+  expect(typeof result.ocr_text).toBe('string')
+  expect(Array.isArray(result.ready_to_add)).toBe(true)
+  expect(Array.isArray(result.needs_review)).toBe(true)
+  expect(Array.isArray(result.skipped)).toBe(true)
+  expect(typeof result.total_items).toBe('number')
+  expect(Array.isArray(result.warnings)).toBe(true)
+})

--- a/nextjs/src/components/pantry/ScanTab.tsx
+++ b/nextjs/src/components/pantry/ScanTab.tsx
@@ -35,6 +35,7 @@ export default function ScanTab({ onItemsReady }: ScanTabProps) {
   const [readyToAdd, setReadyToAdd] = useState<ScannedItem[]>([])
   const [needsReview, setNeedsReview] = useState<ScannedItem[]>([])
   const [skipped, setSkipped] = useState<ScannedItem[]>([])
+  const [warnings, setWarnings] = useState<string[]>([])
 
   function notifyParent(ready: ScannedItem[], review: ScannedItem[]) {
     onItemsReady([...ready, ...review].map(scannedToAddItem))
@@ -51,6 +52,7 @@ export default function ScanTab({ onItemsReady }: ScanTabProps) {
       setReadyToAdd(result.ready_to_add)
       setNeedsReview(result.needs_review)
       setSkipped(result.skipped)
+      setWarnings(result.warnings ?? [])
       setState('results')
       notifyParent(result.ready_to_add, result.needs_review)
     } catch (err) {
@@ -68,6 +70,7 @@ export default function ScanTab({ onItemsReady }: ScanTabProps) {
     setReadyToAdd([])
     setNeedsReview([])
     setSkipped([])
+    setWarnings([])
     onItemsReady([])
     if (inputRef.current) inputRef.current.value = ''
   }
@@ -186,6 +189,7 @@ export default function ScanTab({ onItemsReady }: ScanTabProps) {
               readyToAdd={readyToAdd}
               needsReview={needsReview}
               skipped={skipped}
+              warnings={warnings}
               onReadyChange={handleReadyChange}
               onReviewChange={handleReviewChange}
               onSkippedChange={setSkipped}

--- a/nextjs/src/components/scan/ScanResults.tsx
+++ b/nextjs/src/components/scan/ScanResults.tsx
@@ -1,66 +1,104 @@
 'use client'
 
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import type { ScannedItem } from '@/types/scan'
 import ScannedItemCard from './ScannedItemCard'
+import Chip from '@/components/ui/Chip'
+import type { ChipTone } from '@/components/ui/Chip'
 
 interface ScanResultsProps {
   readyToAdd: ScannedItem[]
   needsReview: ScannedItem[]
   skipped: ScannedItem[]
+  warnings?: string[]
   onReadyChange: (items: ScannedItem[]) => void
   onReviewChange: (items: ScannedItem[]) => void
   onSkippedChange: (items: ScannedItem[]) => void
-  onConfirm: () => void
+  onConfirm: (checkedItems: ScannedItem[]) => void
   isSubmitting: boolean
   /** When true, hides the built-in confirm button (used when embedded in PantryAddSheet) */
   hideConfirmButton?: boolean
 }
 
+// ─── Stable item key ──────────────────────────────────────────────────────────
+// source_line is unique per receipt OCR row; fall back to name+index.
+function itemKey(item: ScannedItem, index: number): string {
+  return item.source_line || `${item.name}-${index}`
+}
+
+// ─── Tier header pill ─────────────────────────────────────────────────────────
+interface TierHeaderProps {
+  label: string
+  emoji: string
+  count: number
+  tone: ChipTone
+  open: boolean
+  onToggle: () => void
+}
+
+function TierHeader({ label, emoji, count, tone, open, onToggle }: TierHeaderProps) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      aria-label={`${label} section, ${count} item${count !== 1 ? 's' : ''}`}
+      className="w-full flex items-center justify-between mb-2 transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)] rounded-full"
+    >
+      <Chip tone={tone} size="md" emoji={emoji}>
+        {label} ({count})
+      </Chip>
+      <motion.span
+        animate={{ rotate: open ? 0 : -90 }}
+        transition={{ duration: 0.2 }}
+        className="text-xs text-[var(--color-muted)] pr-1"
+        aria-hidden
+      >
+        ▼
+      </motion.span>
+    </button>
+  )
+}
+
+// ─── Tier section ─────────────────────────────────────────────────────────────
 interface TierSectionProps {
-  title: string
-  dot: string
-  headerClass: string
+  label: string
+  emoji: string
+  tone: ChipTone
   items: ScannedItem[]
+  checkedKeys: Set<string>
   defaultOpen?: boolean
-  globalIndex: number
+  globalOffset: number
   onItemChange: (index: number, updated: ScannedItem) => void
   onItemDismiss: (index: number) => void
+  onCheckedChange: (key: string, checked: boolean) => void
 }
 
 function TierSection({
-  title,
-  dot,
-  headerClass,
+  label,
+  emoji,
+  tone,
   items,
+  checkedKeys,
   defaultOpen = true,
-  globalIndex,
+  globalOffset,
   onItemChange,
   onItemDismiss,
+  onCheckedChange,
 }: TierSectionProps) {
   const [open, setOpen] = useState(defaultOpen)
 
   return (
     <div className="mb-4">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className={`w-full flex items-center justify-between px-4 py-2.5 rounded-2xl font-semibold text-sm ${headerClass} transition-opacity hover:opacity-90`}
-      >
-        <span className="flex items-center gap-2">
-          <span>{dot}</span>
-          <span>{title}</span>
-          <span className="ml-1 font-normal opacity-70">({items.length})</span>
-        </span>
-        <motion.span
-          animate={{ rotate: open ? 0 : -90 }}
-          transition={{ duration: 0.2 }}
-          className="text-xs"
-        >
-          ▼
-        </motion.span>
-      </button>
+      <TierHeader
+        label={label}
+        emoji={emoji}
+        count={items.length}
+        tone={tone}
+        open={open}
+        onToggle={() => setOpen((o) => !o)}
+      />
 
       <AnimatePresence initial={false}>
         {open && items.length > 0 && (
@@ -73,15 +111,20 @@ function TierSection({
             style={{ overflow: 'hidden' }}
           >
             <div className="mt-2 space-y-2">
-              {items.map((item, i) => (
-                <ScannedItemCard
-                  key={`${item.name}-${globalIndex + i}`}
-                  item={item}
-                  index={i}
-                  onChange={(updated) => onItemChange(i, updated)}
-                  onDismiss={() => onItemDismiss(i)}
-                />
-              ))}
+              {items.map((item, i) => {
+                const key = itemKey(item, globalOffset + i)
+                return (
+                  <ScannedItemCard
+                    key={key}
+                    item={item}
+                    index={i}
+                    checked={checkedKeys.has(key)}
+                    onChange={(updated) => onItemChange(i, updated)}
+                    onDismiss={() => onItemDismiss(i)}
+                    onCheckedChange={(c) => onCheckedChange(key, c)}
+                  />
+                )
+              })}
             </div>
           </motion.div>
         )}
@@ -96,10 +139,12 @@ function TierSection({
   )
 }
 
+// ─── Main component ───────────────────────────────────────────────────────────
 export default function ScanResults({
   readyToAdd,
   needsReview,
   skipped,
+  warnings = [],
   onReadyChange,
   onReviewChange,
   onSkippedChange,
@@ -107,7 +152,34 @@ export default function ScanResults({
   isSubmitting,
   hideConfirmButton = false,
 }: ScanResultsProps) {
-  const totalActive = readyToAdd.length + needsReview.length
+  // Seed: ready_to_add items start checked; needs_review and skipped start unchecked.
+  const initialCheckedKeys = useMemo(() => {
+    const keys = new Set<string>()
+    readyToAdd.forEach((item, i) => keys.add(itemKey(item, i)))
+    return keys
+    // We only want the seed once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const [checkedKeys, setCheckedKeys] = useState<Set<string>>(initialCheckedKeys)
+
+  function toggleKey(key: string, checked: boolean) {
+    setCheckedKeys((prev) => {
+      const next = new Set(prev)
+      if (checked) next.add(key)
+      else next.delete(key)
+      return next
+    })
+  }
+
+  // Remove a key from the checked set when its item is dismissed.
+  function dismissKey(key: string) {
+    setCheckedKeys((prev) => {
+      const next = new Set(prev)
+      next.delete(key)
+      return next
+    })
+  }
 
   function removeAt(list: ScannedItem[], i: number): ScannedItem[] {
     return list.filter((_, idx) => idx !== i)
@@ -116,67 +188,112 @@ export default function ScanResults({
     return list.map((el, idx) => (idx === i ? item : el))
   }
 
+  // Collect all currently-visible checked items in tier order for the confirm handler.
+  const checkedItems = useMemo(() => {
+    const allWithKeys: Array<{ key: string; item: ScannedItem }> = [
+      ...readyToAdd.map((item, i) => ({ key: itemKey(item, i), item })),
+      ...needsReview.map((item, i) => ({
+        key: itemKey(item, readyToAdd.length + i),
+        item,
+      })),
+      ...skipped.map((item, i) => ({
+        key: itemKey(item, readyToAdd.length + needsReview.length + i),
+        item,
+      })),
+    ]
+    return allWithKeys.filter(({ key }) => checkedKeys.has(key)).map(({ item }) => item)
+  }, [readyToAdd, needsReview, skipped, checkedKeys])
+
+  const checkedCount = checkedItems.length
+
   return (
     <div>
+      {/* Warnings banner */}
+      {warnings.length > 0 && (
+        <div className="mb-4 px-4 py-3 bg-yellow-50 border border-yellow-200 text-yellow-800 rounded-2xl text-sm space-y-1">
+          {warnings.map((w, i) => (
+            <p key={i}>{w}</p>
+          ))}
+        </div>
+      )}
+
       {readyToAdd.length > 0 && (
         <TierSection
-          title="Ready to Add"
-          dot="✅"
-          headerClass="bg-green-50 text-green-800"
+          label="Ready to Add"
+          emoji="✅"
+          tone="fresh"
           items={readyToAdd}
+          checkedKeys={checkedKeys}
           defaultOpen={true}
-          globalIndex={0}
+          globalOffset={0}
           onItemChange={(i, updated) => onReadyChange(replaceAt(readyToAdd, i, updated))}
-          onItemDismiss={(i) => onReadyChange(removeAt(readyToAdd, i))}
+          onItemDismiss={(i) => {
+            const key = itemKey(readyToAdd[i], i)
+            dismissKey(key)
+            onReadyChange(removeAt(readyToAdd, i))
+          }}
+          onCheckedChange={toggleKey}
         />
       )}
 
       {needsReview.length > 0 && (
         <TierSection
-          title="Needs Review"
-          dot="⚠️"
-          headerClass="bg-yellow-50 text-yellow-800"
+          label="Needs Review"
+          emoji="⚠️"
+          tone="expiring"
           items={needsReview}
-          defaultOpen={false}
-          globalIndex={readyToAdd.length}
+          checkedKeys={checkedKeys}
+          defaultOpen={true}
+          globalOffset={readyToAdd.length}
           onItemChange={(i, updated) => onReviewChange(replaceAt(needsReview, i, updated))}
-          onItemDismiss={(i) => onReviewChange(removeAt(needsReview, i))}
+          onItemDismiss={(i) => {
+            const key = itemKey(needsReview[i], readyToAdd.length + i)
+            dismissKey(key)
+            onReviewChange(removeAt(needsReview, i))
+          }}
+          onCheckedChange={toggleKey}
         />
       )}
 
       {skipped.length > 0 && (
         <TierSection
-          title="Skipped"
-          dot="⏭️"
-          headerClass="bg-gray-50 text-gray-600"
+          label="Skipped"
+          emoji="⏭️"
+          tone="muted"
           items={skipped}
+          checkedKeys={checkedKeys}
           defaultOpen={false}
-          globalIndex={readyToAdd.length + needsReview.length}
+          globalOffset={readyToAdd.length + needsReview.length}
           onItemChange={(i, updated) => onSkippedChange(replaceAt(skipped, i, updated))}
-          onItemDismiss={(i) => onSkippedChange(removeAt(skipped, i))}
+          onItemDismiss={(i) => {
+            const key = itemKey(skipped[i], readyToAdd.length + needsReview.length + i)
+            dismissKey(key)
+            onSkippedChange(removeAt(skipped, i))
+          }}
+          onCheckedChange={toggleKey}
         />
       )}
 
       {/* Sticky footer CTA */}
       {!hideConfirmButton && (
-      <div className="sticky bottom-4 mt-4">
-        <motion.button
-          type="button"
-          onClick={onConfirm}
-          disabled={totalActive === 0 || isSubmitting}
-          whileHover={{ scale: totalActive === 0 || isSubmitting ? 1 : 1.02 }}
-          whileTap={{ scale: totalActive === 0 || isSubmitting ? 1 : 0.96 }}
-          transition={{ type: 'spring', stiffness: 400, damping: 17 }}
-          className="w-full py-4 rounded-full font-bold text-white shadow-lg transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
-          style={{ background: 'var(--color-primary-dark, #FF8FAB)' }}
-        >
-          {isSubmitting
-            ? 'Adding…'
-            : totalActive === 0
-              ? 'No items selected'
-              : `Add ${totalActive} Item${totalActive === 1 ? '' : 's'} to Pantry`}
-        </motion.button>
-      </div>
+        <div className="sticky bottom-4 mt-4">
+          <motion.button
+            type="button"
+            onClick={() => onConfirm(checkedItems)}
+            disabled={checkedCount === 0 || isSubmitting}
+            whileHover={{ scale: checkedCount === 0 || isSubmitting ? 1 : 1.02 }}
+            whileTap={{ scale: checkedCount === 0 || isSubmitting ? 1 : 0.96 }}
+            transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+            className="w-full py-4 rounded-full font-bold text-white shadow-lg transition-opacity disabled:opacity-50 disabled:cursor-not-allowed"
+            style={{ background: 'var(--color-primary-dark, #FF8FAB)' }}
+          >
+            {isSubmitting
+              ? 'Adding…'
+              : checkedCount === 0
+                ? 'No items selected'
+                : `Add ${checkedCount} Item${checkedCount === 1 ? '' : 's'} to Pantry`}
+          </motion.button>
+        </div>
       )}
     </div>
   )

--- a/nextjs/src/components/scan/ScannedItemCard.tsx
+++ b/nextjs/src/components/scan/ScannedItemCard.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { motion } from 'framer-motion'
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
 import type { ScannedItem } from '@/types/scan'
 import { getFoodEmoji } from '@/lib/food-emoji'
+import Chip from '@/components/ui/Chip'
 
 const CATEGORIES = [
   'produce',
@@ -18,10 +20,10 @@ const CATEGORIES = [
 
 const LOCATIONS = ['fridge', 'freezer', 'pantry', 'counter']
 
-function confidenceColor(confidence: number): string {
-  if (confidence >= 0.8) return 'bg-green-100 text-green-700'
-  if (confidence >= 0.5) return 'bg-yellow-100 text-yellow-700'
-  return 'bg-gray-100 text-gray-500'
+function confidenceChipTone(confidence: number): 'fresh' | 'expiring' | 'muted' {
+  if (confidence >= 0.8) return 'fresh'
+  if (confidence >= 0.5) return 'expiring'
+  return 'muted'
 }
 
 function confidenceLabel(confidence: number): string {
@@ -32,20 +34,28 @@ function confidenceLabel(confidence: number): string {
 
 interface ScannedItemCardProps {
   item: ScannedItem
+  checked: boolean
   onChange: (updated: ScannedItem) => void
   onDismiss: () => void
+  onCheckedChange: (checked: boolean) => void
   index?: number
 }
 
 export default function ScannedItemCard({
   item,
+  checked,
   onChange,
   onDismiss,
+  onCheckedChange,
   index = 0,
 }: ScannedItemCardProps) {
+  const [rawOpen, setRawOpen] = useState(false)
+
   function update<K extends keyof ScannedItem>(key: K, value: ScannedItem[K]) {
     onChange({ ...item, [key]: value })
   }
+
+  const rawLabel = rawOpen ? 'Hide raw frame data' : 'See raw frame data'
 
   return (
     <motion.div
@@ -55,22 +65,79 @@ export default function ScannedItemCard({
       transition={{ duration: 0.25, delay: index * 0.04 }}
       className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-4 relative"
     >
-      {/* Dismiss button */}
-      <button
-        type="button"
-        aria-label={`Dismiss ${item.name}`}
-        onClick={onDismiss}
-        className="absolute top-3 right-3 w-6 h-6 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors text-sm font-bold"
-      >
-        ×
-      </button>
+      {/* Top-right controls: eye toggle + dismiss */}
+      <div className="absolute top-3 right-3 flex items-center gap-1">
+        <button
+          type="button"
+          aria-label={rawLabel}
+          title={rawLabel}
+          onClick={() => setRawOpen((o) => !o)}
+          className="w-7 h-7 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)]"
+        >
+          {rawOpen ? (
+            /* eye-slash icon */
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+              className="w-4 h-4"
+            >
+              <path
+                fillRule="evenodd"
+                d="M3.28 2.22a.75.75 0 00-1.06 1.06l14.5 14.5a.75.75 0 101.06-1.06l-1.745-1.745a10.029 10.029 0 003.3-4.38 1.651 1.651 0 000-1.185A10.004 10.004 0 009.999 3a9.956 9.956 0 00-4.744 1.194L3.28 2.22zM7.752 6.69l1.092 1.092a2.5 2.5 0 013.374 3.373l1.091 1.092a4 4 0 00-5.557-5.557z"
+                clipRule="evenodd"
+              />
+              <path d="M10.748 13.93l2.523 2.524a9.987 9.987 0 01-3.27.547c-4.258 0-7.894-2.66-9.337-6.41a1.651 1.651 0 010-1.186A10.007 10.007 0 012.839 6.02L6.07 9.252a4 4 0 004.678 4.678z" />
+            </svg>
+          ) : (
+            /* eye icon */
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+              className="w-4 h-4"
+            >
+              <path d="M10 12.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z" />
+              <path
+                fillRule="evenodd"
+                d="M.664 10.59a1.651 1.651 0 010-1.186A10.004 10.004 0 0110 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0110 17c-4.257 0-7.893-2.66-9.336-6.41zM14 10a4 4 0 11-8 0 4 4 0 018 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+          )}
+        </button>
 
-      {/* Confidence badge */}
-      <span
-        className={`inline-block text-xs font-semibold px-2 py-0.5 rounded-full mb-2 ${confidenceColor(item.confidence)}`}
-      >
-        {confidenceLabel(item.confidence)}
-      </span>
+        <button
+          type="button"
+          aria-label={`Dismiss ${item.name}`}
+          onClick={onDismiss}
+          className="w-7 h-7 flex items-center justify-center rounded-full text-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors text-sm font-bold focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)]"
+        >
+          ×
+        </button>
+      </div>
+
+      {/* Checkbox + confidence badge row */}
+      <div className="flex items-center gap-2 mb-2 pr-16">
+        <input
+          type="checkbox"
+          id={`scan-item-${index}-${item.name}`}
+          checked={checked}
+          onChange={(e) => onCheckedChange(e.target.checked)}
+          aria-label={`Include ${item.name}`}
+          className="w-4 h-4 rounded accent-[var(--color-primary)] cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-[var(--color-primary)]"
+        />
+        <Chip tone={confidenceChipTone(item.confidence)} size="sm">
+          {confidenceLabel(item.confidence)}
+        </Chip>
+        {item.category && (
+          <Chip tone="muted" size="sm">
+            {item.category.replace('_', ' ')}
+          </Chip>
+        )}
+      </div>
 
       {/* Name field */}
       <div className="flex items-center gap-2 mb-3">
@@ -80,7 +147,7 @@ export default function ScannedItemCard({
           aria-label="Item name"
           value={item.name}
           onChange={(e) => update('name', e.target.value)}
-          className="flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] pb-1 transition-colors"
+          className="flex-1 text-sm font-semibold text-[var(--color-text)] bg-transparent border-b border-[var(--color-border)] focus:border-[var(--color-primary)] pb-1 transition-colors focus-visible:outline-none"
           placeholder="Item name"
         />
       </div>
@@ -145,6 +212,48 @@ export default function ScannedItemCard({
           </select>
         </div>
       </div>
+
+      {/* Raw face — toggles open beneath the fields */}
+      <AnimatePresence initial={false}>
+        {rawOpen && (
+          <motion.div
+            key="raw-face"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            style={{ overflow: 'hidden' }}
+          >
+            <div className="mt-3 pt-3 border-t border-[var(--color-border)] space-y-1">
+              <p className="text-xs font-semibold text-[var(--color-muted)] uppercase tracking-wide mb-1.5">
+                Raw frame data
+              </p>
+              <div className="text-xs text-[var(--color-text)] space-y-1">
+                <div className="flex gap-2">
+                  <span className="text-[var(--color-muted)] w-24 flex-shrink-0">Receipt line</span>
+                  <span className="font-mono break-all">{item.source_line || '—'}</span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[var(--color-muted)] w-24 flex-shrink-0">Parsed as</span>
+                  <span className="font-mono break-all">{item.original_name || '—'}</span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[var(--color-muted)] w-24 flex-shrink-0">Price</span>
+                  <span className="font-mono">
+                    {item.price !== null && item.price !== undefined
+                      ? `$${item.price.toFixed(2)}`
+                      : '—'}
+                  </span>
+                </div>
+                <div className="flex gap-2">
+                  <span className="text-[var(--color-muted)] w-24 flex-shrink-0">Confidence</span>
+                  <span className="font-mono">{Math.round(item.confidence * 100)}%</span>
+                </div>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </motion.div>
   )
 }

--- a/nextjs/src/types/scan.ts
+++ b/nextjs/src/types/scan.ts
@@ -1,22 +1,29 @@
 /**
  * Types for the receipt scanning workflow.
+ *
+ * FROZEN CONTRACT — matches the pinned API shape from docs/plans/2026-08-19-receipt-scan-rework.md.
+ * Any change here must be coordinated with the backend agent.
  */
 
 export interface ScannedItem {
-  name: string
+  name: string           // normalized display name  → "Italian Bomba Hot Pepper Spread"
+  original_name: string  // LLM parse, pre-normalize → "italian bomba hot pepper"
+  source_line: string    // raw OCR receipt line     → "ITALIAN BOMBA HOT PEPPER"
+  price: number | null
   quantity: number
   unit: string
   category: string
   location: string
-  confidence: number
+  confidence: number     // PER ITEM — 0..1
 }
 
 export interface ScanResult {
   ocr_text: string
-  ready_to_add: ScannedItem[]
-  needs_review: ScannedItem[]
-  skipped: ScannedItem[]
+  ready_to_add: ScannedItem[]   // confidence >= 0.8  → pre-checked
+  needs_review: ScannedItem[]   // 0.5 .. 0.8         → unchecked
+  skipped: ScannedItem[]        // < 0.5              → unchecked, collapsed
   total_items: number
+  warnings: string[]            // always present, may be empty
 }
 
 /** An item confirmed by the user, ready to be added to the pantry. */


### PR DESCRIPTION
## Summary

Fixes #250 — a real six-item Trader Joe's receipt reached Gemini Vision and returned **zero items**. Six independent causes sat behind that zero. This PR lands slices 1–3 of the rework in `docs/plans/2026-08-19-receipt-scan-rework.md`.

## What lands

**Slice 1 — restore the flow** (`ae003d4`)
- `_preprocess_aggressive` takes `already_cropped`; auto mode passes `True` so `_crop_receipt` runs once, not twice. The double crop shrank a 3419px receipt to 992px — header only — so the item list never reached the model.
- `preprocess` defaults to `False` in the scan route (opt-in retry only). Docstring updated: Tesseract is gone, Gemini reads raw phone photos better.
- Empty-OCR path returns the full `ScanResult` shape with populated `warnings` instead of a divergent `{items}` object; the normal path always includes `warnings`.
- Deleted `clean_receipt_items`'s substring keyword filter that silently ate baguette/cabbage (`"bag"`) and cashews (`"cash"`). Length guards kept.

**Slice 2 — parse and normalize quality** (`48fef16`)
- Per-item confidence through the spine, batch value only as fallback (product-ingest unaffected).
- Dropped the blanket ×0.9 OCR penalty — it put the 0.8 auto-add tier out of reach; per-item confidence now carries readability at the right granularity.
- Prompt preserves the product name, emits per-item confidence, returns `source_line` + `price`.
- Receipt normalization routed through the head-noun matcher, so `italian bomba hot pepper` no longer collapses to black pepper and `milk chocolate` stays milk chocolate.
- `original_name` / `source_line` / `price` exposed in the scan response per the pinned contract.

**Slice 3 — review screen** (`d2f463f`)
- Tier sections with header pills; confident items pre-checked, others unchecked.
- One consistent item card; eye icon-button toggles a raw face showing `source_line`, `original_name`, `price`, `confidence`.
- Warnings banner; Add button count tracks the checked set; keyboard focus visible; Chip tone tokens reused.

## Tests

- Backend: 406 pass, `ruff` clean, no new `mypy` errors.
- Frontend: `tsc --noEmit` clean, 102 jest pass (18 new).
- Deterministic acceptance verified: `ITALIAN BOMBA HOT PEPPER` stays itself, `ORG CANE SUGAR` stays cane sugar, `milk chocolate` stays milk chocolate, baguette/cashews/cabbage survive.

## Linked

Fixes #250. Design doc from #249 rides along on the branch.

## Out of scope

- **Slice 4** (fixture corpus + regression tests) — blocked on collecting real receipt photos, including the Trader Joe's receipt itself. Full "six items return" acceptance is pinned there.
- Deleting the preprocessor outright, auto-writing items without confirmation, unifying the two normalizers, routing receipts through the `/ingest` dispatcher.
