### PR TITLE
docs: UX audit findings + PR issue-linking convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,6 +306,34 @@ Two other schemes (hash-suffixed, `ui-wN-*`) exist on older branches; don't
 bulk-rename them, just use the convention above for anything new. See `WORKFLOW.md`
 §4.
 
+**Linking issues in PRs — auto-close is by design.** Every PR that resolves an
+issue must use a GitHub closing keyword in the **PR body**, one per issue, each
+on its own line:
+
+```markdown
+Fixes #239
+Fixes #240
+Closes #241
+```
+
+Accepted keywords: `Fixes` / `Closes` / `Resolves` (GitHub treats them
+identically). Rules that make this actually work:
+
+- **One keyword per issue.** `Fixes #239, #240` only closes #239 — the second
+  number is plain text. Comma-separated lists silently half-work.
+- **The keyword must be in the PR body**, not the commit message alone, and not
+  only in prose like "addresses the expiry bug (#239)". A bare `#239` links but
+  never closes.
+- **Only issues in the same repo** auto-close on merge to the default branch.
+- **Partial fixes don't get a keyword.** If a PR only lands part of an issue,
+  reference it *without* a keyword (`Related to #242`) and leave a comment
+  saying what shipped and what remains — closing it would lose the rest.
+
+Getting this wrong is a silent failure: #251 fixed six issues with the numbers
+only in prose, so all six stayed open after merge and had to be closed by hand.
+Prefer the keyword over manual closing — a merged PR should leave the tracker
+correct with no follow-up step.
+
 ---
 
 ## Environment Variables

