### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ Thumbs.db
 .vibe/
 .windsurf/
 .zencoder/
+
+# Transient agent worktrees. `.claude/agents/` and `.claude/settings.json` are
+# tracked deliberately — scope this to worktrees only, never the whole dir.
+.claude/worktrees/


### PR DESCRIPTION
## Summary

One line in `.gitignore`. Agent worktrees are nested git checkouts created under `.claude/worktrees/` during a session and removed afterwards — transient scaffolding, never project content.

## What lands

```
.claude/worktrees/
```

Scoped to `worktrees/` specifically, **not** `.claude/` — `.claude/agents/*.md` and `.claude/settings.json` are tracked deliberately and must stay tracked. Verified: 6 tracked files under `.claude/` before and after.

## Why

Committing a worktree would nest a git checkout inside the repo. It also trips the stop-hook git check on every session that spawns an isolated agent, producing a false "uncommitted changes" warning that has to be dismissed by hand each time.

## Tests

n/a — gitignore only. Verified behaviorally: the untracked worktree path disappears from `git status --untracked-files=all`, and `git ls-files .claude/` still returns all 6 tracked files.

## Demo

n/a

## Linked issue

None — housekeeping.

## Out of scope

Nothing else in `.gitignore` touched.

---

- [ ] `/code-review` run
- [ ] `/interrogate` run (feature-level PRs only)
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8Xs73WomYqa8icmBkD5GW)_