### PR TITLE
ux(cook): narrate the pantry match instead of a six-second static spinner

### DIFF
--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -32,6 +32,34 @@ interface CookModalProps {
 
 type ModalState = 'loading' | 'review' | 'confirming' | 'success' | 'error'
 
+/** Matches the skeleton idiom in src/app/loading.tsx. */
+const PULSE = 'rounded animate-pulse motion-reduce:animate-none'
+const PULSE_BG = { background: 'var(--color-border)' } as const
+
+const SKELETON_ROWS = ['70%', '55%', '80%', '45%'] as const
+
+/**
+ * What the wait is actually spent on, narrated in order (audit B8).
+ *
+ * The cook match runs a deterministic pass over the pantry, then sends only the
+ * leftovers to the model in one batch — measured at 4.9–6.2s end to end, nearly
+ * all of it the model call. A single static line for six seconds reads as a
+ * hang, so the stages advance on a timer to show the work is ongoing.
+ *
+ * These are honest labels for real phases, not a fake progress bar: the request
+ * gives no completion signal, so the copy describes what is happening rather
+ * than claiming a percentage. The last stage is deliberately open-ended — it
+ * stays put until the response lands however long that takes.
+ */
+const LOADING_STAGES = [
+  { label: 'Reading the recipe…', hint: 'Working out what each ingredient needs.' },
+  { label: 'Checking your pantry…', hint: 'Matching ingredients against what you have.' },
+  { label: 'Finding substitutes…', hint: 'Looking for stand-ins for anything missing.' },
+] as const
+
+/** Rough duration of the first two stages; the last one holds until the response. */
+const STAGE_MS = 1400
+
 function statusColor(status: IngredientMatch['status']): string {
   switch (status) {
     case 'ready':
@@ -153,7 +181,18 @@ export default function CookModal({
   const [errorMsg, setErrorMsg] = useState<string>('')
   const [addingToLibrary, setAddingToLibrary] = useState(false)
   const [overrides, setOverrides] = useState<Record<string, string>>({})
+  const [loadingStage, setLoadingStage] = useState(0)
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Advance the loading copy while the match runs, stopping on the last stage
+  // rather than looping — a cycling message would suggest repeated work.
+  useEffect(() => {
+    if (state !== 'loading') return
+    const id = setInterval(() => {
+      setLoadingStage((s) => (s < LOADING_STAGES.length - 1 ? s + 1 : s))
+    }, STAGE_MS)
+    return () => clearInterval(id)
+  }, [state])
 
   useEffect(() => {
     let cancelled = false
@@ -262,16 +301,43 @@ export default function CookModal({
           {/* Body */}
           <div className="flex-1 overflow-y-auto px-5 py-4">
             {state === 'loading' && (
-              <div className="flex flex-col items-center gap-3 py-10">
-                <div
-                  className="w-8 h-8 rounded-full border-2 border-t-transparent animate-spin"
-                  style={{ borderColor: 'var(--color-primary)', borderTopColor: 'transparent' }}
-                />
+              <div role="status" aria-live="polite" className="flex flex-col gap-4 py-2">
+                <span className="sr-only">Matching recipe ingredients against your pantry</span>
+
+                <div className="flex items-center gap-2.5">
+                  <div
+                    className="w-5 h-5 rounded-full border-2 border-t-transparent animate-spin motion-reduce:animate-none shrink-0"
+                    style={{ borderColor: 'var(--color-primary)', borderTopColor: 'transparent' }}
+                  />
+                  <p
+                    className="text-sm font-semibold text-[var(--color-text)]"
+                    style={{ fontFamily: 'Nunito, sans-serif' }}
+                  >
+                    {LOADING_STAGES[loadingStage].label}
+                  </p>
+                </div>
+
+                {/* Skeleton rows standing in for the match table. Gives the wait a
+                    shape that matches what arrives, so the modal doesn't jump
+                    from a centred spinner to a dense table (#245 / audit B8). */}
+                <div className="flex flex-col gap-2" aria-hidden="true">
+                  {SKELETON_ROWS.map((width, i) => (
+                    <div key={i} className="flex items-center gap-2">
+                      <div
+                        className={`h-3 ${PULSE} flex-1`}
+                        style={{ ...PULSE_BG, maxWidth: width }}
+                      />
+                      <div className={`h-3 w-12 ${PULSE}`} style={PULSE_BG} />
+                      <div className={`h-4 w-14 rounded-full ${PULSE}`} style={PULSE_BG} />
+                    </div>
+                  ))}
+                </div>
+
                 <p
-                  className="text-sm text-[var(--color-muted)]"
+                  className="text-xs text-[var(--color-muted)]"
                   style={{ fontFamily: 'Nunito, sans-serif' }}
                 >
-                  Checking your pantry...
+                  {LOADING_STAGES[loadingStage].hint}
                 </p>
               </div>
             )}


### PR DESCRIPTION
Stacked on #276 — review that one first. This PR's own diff is a single commit touching only `CookModal.tsx`'s loading state.

## Summary

The cook match takes **4.9–6.2s** against a real pantry and showed a centred spinner with one unchanging line, "Checking your pantry…", for the whole wait. That reads as a hang. #276 made it more exposed by moving the match onto the path *into* cooking rather than leaving it as a post-cook audit.

## Not a latency fix

Worth being explicit, because the issue title invites the wrong fix: `match_ingredients_with_llm` is already well structured. A deterministic pass resolves what it can, and only the leftovers go to the model, batched into one request — a fully-matched recipe makes no API call at all. The remaining time is that single unavoidable Gemini call:

```
INFO:bubbly_chef.ai.manager:AI request completed on [gemini/gemini-2.5-flash] in 4.85s → _LLMMatchBatch
INFO:bubbly_chef.ai.manager:AI request completed on [gemini/gemini-2.5-flash] in 6.15s → _LLMMatchBatch
```

So this changes the *perceived* wait, not the real one.

## What lands

- **Three stages advance on a timer** — "Reading the recipe…" → "Checking your pantry…" → "Finding substitutes…" — and stop on the last rather than looping, which would imply repeated work. The copy names real phases and never claims a percentage: the request gives no completion signal, so a progress bar would be fiction.
- **Skeleton rows stand in for the match table**, so the modal grows into its result instead of jumping from a centred spinner to a dense table. Reuses the `PULSE` idiom from `src/app/loading.tsx`, including its `motion-reduce` handling.
- **`role="status"` + `aria-live="polite"`** with an sr-only description, so the wait is announced rather than silent.

## Tests

`npx tsc --noEmit` clean; `npm test` 136 passed / 14 suites (unchanged — this is presentation only).

Verified live against a real pantry: stages advanced at **19ms / 1421ms / 2817ms**, held on the last until the response landed, then handed off to the table with no repeats and no loop.

## Linked

Closes #277

## Note

While measuring this I noticed the cook request fires **twice** per modal open in dev — React StrictMode double-invoking the effect. The `cancelled` flag correctly discards the second response, so there's no user-visible bug and production is unaffected, but it does mean every dev cook burns two Gemini calls. Not fixed here; mentioning it in case it's worth a look.