--- a/docs/plans/2026-08-24-ux-audit.md
+++ b/docs/plans/2026-08-24-ux-audit.md
@@ -1,0 +1,242 @@
+# UX + Logic Audit — 2026-08-24
+
+Driven as a real user against a live local stack (Next.js :3000 + ai-service :8888,
+Gemini live, seeded test account, 49 pantry items) at mobile width (390×844).
+Findings below are only those reproduced against running code or proven with a
+deterministic repro — unverified hypotheses are marked as such.
+
+## Summary
+
+The app works end to end: login, pantry, receipt scan, chat, recipe generation,
+and the cook flow all function. The problems cluster in three places:
+
+1. **Expiry is computed four different ways** and two of them have no lower
+   bound, so long-expired food is treated as "expiring soon" — including being
+   fed to the AI as a priority ingredient to cook tonight.
+2. **The cook flow is not a flow.** "Cook this" means "deduct stock for something
+   I already cooked", but it reads as "help me cook this now", it is gated behind
+   saving, and the cooking context is sent only once.
+3. **Failures are silent.** Several write paths swallow errors and close the
+   modal as if the write succeeded.
+
+---
+
+## A. Expiry correctness (highest impact)
+
+### A1. `/api/pantry/expiring` counts expired food as expiring — HIGH
+
+`nextjs/src/app/api/pantry/expiring/route.ts:23` filters
+`lte('expiry_date', futureDateStr)` with **no lower bound**.
+
+Measured on the live test account:
+
+| query | returns | actually expiring in window |
+|---|---|---|
+| `/api/pantry/expiring?days=3` | **31** | **2** |
+| `/api/pantry/expiring?days=7` | **33** | **4** |
+
+29 already-expired items are included in every "expiring" response. `HeroHome`
+only looks correct because it re-filters client-side
+(`HeroHome.tsx:110-124`) — the API itself is wrong for any other consumer.
+
+### A2. AI scoring ranks 2-week-old food as "expiring soon" — HIGH (food safety)
+
+`ai-service/bubbly_chef/workflows/recipe/nodes.py:361-367` scores expiry with
+`if days_left <= 3: score += 10` — again no lower bound. Items are then handed
+to the LLM under the label `Expiring soon (prioritize)` (`nodes.py:604`).
+
+Deterministic repro:
+
+```
+baby spinach     expiry=2026-08-10 days_left= -14  score=+10 -> PRIORITY(expiring)
+banana           expiry=2026-08-14 days_left= -10  score=+10 -> PRIORITY(expiring)
+yellow onions    expiry=2026-08-25 days_left=   1  score=+10 -> PRIORITY(expiring)
+```
+
+Observed live: asked "what can I make with the onions before they go bad?" and
+Bubbles suggested dishes built on 14-day-expired spinach and 10-day-expired
+banana. The app actively recommends cooking spoiled food.
+
+### A3. Two different day-count implementations disagree at night — MED
+
+- `nextjs/src/lib/pantry-helpers.ts:37` — `expiry − local midnight`
+- `nextjs/src/app/pantry/page.tsx:70` — `expiry − Date.now()` (current time)
+
+The second loses the elapsed part of the day. Repro across times of day:
+
+```
+local 08:00  onions(tomorrow): server=1 badge="1d left"
+local 15:00  onions(tomorrow): server=1 badge="1d left"
+local 23:48  onions(tomorrow): server=1 badge="Today"     <-- diverges
+```
+
+Observed live at 23:48: API reported cheese `days=2`, badge rendered `1d left`;
+API reported onions `days=1`, badge rendered `Today` while the dashboard
+simultaneously said "expires tomorrow". The comment at `pantry/page.tsx:74-81`
+claims the two badges can never contradict each other; they can, after ~18:00.
+
+Additionally both use `new Date("YYYY-MM-DD")`, which parses as **UTC** midnight
+while `today` is **local** midnight — a second, timezone-dependent skew.
+
+---
+
+## B. The cook flow
+
+### B1. "Cook this" is gated behind saving — HIGH (user-reported)
+
+`nextjs/src/components/chat/ChatRecipeCard.tsx:204` — `disabled={!savedRecipeId}`,
+tooltip: *"Save the recipe first to cook it"*. You cannot act on a recipe without
+committing it to your library first. Suggested: allow cooking immediately, then
+ask "add this to your library?" afterwards.
+
+### B2. "Cook this" does not mean what it says — HIGH (design)
+
+In chat, "Cook this" opens `CookModal` (`chat/page.tsx:409-416`), which is a
+**stock-deduction confirmation** ("Yes, I cooked this"), not a cooking mode.
+Cooking mode is only entered *afterwards*, when `CookModal` redirects to
+`/chat?cooking=<id>` (`CookModal.tsx:140-144`).
+
+So one button labelled "Cook this" means "I already cooked this, subtract the
+ingredients." There is no "help me cook this now" mode reachable before cooking.
+
+### B3. The COOKING NOW banner scrolls away — MED (user-reported)
+
+`chat/page.tsx:362` renders `CookingContextCard` **inside** the scrolling message
+list. Once the thread grows the user must scroll up to confirm the AI still knows
+what they're cooking. Given cooking is the hero task of that screen, it should be
+pinned.
+
+### B4. Cooking context is sent only on the first message — MED
+
+`chat/page.tsx:195-201` — `contextSentRef` latches after one send, so follow-ups
+carry no cook context. The session *is* pinned server-side
+(`router.py:657`, `SessionMode.COOKING`), and in testing follow-ups did stay on
+topic. **Unverified:** the reported "asked about the oven, got new recipes"
+failure was not reproduced in two attempts; the mode held both times. Needs the
+exact entry path (cook-from-chat-card after a brainstorm) to reproduce.
+
+### B5. First reply in cooking mode ignores the pinned recipe — MED
+
+Reproduced: opened `/chat?cooking=<id>`, banner read "COOKING NOW — Salmon
+Avocado Toast", asked "How do I start?" and got the generic onboarding reply
+*"Welcome to BubblyChef! You can start by telling me what groceries you have…"*.
+
+### B6. Confirm is the primary CTA while ingredients are unresolved — MED
+
+Observed: cook modal showed 2 × `Unit conflict` (empty qty inputs) and 2 ×
+`Not enough`, yet **"Yes, I cooked this"** was the bright primary button with no
+warning. `CookModal.tsx:117` silently drops any row with `deductQty <= 0`, so
+those ingredients are never deducted and the user is never told.
+
+### B7. Post-cook redirect fires even if the modal was closed — LOW
+
+`CookModal.tsx:140-144` — `setTimeout(..., 1200)` calls `router.push('/chat?...')`
+with no cancel path.
+
+### B8. Cook match takes ~6.7s with no progress feedback — LOW
+
+Measured 6685 ms showing only static text "Checking your pantry…".
+
+---
+
+## C. Empty pantry / onboarding (user-reported)
+
+### C1. Empty pantry invents recipes instead of prompting to stock — MED
+
+`ai-service/bubbly_chef/workflows/recipe/nodes.py:607` — with no pantry items the
+prompt becomes *"No pantry items available — suggest general recipes."* A new
+user asking "what can I cook tonight?" gets generic recipes rather than being
+routed into the ingest flow, wasting the highest-intent onboarding moment.
+
+The three ingest paths that exist today:
+- **Receipt scan** — `/pantry?add=scan` → `ScanTab` → Gemini Vision OCR →
+  confidence-bucketed review → confirm.
+- **Manual** — same sheet, "Type" tab (`PantryAddSheet.tsx:18` `'scan' | 'type'`).
+- **Natural language in chat** — real and shipped: `pantry_update` intent
+  (`router.py:100`) returns a proposal card the user approves.
+
+None of these are surfaced when the pantry is empty.
+
+---
+
+## D. Silent failures
+
+### D1. Pantry add/edit/delete fail silently — HIGH
+
+`nextjs/src/components/pantry/AddItemModal.tsx:117-168`. Neither `handleSubmit`
+nor `handleDelete` checks `res.ok`; both `catch {}` with a `// silent` comment
+and call `onClose()` regardless. A 401/409/500 closes the modal exactly like
+success. The user believes the item was saved.
+
+### D2. Chat stream can hang forever — HIGH
+
+`nextjs/src/hooks/useChat.ts` sets `setIsStreaming(false)` only in `onDone` (110)
+and `onError` (146). In `lib/api/chat.ts:95-136`, if the SSE body closes without
+an `envelope` or `error` event, the loop exits and `finally` only calls
+`reader.releaseLock()` — neither callback fires. `isStreaming` stays `true`
+permanently: Send stays hidden, the typing indicator never stops. No timeout
+anywhere.
+
+### D3. Import modal backdrop closes mid-import — MED
+
+`RecipeImportModal.tsx:91` — backdrop `onClick={onClose}` unguarded, while the
+Cancel button 130 lines below correctly uses `disabled={state === 'loading'}`.
+
+### D4. Re-uploading the same receipt after an error does nothing — MED
+
+`ScanTab.tsx:56-58` — the error path never resets `inputRef.current.value`
+(only `handleReset` does, line 72). Re-picking the same file fires no `onChange`.
+
+### D5. Pantry proposal approve/reject swallow errors — MED
+
+`useChat.ts` — optimistic state flips to approved before the request; failures
+are caught and discarded, so the card says "Added to pantry!" when nothing was
+written. *(Reported by audit agent; line-level detail not independently re-verified.)*
+
+---
+
+## E. Pantry browsing
+
+### E1. "Use Soon" leads to an unfiltered 49-item list — MED
+
+The dashboard tile links to `/pantry`, which renders everything grouped by
+category with no expiry filter and no urgency sort. With 29 expired items the
+urgency signal is lost on arrival. Location chips exist (All/Fridge/Freezer/
+Pantry/Counter) but there is no expiry facet. Overlaps open issues #139 / #228.
+
+### E2. Duplicate pantry rows are visible — MED
+
+Live data shows `Banana` + `Bananas`, `Carrot` + `Carrots`, `Spinach` +
+`Baby Spinach`, `Bread` + `Sourdough Bread` as separate rows. Related to #127.
+
+### E3. Long names truncate — LOW
+
+"Cheddar Che…", "All-purpose F…", "Red Bell Pep…" at 390px. Existing issue #2.
+
+### E4. Empty search/filter result is a dead end — LOW
+
+`pantry/page.tsx:226-240` — copy says "Try different search terms." with no
+button to clear the search or reset the filter.
+
+---
+
+## F. Time-of-day correctness
+
+### F1. Chat suggests breakfast at midnight — MED
+
+`_default_meal_type()` (`nodes.py:400-411`) is correct and would return
+"late-night snack" at 23:48, but it is only applied in the recipe-generate path
+(`nodes.py:504-507`). The brainstorm path passes meal type only *if present*
+(`nodes.py:616`), and `BRAINSTORM_SYSTEM_PROMPT` says "if meal_type is
+specified". Observed twice at 23:48: "here are a few breakfast ideas" and
+"a few refreshing breakfast options".
+
+The dashboard greeting itself is correct ("Late night snack?" at 23:48) —
+`HeroHome.tsx:35-41` is fine.
+
+---
+
+## Not re-reported
+
+Already tracked: #227, #222, #223, #224, #226, #186, #149, #127, #2, #139, #228,
+#170, #168, #169.


