### PR TITLE
feat(cook): preview the pantry cost before cooking, warn on unresolved rows

### DIFF
--- a/nextjs/src/__tests__/cook-flow-redesign.test.tsx
+++ b/nextjs/src/__tests__/cook-flow-redesign.test.tsx
@@ -346,3 +346,79 @@ describe('endCookingSession — banner retires after a completed cook (#268)', (
     expect(state.url).toBe('/chat?cooking=r1')
   })
 })
+
+// ─── Cook preview + unresolved-row summary (#267, #245) ──────────────────────
+
+import { summariseDeductions } from '@/components/recipes/CookModal'
+import type { CookProposal, IngredientMatch } from '@/types/recipes'
+
+const match = (over: Partial<IngredientMatch>): IngredientMatch => ({
+  ingredient_name: 'thing',
+  pantry_item_id: 'p1',
+  pantry_item_name: 'thing',
+  status: 'ready',
+  match_type: 'exact',
+  deduct_qty: 10,
+  base_unit: 'g',
+  substitution_note: null,
+  ...over,
+} as IngredientMatch)
+
+const proposalOf = (matches: IngredientMatch[]): CookProposal => ({
+  recipe_id: 'r1',
+  recipe_title: 'Test',
+  matches,
+  missing: [],
+  unit_conflicts: [],
+} as unknown as CookProposal)
+
+describe('summariseDeductions (#245)', () => {
+  it('reports unresolved unit_conflict rows instead of dropping them silently', () => {
+    const p = proposalOf([
+      match({ ingredient_name: 'pasta', pantry_item_id: 'p1' }),
+      match({ ingredient_name: 'garlic', pantry_item_id: 'p2', status: 'unit_conflict', deduct_qty: null }),
+    ])
+    const { deductions, skipped, matchedCount } = summariseDeductions(p, {})
+    expect(matchedCount).toBe(2)
+    expect(deductions).toHaveLength(1)
+    // The whole point of #245: the skipped row is surfaced, not swallowed.
+    expect(skipped).toEqual([{ name: 'garlic', reason: 'needs_quantity' }])
+  })
+
+  it('includes a unit_conflict row once the user supplies a quantity', () => {
+    const p = proposalOf([
+      match({ ingredient_name: 'garlic', pantry_item_id: 'p2', status: 'unit_conflict', deduct_qty: null }),
+    ])
+    const { deductions, skipped } = summariseDeductions(p, { '0': '3' })
+    expect(skipped).toHaveLength(0)
+    expect(deductions).toEqual([{ pantry_item_id: 'p2', deduct_qty: 3, base_unit: 'g' }])
+  })
+
+  it('excludes missing rows from the matched count entirely', () => {
+    const p = proposalOf([
+      match({ ingredient_name: 'pasta' }),
+      match({ ingredient_name: 'saffron', status: 'missing', pantry_item_id: null }),
+    ])
+    const { matchedCount, skipped } = summariseDeductions(p, {})
+    expect(matchedCount).toBe(1)
+    expect(skipped).toHaveLength(0)
+  })
+
+  it('still sums rows that collapse onto one pantry item', () => {
+    const p = proposalOf([
+      match({ ingredient_name: 'cheddar', pantry_item_id: 'cheese', deduct_qty: 30 }),
+      match({ ingredient_name: 'parmesan', pantry_item_id: 'cheese', deduct_qty: 20 }),
+    ])
+    const { deductions } = summariseDeductions(p, {})
+    expect(deductions).toEqual([{ pantry_item_id: 'cheese', deduct_qty: 50, base_unit: 'g' }])
+  })
+
+  it('treats a blank or zero override as unresolved, not as a real deduction', () => {
+    const p = proposalOf([
+      match({ ingredient_name: 'salt', pantry_item_id: 'p3', status: 'unit_conflict', deduct_qty: null }),
+    ])
+    expect(summariseDeductions(p, { '0': '' }).skipped).toHaveLength(1)
+    expect(summariseDeductions(p, { '0': '0' }).skipped).toHaveLength(1)
+    expect(summariseDeductions(p, { '0': 'abc' }).skipped).toHaveLength(1)
+  })
+})