### PR DESCRIPTION
## Summary

Docs-only follow-up to #251. Two things that should have ridden along with that PR but didn't: the audit record it came from, and the convention that would have saved the manual cleanup afterwards.

## What lands

**`docs/plans/2026-08-24-ux-audit.md`** — the record behind issues #239–#248. Written during a QA pass driven against a live local stack (Next.js + ai-service, Gemini live, seeded 49-item pantry) at mobile width. Every finding carries file:line evidence, measured numbers, or a deterministic repro; the one hypothesis that failed to reproduce is marked unverified rather than dropped or asserted.

Each of those issues links to this file, so it needs to be in the repo — it existed only inside a throwaway worktree and was nearly lost when that worktree was cleaned up.

**`CLAUDE.md` — issue-linking convention.** #251 fixed six issues but referenced the numbers only in prose, so none auto-closed on merge and all six had to be closed by hand. The new section spells out the parts that actually bite:

- One keyword per issue — `Fixes #239, #240` only closes the first; the rest is plain text
- The keyword must be in the PR body, not the commit message alone
- Partial fixes get `Related to #N` with no keyword, so the remaining scope isn't silently closed

## Tests

None — no code changes. `docs/` and `CLAUDE.md` only.

## Linked

Related to #239, #240, #241, #244, #246, #247, #248 (closed via #251)
Related to #242, #243, #245 (still open; the audit documents them)

## Out of scope

The open findings themselves. #242 (cook-flow redesign) is design work and needs its own PR; #243 and #245 are unstarted.