--- a/nextjs/src/app/chat/page.tsx
+++ b/nextjs/src/app/chat/page.tsx
@@ -145,8 +145,19 @@ function ChatSurface() {
   const [cookStartedIds, setCookStartedIds] = useState<Set<string>>(new Set())
   /** msgIds whose cook button is pending (draft POST in flight). Re-renders on change. */
   const [cookPending, setCookPending] = useState<Set<string>>(new Set())
-  /** When set, the CookModal is open for this { recipeId, recipeTitle, isDraft } triple. */
-  const [cookTarget, setCookTarget] = useState<{ recipeId: string; recipeTitle: string; isDraft: boolean } | null>(null)
+  /**
+   * When set, the CookModal is open for this recipe. `mode` decides which
+   * question it asks: 'preview' (what will this cost me, deducts nothing) or
+   * 'confirm' (I cooked it, deduct now). `msgId` is carried so a preview that
+   * proceeds to cooking can mark the originating card as started.
+   */
+  const [cookTarget, setCookTarget] = useState<{
+    recipeId: string
+    recipeTitle: string
+    isDraft: boolean
+    mode: 'preview' | 'confirm'
+    msgId?: string
+  } | null>(null)
   const [loadedRecipe, setLoadedRecipe] = useState<Recipe | null>(null)
   const [dismissedRecipeId, setDismissedRecipeId] = useState<string | null>(null)
   const [dismissedSeedKey, setDismissedSeedKey] = useState<string | null>(null)
@@ -437,7 +448,12 @@ function ChatSurface() {
               onFinishCooking={() => {
                 if (!cookingRecipeId) return
                 const isDraft = draftRecipeIds.has(msgIdForRecipeId(cookingRecipeId) ?? '')
-                setCookTarget({ recipeId: cookingRecipeId, recipeTitle: cookingRecipe.title, isDraft })
+                setCookTarget({
+                  recipeId: cookingRecipeId,
+                  recipeTitle: cookingRecipe.title,
+                  isDraft,
+                  mode: 'confirm',
+                })
               }}
             />
           </div>
@@ -486,10 +502,19 @@ function ChatSurface() {
                 savedRecipeId={savedRecipeIds[msg.id] ?? null}
                 isSavedDraft={draftRecipeIds.has(msg.id)}
                 onCookWithMe={(recipe) => {
+                  const title = recipe.title ?? 'Recipe'
                   setCookPending((prev) => new Set(prev).add(msg.id))
-                  ensureRecipeId(msg.id, recipe).then(({ id: recipeId }) => {
-                    setCookStartedIds((prev) => new Set(prev).add(msg.id))
-                    router.replace(`/chat?cooking=${encodeURIComponent(recipeId)}`, { scroll: false })
+                  ensureRecipeId(msg.id, recipe).then(({ id: recipeId, isDraft }) => {
+                    // Show what the cook will cost the pantry BEFORE starting,
+                    // not as an audit afterwards (#267). Nothing is deducted
+                    // here — "Start cooking" pins the session as before.
+                    setCookTarget({
+                      recipeId,
+                      recipeTitle: title,
+                      isDraft,
+                      mode: 'preview',
+                      msgId: msg.id,
+                    })
                   }).catch(() => {
                     // POST failed — pending cleared in finally; buttons re-enable
                   })
@@ -501,7 +526,7 @@ function ChatSurface() {
                   setCookPending((prev) => new Set(prev).add(msg.id))
                   ensureRecipeId(msg.id, recipe).then(({ id: recipeId, isDraft }) => {
                     setCookStartedIds((prev) => new Set(prev).add(msg.id))
-                    setCookTarget({ recipeId, recipeTitle: title, isDraft })
+                    setCookTarget({ recipeId, recipeTitle: title, isDraft, mode: 'confirm' })
                   }).catch(() => {
                     // POST failed — pending cleared in finally; buttons re-enable
                   })
@@ -606,6 +631,15 @@ function ChatSurface() {
           recipeId={cookTarget.recipeId}
           recipeTitle={cookTarget.recipeTitle}
           isDraft={cookTarget.isDraft}
+          mode={cookTarget.mode}
+          onStartCooking={() => {
+            // The preview was the decision point; this is where cooking actually
+            // begins. Nothing was deducted by the preview.
+            const { recipeId, msgId } = cookTarget
+            if (msgId) setCookStartedIds((prev) => new Set(prev).add(msgId))
+            setCookTarget(null)
+            router.replace(`/chat?cooking=${encodeURIComponent(recipeId)}`, { scroll: false })
+          }}
           onAddToLibrary={cookTarget.isDraft ? async () => {
             await promoteRecipeDraft(cookTarget.recipeId)
             setDraftRecipeIds((prev) => {

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -15,6 +15,19 @@ interface CookModalProps {
   isDraft?: boolean
   /** Called when user taps "Add to library" in the draft success state. */
   onAddToLibrary?: () => Promise<void>
+  /**
+   * Which question the modal is answering (#267).
+   *
+   * - 'confirm' (default) — "I already cooked this." Deducts on confirm. This is
+   *   the original behaviour, reached from "I already made this" and from
+   *   "Finished cooking" at the end of a cook session.
+   * - 'preview' — "What will this cost me?" Shows the same pantry match as a
+   *   plan, deducts nothing, and hands off to cooking. The substitute/shortfall
+   *   information is most useful before you start, not as an audit afterwards.
+   */
+  mode?: 'confirm' | 'preview'
+  /** Called when the user starts cooking from a preview. Required for 'preview'. */
+  onStartCooking?: () => void
 }
 
 type ModalState = 'loading' | 'review' | 'confirming' | 'success' | 'error'
@@ -59,6 +72,71 @@ function formatQty(qty: number | null, unit: string | null): string {
   return unit ? `${rounded} ${unit}` : String(rounded)
 }
 
+/**
+ * Splits the proposal into what will actually be deducted and what will not.
+ *
+ * The two are derived together on purpose: the confirm payload and the summary
+ * shown above the button must never disagree. Previously the payload was built
+ * inline at confirm time and rows that fell out (`deductQty <= 0`) simply
+ * vanished, so the user was told nothing about ingredients their pantry never
+ * gave up (#245).
+ */
+export function summariseDeductions(
+  proposal: CookProposal,
+  overrides: Record<string, string>,
+): {
+  deductions: DeductionItem[]
+  /** Matched rows that will NOT be deducted, and why. */
+  skipped: Array<{ name: string; reason: 'needs_quantity' | 'no_quantity' }>
+  /** Count of matched (non-missing) rows considered. */
+  matchedCount: number
+} {
+  const byPantryItem = new Map<string, DeductionItem>()
+  const skipped: Array<{ name: string; reason: 'needs_quantity' | 'no_quantity' }> = []
+  let matchedCount = 0
+
+  proposal.matches.forEach((m: IngredientMatch, i: number) => {
+    if (m.pantry_item_id == null || m.status === 'missing') return
+    matchedCount += 1
+
+    // For unit_conflict rows, use the user's override qty (or 0 if not set).
+    // Keyed by row index, not pantry item — two rows sharing an item still
+    // need their own input.
+    const isConflict = m.status === 'unit_conflict'
+    const deductQty = isConflict
+      ? parseFloat(overrides[String(i)] ?? '0') || 0
+      : (m.deduct_qty ?? 0)
+
+    if (deductQty <= 0) {
+      skipped.push({
+        name: m.ingredient_name,
+        reason: isConflict ? 'needs_quantity' : 'no_quantity',
+      })
+      return
+    }
+
+    // Several recipe lines can resolve to one pantry row — literal duplicates,
+    // or names the backend collapses onto the same item (cheddar and parmesan
+    // both normalize to "cheese"). Emitting one entry per match would then send
+    // two deductions for one row, and the server applies each as a
+    // read-modify-write. The backend sums defensively too; doing it here keeps
+    // the payload honest about what is actually being deducted.
+    const id = m.pantry_item_id
+    const existing = byPantryItem.get(id)
+    if (existing) {
+      existing.deduct_qty += deductQty
+    } else {
+      byPantryItem.set(id, {
+        pantry_item_id: id,
+        deduct_qty: deductQty,
+        base_unit: m.base_unit ?? 'item',
+      })
+    }
+  })
+
+  return { deductions: Array.from(byPantryItem.values()), skipped, matchedCount }
+}
+
 export default function CookModal({
   recipeId,
   recipeTitle,
@@ -66,6 +144,8 @@ export default function CookModal({
   onCooked,
   isDraft = false,
   onAddToLibrary,
+  mode = 'confirm',
+  onStartCooking,
 }: CookModalProps) {
   const router = useRouter()
   const [state, setState] = useState<ModalState>('loading')
@@ -96,48 +176,18 @@ export default function CookModal({
     }
   }, [recipeId])
 
+  // Recomputed as the user fills in override quantities, so the summary above
+  // the button always describes the payload the button will actually send.
+  const summary = proposal ? summariseDeductions(proposal, overrides) : null
+  /** Rows the user could still resolve by typing a quantity. */
+  const needsQuantity = summary?.skipped.filter((s) => s.reason === 'needs_quantity') ?? []
+  const hasUnresolved = needsQuantity.length > 0
+
   const handleConfirm = async () => {
-    if (!proposal) return
+    if (!proposal || !summary) return
     setState('confirming')
 
-    // Build deductions from matched items that have a deduct_qty, summing any
-    // that land on the same pantry item.
-    //
-    // Several recipe lines can resolve to one pantry row — literal duplicates,
-    // or names the backend collapses onto the same item (cheddar and parmesan
-    // both normalize to "cheese"). Emitting one entry per match would then send
-    // two deductions for one row, and the server applies each as a
-    // read-modify-write. The backend sums defensively too; doing it here keeps
-    // the payload honest about what is actually being deducted.
-    const byPantryItem = new Map<string, DeductionItem>()
-
-    proposal.matches.forEach((m: IngredientMatch, i: number) => {
-      if (m.pantry_item_id == null || m.status === 'missing') return
-
-      // For unit_conflict rows, use the user's override qty (or 0 if not set).
-      // Keyed by row index, not pantry item — two rows sharing an item still
-      // need their own input.
-      const deductQty =
-        m.status === 'unit_conflict'
-          ? parseFloat(overrides[String(i)] ?? '0') || 0
-          : (m.deduct_qty ?? 0)
-
-      if (deductQty <= 0) return
-
-      const id = m.pantry_item_id
-      const existing = byPantryItem.get(id)
-      if (existing) {
-        existing.deduct_qty += deductQty
-      } else {
-        byPantryItem.set(id, {
-          pantry_item_id: id,
-          deduct_qty: deductQty,
-          base_unit: m.base_unit ?? 'item',
-        })
-      }
-    })
-
-    const deductions: DeductionItem[] = Array.from(byPantryItem.values())
+    const { deductions } = summary
 
     try {
       await confirmCook(recipeId, deductions)
@@ -191,7 +241,7 @@ export default function CookModal({
                 className="text-base font-extrabold text-[var(--color-text)]"
                 style={{ fontFamily: 'Nunito, sans-serif' }}
               >
-                Mark as cooked
+                {mode === 'preview' ? "What you'll use" : 'Mark as cooked'}
               </h2>
               <p
                 className="text-xs text-[var(--color-muted)] mt-0.5 line-clamp-1"
@@ -382,25 +432,85 @@ export default function CookModal({
           {/* Footer actions */}
           {(state === 'review' || state === 'confirming') && (
             <div
-              className="px-5 py-4 flex gap-2 flex-shrink-0 border-t border-[var(--color-border)]"
+              className="px-5 py-3 flex flex-col gap-2.5 flex-shrink-0 border-t border-[var(--color-border)]"
               style={{ background: 'var(--color-bg)' }}
             >
-              <button
-                onClick={onClose}
-                disabled={state === 'confirming'}
-                className="flex-1 py-2 rounded-full text-sm font-bold border border-[var(--color-border)] text-[var(--color-muted)] active:scale-95 transition-transform disabled:opacity-50"
-                style={{ fontFamily: 'Nunito, sans-serif' }}
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleConfirm}
-                disabled={state === 'confirming'}
-                className="flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform disabled:opacity-50"
-                style={{ background: 'var(--color-primary-dark)', fontFamily: 'Nunito, sans-serif' }}
-              >
-                {state === 'confirming' ? 'Saving...' : 'Yes, I cooked this'}
-              </button>
+              {/* What will actually happen, stated before the button that does it.
+                  In confirm mode a partial deduction is a warning; in preview
+                  nothing is being written, so the same numbers are just a plan. */}
+              {summary && summary.matchedCount > 0 && (
+                <div
+                  className="text-xs leading-snug"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  <p
+                    className={
+                      summary.skipped.length > 0 && mode === 'confirm'
+                        ? 'font-bold text-[var(--color-text)]'
+                        : 'text-[var(--color-muted)]'
+                    }
+                  >
+                    {summary.skipped.length > 0 && mode === 'confirm' && '⚠️ '}
+                    {summary.deductions.length} of {summary.matchedCount} ingredient
+                    {summary.matchedCount === 1 ? '' : 's'}{' '}
+                    {mode === 'preview' ? 'will come from your pantry' : 'will be deducted'}
+                    {needsQuantity.length > 0 && ` — ${needsQuantity.length} need${
+                      needsQuantity.length === 1 ? 's' : ''
+                    } a quantity`}
+                  </p>
+                  {summary.skipped.length > 0 && (
+                    <p className="text-[var(--color-muted)] mt-0.5">
+                      Not {mode === 'preview' ? 'counted' : 'deducted'}:{' '}
+                      {summary.skipped.map((s) => s.name).join(', ')}
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="flex gap-2">
+                <button
+                  onClick={onClose}
+                  disabled={state === 'confirming'}
+                  className="flex-1 py-2 rounded-full text-sm font-bold border border-[var(--color-border)] text-[var(--color-muted)] active:scale-95 transition-transform disabled:opacity-50"
+                  style={{ fontFamily: 'Nunito, sans-serif' }}
+                >
+                  {mode === 'preview' ? 'Back' : 'Cancel'}
+                </button>
+                {mode === 'preview' ? (
+                  <button
+                    onClick={onStartCooking}
+                    className="flex-1 py-2 rounded-full text-sm font-bold text-white active:scale-95 transition-transform"
+                    style={{ background: 'var(--color-primary-dark)', fontFamily: 'Nunito, sans-serif' }}
+                  >
+                    Start cooking →
+                  </button>
+                ) : (
+                  <button
+                    onClick={handleConfirm}
+                    disabled={state === 'confirming'}
+                    /* Demoted to a secondary treatment while rows are unresolved:
+                       confirming then silently drops them, so it should not look
+                       like the obviously-correct action (#245). Still reachable —
+                       some quantities genuinely cannot be measured. */
+                    className={[
+                      'flex-1 py-2 rounded-full text-sm font-bold active:scale-95 transition-transform disabled:opacity-50',
+                      hasUnresolved
+                        ? 'border-2 border-[var(--color-primary-dark)] text-[var(--color-primary-dark)]'
+                        : 'text-white',
+                    ].join(' ')}
+                    style={{
+                      background: hasUnresolved ? 'transparent' : 'var(--color-primary-dark)',
+                      fontFamily: 'Nunito, sans-serif',
+                    }}
+                  >
+                    {state === 'confirming'
+                      ? 'Saving...'
+                      : hasUnresolved
+                      ? 'Cook anyway'
+                      : 'Yes, I cooked this'}
+                  </button>
+                )}
+              </div>
             </div>
           )}
         </motion.div>


### PR DESCRIPTION
## Summary

Two halves of the same complaint: the pantry match was only ever shown *after* the decision it should inform, and when it had gaps it said nothing about them.

## What lands

### #267 — the match is now reachable before you cook

`CookModal` gains a `mode` prop:

| mode | entered from | reads | CTA | deducts |
|---|---|---|---|---|
| `preview` | `Cook with me` | "What you'll use" | `Start cooking →` | no |
| `confirm` | `I already made this`, `Finished cooking` | "Mark as cooked" | `Yes, I cooked this` | yes |

`Cook with me` previously pinned the recipe with no pantry information at all — you found out what you were short of only after cooking. Same component, same matcher call, both intentions served.

Backing out of a preview leaves the card tappable; only `Start cooking` marks it as started, so the #269 inert behaviour still keys on actually cooking rather than merely looking.

### #245 — unresolved rows are surfaced instead of silently dropped

A `unit_conflict` row with a blank quantity was dropped at confirm time (`deductQty <= 0` → `return`) with nothing shown, so the user believed their pantry had been updated.

Extracted `summariseDeductions()`, which returns the confirm payload *and* the skipped rows from one pass — the summary and the request can no longer disagree. The modal now states what will happen above the button that does it:

> ⚠️ 4 of 7 ingredients will be deducted — 3 need a quantity
> Not deducted: Pasta, Garlic, Cherry Tomatoes

While anything is unresolved the confirm button is demoted to an outline and reads **Cook anyway**. It stays reachable — some quantities genuinely cannot be measured — but it no longer looks like the obviously-correct action. Fill the quantities and it returns to a solid `Yes, I cooked this`.

## Tests

`npx tsc --noEmit` clean; `npm test` 136 passed / 14 suites (was 131).

Five new cases on `summariseDeductions`: unresolved conflicts are reported rather than dropped, a supplied quantity moves a row into the payload, `missing` rows stay out of the matched count, rows collapsing onto one pantry item still sum, and blank/zero/non-numeric overrides all count as unresolved.

Verified live signed-in against real Gemini output and a 49-item pantry — preview shows the match with no deduction and no `Yes, I cooked this`; confirm warns and names the three skipped rows; filling the quantities moves the summary to "7 of 7" and restores the solid CTA.

## Linked

Closes #267
Closes #245

## Out of scope

B8 from the UX audit — cook matching takes ~6.7 s behind a static "Checking your pantry…". More visible now that the match sits on the path *into* cooking rather than after it, so it's worth doing next, but it's a loading-state change rather than part of this one.