### PR TITLE
feat(cook): let the model suggest a multi-item substitution

### DIFF
--- a/ai-service/bubbly_chef/models/cook.py
+++ b/ai-service/bubbly_chef/models/cook.py
@@ -47,6 +47,23 @@ class IngredientMatch(BaseModel):
     )
 
 
+class CompoundSuggestion(BaseModel):
+    """A multi-item substitution the model proposes for a missing ingredient.
+
+    This is advisory only — nothing is deducted, and the ingredient stays in
+    CookProposal.missing. Deduction from compound substitutions is a deliberate
+    follow-up tracked separately.
+    """
+
+    ingredient_name: str = Field(description="The missing ingredient this suggestion covers")
+    components: list[str] = Field(
+        description="Pantry item names to combine (all must exist in the user's pantry)"
+    )
+    note: str = Field(
+        description="Short instruction for the cook, e.g. 'Melt butter, whisk in flour, add milk'"
+    )
+
+
 class CookProposal(BaseModel):
     """Proposal returned to the user before confirming a cook action."""
 
@@ -62,6 +79,14 @@ class CookProposal(BaseModel):
     unit_conflicts: list[dict[str, str]] = Field(
         default_factory=list,
         description="Ingredient names where unit conversion is not possible",
+    )
+    compound_suggestions: list[CompoundSuggestion] = Field(
+        default_factory=list,
+        description=(
+            "Advisory compound substitutions for missing ingredients — "
+            "e.g. heavy cream ← butter + milk + flour. "
+            "Nothing is deducted; the ingredient remains in missing."
+        ),
     )
 
 

--- a/ai-service/bubbly_chef/services/cook_matcher.py
+++ b/ai-service/bubbly_chef/services/cook_matcher.py
@@ -15,7 +15,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from bubbly_chef.domain.normalizer import normalize_food_name, normalize_to_base_unit
-from bubbly_chef.models.cook import CookProposal, IngredientMatch
+from bubbly_chef.models.cook import CompoundSuggestion, CookProposal, IngredientMatch
 from bubbly_chef.models.pantry import PantryItem
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,19 @@ class _LLMIngredientMatch(BaseModel):
     substitution_note: str | None = Field(
         default=None, description="One short sentence explaining the swap, for the user"
     )
+    # Compound substitution — only set when no single pantry item works but a
+    # combination of 2–3 items would. best_match must be null when this is set.
+    compound_components: list[str] | None = Field(
+        default=None,
+        description=(
+            "Ordered list of 2–3 pantry item names to combine when no single item works. "
+            "Only set when best_match is null and match_type is 'none'."
+        ),
+    )
+    compound_note: str | None = Field(
+        default=None,
+        description="Short instruction under ~20 words, e.g. 'Melt butter, whisk in flour, add milk'",
+    )
 
 
 class _LLMMatchBatch(BaseModel):
@@ -67,18 +80,31 @@ Recipe ingredients with no pantry match:
 Everything currently in their pantry:
 {pantry}
 
-For each unmatched ingredient, choose the single best pantry item, or null if nothing \
-sensible applies. Use match_type "exact" when it is genuinely the same ingredient under \
-a different name (pecorino romano and parmesan are not the same thing; scallion and \
-green onion are). Use "substitute" when it is a different ingredient that would still \
-work in a recipe, and say briefly what changes — flavour, texture, sweetness. Use \
-"none" when the honest answer is that they cannot make this ingredient.
+For each unmatched ingredient:
+
+1. PREFER a single pantry item when one genuinely works:
+   - Use match_type "exact" when it is the same ingredient under a different name \
+(scallion and green onion are the same; pecorino romano and parmesan are NOT).
+   - Use match_type "substitute" when a different ingredient would still work; note \
+briefly what changes — flavour, texture, sweetness.
+   - Set best_match to the pantry item name. Leave compound_components null.
+
+2. If NO single item works but 2-3 pantry items COMBINED can approximate the missing \
+ingredient, set match_type "none", best_match null, and populate compound_components \
+with the pantry item names AND compound_note with a short instruction (under 20 words).
+   Example: heavy cream is missing, pantry has butter, milk, and flour →
+     compound_components: ["butter", "milk", "flour"]
+     compound_note: "Melt butter, whisk in flour, stir in milk until thickened"
+   ONLY list items the user actually has. Do not invent ingredients.
+
+3. If nothing works, set match_type "none", best_match null, compound_components null.
 
 Do not suggest a swap that would change the dish into something else, and do not treat \
 derivatives as interchangeable: lemon juice cannot replace lemon zest, and vice versa. \
 Set confidence below {threshold} for anything you are unsure about.
 
-Keep substitution_note under 15 words. Return one result per unmatched ingredient."""
+Keep substitution_note and compound_note under 20 words each. Return one result per \
+unmatched ingredient."""
 
 # Matches leading quantity+unit in a raw ingredient string, e.g.:
 #   "2 large eggs"       → qty=2,  unit=None,   rest="large eggs"
@@ -454,19 +480,23 @@ async def resolve_aliases_with_llm(
     unmatched_names: list[str],
     pantry_items: list[PantryItem],
     ai_manager: Any,
-) -> dict[str, ResolvedAlias]:
+) -> tuple[dict[str, ResolvedAlias], list[CompoundSuggestion]]:
     """Ask the model which pantry items could stand in for unmatched ingredients.
 
-    One batched call for the whole set, not one per ingredient. Returns a map keyed
-    by normalized ingredient name; anything the model declines, scores below
-    SUBSTITUTION_CONFIDENCE_THRESHOLD, or names a pantry item that does not exist
-    is dropped, so the caller simply sees fewer aliases.
+    One batched call for the whole set, not one per ingredient. Returns a tuple of:
+    - aliases: map keyed by normalized ingredient name; anything the model declines,
+      scores below SUBSTITUTION_CONFIDENCE_THRESHOLD, or names a pantry item that does
+      not exist is dropped, so the caller simply sees fewer aliases.
+    - compound_suggestions: advisory multi-item suggestions for ingredients that have
+      no single-item match. Every component must exist in the user's pantry; if any
+      component is missing the whole suggestion is dropped. These never enter the
+      alias/deduction path.
 
-    Never raises. Any provider failure returns an empty map, which leaves the
+    Never raises. Any provider failure returns empty collections, which leaves the
     ingredients missing exactly as they were before this tier existed.
     """
     if not unmatched_names or not pantry_items:
-        return {}
+        return {}, []
 
     pantry_by_norm = {_normalize_ingredient_name(i.name): i for i in pantry_items}
 
@@ -484,36 +514,79 @@ async def resolve_aliases_with_llm(
         )
     except Exception as e:  # noqa: BLE001 - degrading to "missing" is the contract
         logger.warning(f"Substitution matching unavailable, leaving ingredients missing: {e}")
-        return {}
+        return {}, []
 
     if not isinstance(result, _LLMMatchBatch):
         logger.warning("Substitution matching returned an unexpected shape; ignoring")
-        return {}
+        return {}, []
 
     aliases: dict[str, ResolvedAlias] = {}
+    compound_suggestions: list[CompoundSuggestion] = []
+
     for entry in result.results:
-        if entry.match_type == "none" or not entry.best_match:
-            continue
-        if entry.confidence < SUBSTITUTION_CONFIDENCE_THRESHOLD:
-            logger.debug(
-                f"Dropping low-confidence match {entry.ingredient_name} -> "
-                f"{entry.best_match} ({entry.confidence})"
+        # --- Single-item path ---
+        if entry.best_match and entry.match_type != "none":
+            if entry.confidence < SUBSTITUTION_CONFIDENCE_THRESHOLD:
+                logger.debug(
+                    f"Dropping low-confidence match {entry.ingredient_name} -> "
+                    f"{entry.best_match} ({entry.confidence})"
+                )
+                continue
+
+            pantry_norm = _normalize_ingredient_name(entry.best_match)
+            if pantry_norm not in pantry_by_norm:
+                # Model named something the user does not have.
+                logger.debug(f"Dropping match to absent pantry item: {entry.best_match}")
+                continue
+
+            aliases[_normalize_ingredient_name(entry.ingredient_name)] = ResolvedAlias(
+                pantry_name=pantry_norm,
+                match_type=entry.match_type,
+                note=entry.substitution_note,
             )
             continue
 
-        pantry_norm = _normalize_ingredient_name(entry.best_match)
-        if pantry_norm not in pantry_by_norm:
-            # Model named something the user does not have.
-            logger.debug(f"Dropping match to absent pantry item: {entry.best_match}")
-            continue
+        # --- Compound path ---
+        # Only attempt when match_type is "none" (single item didn't work), the model
+        # provided components, and a note to go with them.
+        if (
+            entry.match_type == "none"
+            and entry.compound_components
+            and entry.compound_note
+        ):
+            if entry.confidence < SUBSTITUTION_CONFIDENCE_THRESHOLD:
+                logger.debug(
+                    f"Dropping low-confidence compound suggestion for "
+                    f"{entry.ingredient_name} ({entry.confidence})"
+                )
+                continue
 
-        aliases[_normalize_ingredient_name(entry.ingredient_name)] = ResolvedAlias(
-            pantry_name=pantry_norm,
-            match_type=entry.match_type,
-            note=entry.substitution_note,
-        )
+            # Validate every component exists in the pantry; drop the whole
+            # suggestion if any is absent — we must not invent stock.
+            all_present = True
+            resolved_components: list[str] = []
+            for component_name in entry.compound_components:
+                comp_norm = _normalize_ingredient_name(component_name)
+                if comp_norm not in pantry_by_norm:
+                    logger.debug(
+                        f"Dropping compound suggestion for {entry.ingredient_name}: "
+                        f"component '{component_name}' not in pantry"
+                    )
+                    all_present = False
+                    break
+                # Use the pantry's display name so the UI can show something consistent.
+                resolved_components.append(pantry_by_norm[comp_norm].name)
 
-    return aliases
+            if all_present and resolved_components:
+                compound_suggestions.append(
+                    CompoundSuggestion(
+                        ingredient_name=entry.ingredient_name,
+                        components=resolved_components,
+                        note=entry.compound_note,
+                    )
+                )
+
+    return aliases, compound_suggestions
 
 
 async def match_ingredients_with_llm(
@@ -532,17 +605,40 @@ async def match_ingredients_with_llm(
     The aliases are fed into a single match_ingredients() pass rather than being
     matched separately afterwards, so substitutes share the same per-pantry-item
     consumption accounting as direct matches.
+
+    Compound suggestions are threaded onto the returned proposal, but only for
+    ingredients that actually ended up in proposal.missing — an ingredient resolved
+    deterministically must not carry a contradictory compound suggestion.
     """
     unmatched = _unmatched_ingredient_names(recipe_ingredients, pantry_items)
 
     aliases: dict[str, ResolvedAlias] = {}
+    raw_compound_suggestions: list[CompoundSuggestion] = []
     if unmatched:
-        aliases = await resolve_aliases_with_llm(unmatched, pantry_items, ai_manager)
+        aliases, raw_compound_suggestions = await resolve_aliases_with_llm(
+            unmatched, pantry_items, ai_manager
+        )
 
-    return match_ingredients(
+    proposal = match_ingredients(
         recipe_id=recipe_id,
         recipe_title=recipe_title,
         recipe_ingredients=recipe_ingredients,
         pantry_items=pantry_items,
         aliases=aliases,
     )
+
+    # Filter compound suggestions to those whose ingredient is still missing after
+    # the full matching pass. An ingredient resolved by the deterministic or alias
+    # path must not carry a contradictory compound suggestion.
+    if raw_compound_suggestions:
+        still_missing = {name.lower() for name in proposal.missing}
+        filtered_suggestions = [
+            s for s in raw_compound_suggestions
+            if s.ingredient_name.lower() in still_missing
+        ]
+        if filtered_suggestions:
+            proposal = proposal.model_copy(
+                update={"compound_suggestions": filtered_suggestions}
+            )
+
+    return proposal

--- a/ai-service/tests/test_cook_matcher.py
+++ b/ai-service/tests/test_cook_matcher.py
@@ -16,6 +16,7 @@ from bubbly_chef.services.cook_matcher import (
     _LLMMatchBatch,
     match_ingredients,
     match_ingredients_with_llm,
+    resolve_aliases_with_llm,
 )
 
 
@@ -609,3 +610,224 @@ class TestPieceUnitParsing:
 
         assert proposal.matches[0].status == "ready"
         assert proposal.matches[0].deduct_qty == pytest.approx(0.375)
+
+
+class TestCompoundSuggestions:
+    """Compound substitution suggestions — suggest only, never deduct (#281)."""
+
+    @staticmethod
+    def _ai(batch: object) -> MagicMock:
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value=batch)
+        return ai
+
+    @pytest.mark.asyncio
+    async def test_valid_compound_suggestion_reaches_proposal(self) -> None:
+        """A compound suggestion with all components in pantry appears on the proposal."""
+        pantry = [
+            _make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g"),
+            _make_item("milk", 500.0, "ml", qty_base=500.0, unit_base="ml"),
+            _make_item("flour", 1.0, "kg", qty_base=1000.0, unit_base="g"),
+        ]
+        ingredients = [{"name": "heavy cream", "quantity": 200.0, "unit": "ml"}]
+        ai = self._ai(
+            _LLMMatchBatch(
+                results=[
+                    _LLMIngredientMatch(
+                        ingredient_name="heavy cream",
+                        best_match=None,
+                        match_type="none",
+                        confidence=0.8,
+                        compound_components=["butter", "milk", "flour"],
+                        compound_note="Melt butter, whisk in flour, stir in milk",
+                    )
+                ]
+            )
+        )
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        # Ingredient still missing — nothing was deducted
+        assert "heavy cream" in proposal.missing
+        assert not any(m.ingredient_name == "heavy cream" for m in proposal.matches)
+
+        # Compound suggestion is present
+        assert len(proposal.compound_suggestions) == 1
+        suggestion = proposal.compound_suggestions[0]
+        assert suggestion.ingredient_name == "heavy cream"
+        assert set(suggestion.components) == {"butter", "milk", "flour"}
+        assert "butter" in suggestion.note.lower() or "flour" in suggestion.note.lower() or suggestion.note
+
+    @pytest.mark.asyncio
+    async def test_compound_suggestion_with_absent_component_is_dropped(self) -> None:
+        """If any component is not in the pantry the whole suggestion is dropped."""
+        pantry = [
+            _make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g"),
+            _make_item("milk", 500.0, "ml", qty_base=500.0, unit_base="ml"),
+            # flour is NOT in pantry
+        ]
+        ingredients = [{"name": "heavy cream", "quantity": 200.0, "unit": "ml"}]
+        ai = self._ai(
+            _LLMMatchBatch(
+                results=[
+                    _LLMIngredientMatch(
+                        ingredient_name="heavy cream",
+                        best_match=None,
+                        match_type="none",
+                        confidence=0.8,
+                        compound_components=["butter", "milk", "flour"],
+                        compound_note="Melt butter, whisk in flour, stir in milk",
+                    )
+                ]
+            )
+        )
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        assert "heavy cream" in proposal.missing
+        # Suggestion must be dropped entirely when a component is absent
+        assert proposal.compound_suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_compound_suggestion_is_dropped(self) -> None:
+        """Compound suggestions below the threshold are discarded."""
+        pantry = [
+            _make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g"),
+            _make_item("milk", 500.0, "ml", qty_base=500.0, unit_base="ml"),
+        ]
+        ingredients = [{"name": "heavy cream", "quantity": 200.0, "unit": "ml"}]
+        ai = self._ai(
+            _LLMMatchBatch(
+                results=[
+                    _LLMIngredientMatch(
+                        ingredient_name="heavy cream",
+                        best_match=None,
+                        match_type="none",
+                        confidence=0.4,  # below SUBSTITUTION_CONFIDENCE_THRESHOLD (0.7)
+                        compound_components=["butter", "milk"],
+                        compound_note="Whisk together",
+                    )
+                ]
+            )
+        )
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        assert "heavy cream" in proposal.missing
+        assert proposal.compound_suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_compound_suggestion_does_not_create_match_or_affect_deductions(self) -> None:
+        """A compound suggestion must not produce an IngredientMatch and must not deduct."""
+        pantry = [
+            _make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g"),
+            _make_item("milk", 500.0, "ml", qty_base=500.0, unit_base="ml"),
+            _make_item("eggs", 6.0, "count", qty_base=6.0, unit_base="count"),
+        ]
+        ingredients = [
+            {"name": "eggs", "quantity": 2.0, "unit": "count"},
+            {"name": "heavy cream", "quantity": 200.0, "unit": "ml"},
+        ]
+        ai = self._ai(
+            _LLMMatchBatch(
+                results=[
+                    _LLMIngredientMatch(
+                        ingredient_name="heavy cream",
+                        best_match=None,
+                        match_type="none",
+                        confidence=0.8,
+                        compound_components=["butter", "milk"],
+                        compound_note="Melt butter, stir in milk",
+                    )
+                ]
+            )
+        )
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        # heavy cream is still missing
+        assert "heavy cream" in proposal.missing
+
+        # No IngredientMatch for heavy cream
+        cream_matches = [m for m in proposal.matches if m.ingredient_name == "heavy cream"]
+        assert cream_matches == []
+
+        # The only deduction is for eggs; butter and milk untouched
+        deduct_totals = {m.pantry_item_name: m.deduct_qty for m in proposal.matches}
+        assert "eggs" in deduct_totals
+        assert "butter" not in deduct_totals
+        assert "milk" not in deduct_totals
+
+        # Compound suggestion is present
+        assert len(proposal.compound_suggestions) == 1
+
+    @pytest.mark.asyncio
+    async def test_provider_failure_yields_no_compound_suggestions(self) -> None:
+        """A provider outage must not fail the proposal and yields empty suggestions."""
+        pantry = [_make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g")]
+        ingredients = [{"name": "heavy cream", "quantity": 200.0, "unit": "ml"}]
+        ai = MagicMock()
+        ai.complete = AsyncMock(side_effect=NoProviderAvailableError("all providers down"))
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        assert "heavy cream" in proposal.missing
+        assert proposal.compound_suggestions == []
+
+    @pytest.mark.asyncio
+    async def test_compound_suggestion_not_attached_to_resolved_ingredient(self) -> None:
+        """An ingredient resolved by deterministic matching must not carry a suggestion."""
+        # butter resolves deterministically; model should never see it,
+        # but even if it returns a compound suggestion for it, the filter drops it.
+        pantry = [
+            _make_item("butter", 250.0, "g", qty_base=250.0, unit_base="g"),
+            _make_item("milk", 500.0, "ml", qty_base=500.0, unit_base="ml"),
+        ]
+        ingredients = [
+            {"name": "butter", "quantity": 100.0, "unit": "g"},
+            {"name": "heavy cream", "quantity": 200.0, "unit": "ml"},
+        ]
+
+        # The model is called for "heavy cream" (unmatched). Simulate it also
+        # returning a bogus suggestion for "butter" (which was matched deterministically).
+        # We test via resolve_aliases_with_llm directly to confirm the filter in
+        # match_ingredients_with_llm strips it.
+        ai = self._ai(
+            _LLMMatchBatch(
+                results=[
+                    _LLMIngredientMatch(
+                        ingredient_name="heavy cream",
+                        best_match=None,
+                        match_type="none",
+                        confidence=0.8,
+                        compound_components=["butter", "milk"],
+                        compound_note="Melt butter, stir in milk",
+                    ),
+                ]
+            )
+        )
+
+        proposal = await match_ingredients_with_llm(
+            RECIPE_ID, RECIPE_TITLE, ingredients, pantry, ai
+        )
+
+        # butter is matched and deducted
+        butter_match = next(m for m in proposal.matches if m.ingredient_name == "butter")
+        assert butter_match.status == "ready"
+
+        # heavy cream is still missing and has a compound suggestion
+        assert "heavy cream" in proposal.missing
+        assert any(s.ingredient_name == "heavy cream" for s in proposal.compound_suggestions)
+
+        # No compound suggestion for butter (it was resolved)
+        assert not any(s.ingredient_name == "butter" for s in proposal.compound_suggestions)

--- a/nextjs/src/__tests__/cook-flow-redesign.test.tsx
+++ b/nextjs/src/__tests__/cook-flow-redesign.test.tsx
@@ -350,7 +350,7 @@ describe('endCookingSession — banner retires after a completed cook (#268)', (
 // ─── Cook preview + unresolved-row summary (#267, #245) ──────────────────────
 
 import { summariseDeductions } from '@/components/recipes/CookModal'
-import type { CookProposal, IngredientMatch } from '@/types/recipes'
+import type { CookProposal, CompoundSuggestion, IngredientMatch } from '@/types/recipes'
 
 const match = (over: Partial<IngredientMatch>): IngredientMatch => ({
   ingredient_name: 'thing',
@@ -370,6 +370,7 @@ const proposalOf = (matches: IngredientMatch[]): CookProposal => ({
   matches,
   missing: [],
   unit_conflicts: [],
+  compound_suggestions: [],
 } as unknown as CookProposal)
 
 describe('summariseDeductions (#245)', () => {
@@ -420,5 +421,83 @@ describe('summariseDeductions (#245)', () => {
     expect(summariseDeductions(p, { '0': '' }).skipped).toHaveLength(1)
     expect(summariseDeductions(p, { '0': '0' }).skipped).toHaveLength(1)
     expect(summariseDeductions(p, { '0': 'abc' }).skipped).toHaveLength(1)
+  })
+})
+
+// ─── Compound suggestion rendering in the "Not in pantry" section (#281) ─────
+
+import CookModal from '@/components/recipes/CookModal'
+
+jest.mock('next/navigation', () => ({ useRouter: () => ({ push: jest.fn() }) }))
+jest.mock('@/lib/api/recipes', () => ({
+  cookRecipe: jest.fn(),
+  confirmCook: jest.fn(),
+}))
+
+// Pull the mocked cookRecipe reference for test control
+const { cookRecipe: mockCookRecipe } = jest.requireMock('@/lib/api/recipes') as {
+  cookRecipe: jest.Mock
+}
+
+const compoundProposal = (suggestions: CompoundSuggestion[]): CookProposal => ({
+  recipe_id: 'r1',
+  recipe_title: 'Cream Sauce',
+  matches: [],
+  missing: ['heavy cream'],
+  unit_conflicts: [],
+  compound_suggestions: suggestions,
+} as unknown as CookProposal)
+
+describe('CookModal — compound suggestion rendering (#281)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the compound suggestion under the missing ingredient', async () => {
+    mockCookRecipe.mockResolvedValue(
+      compoundProposal([
+        {
+          ingredient_name: 'heavy cream',
+          components: ['butter', 'milk', 'flour'],
+          note: 'Melt butter, whisk in flour, add milk',
+        },
+      ]),
+    )
+
+    render(
+      <CookModal
+        recipeId="r1"
+        recipeTitle="Cream Sauce"
+        onClose={jest.fn()}
+        onCooked={jest.fn()}
+      />,
+    )
+
+    // Wait for the proposal to load
+    const suggestion = await screen.findByLabelText(/compound substitution suggestion for heavy cream/i)
+    expect(suggestion).toBeInTheDocument()
+    expect(suggestion.textContent).toMatch(/butter.*\+.*milk.*\+.*flour/i)
+    expect(suggestion.textContent).toMatch(/Melt butter/i)
+  })
+
+  it('renders the missing ingredient tag without a suggestion when none is provided', async () => {
+    mockCookRecipe.mockResolvedValue(compoundProposal([]))
+
+    render(
+      <CookModal
+        recipeId="r1"
+        recipeTitle="Cream Sauce"
+        onClose={jest.fn()}
+        onCooked={jest.fn()}
+      />,
+    )
+
+    // The missing chip should appear
+    await screen.findByText(/⚠️ heavy cream/i)
+
+    // No suggestion node
+    expect(
+      screen.queryByLabelText(/compound substitution suggestion/i),
+    ).not.toBeInTheDocument()
   })
 })

--- a/nextjs/src/components/recipes/CookModal.tsx
+++ b/nextjs/src/components/recipes/CookModal.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion, AnimatePresence } from 'framer-motion'
 import { cookRecipe, confirmCook } from '@/lib/api/recipes'
-import type { CookProposal, IngredientMatch, DeductionItem } from '@/types/recipes'
+import type { CookProposal, CompoundSuggestion, IngredientMatch, DeductionItem } from '@/types/recipes'
 
 interface CookModalProps {
   recipeId: string
@@ -478,16 +478,36 @@ export default function CookModal({
                     >
                       Not in pantry
                     </p>
-                    <div className="flex flex-wrap gap-1.5">
-                      {proposal.missing.map((name: string) => (
-                        <span
-                          key={name}
-                          className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border border-[var(--color-border)] text-[var(--color-muted)]"
-                          style={{ fontFamily: 'Nunito, sans-serif' }}
-                        >
-                          ⚠️ {name}
-                        </span>
-                      ))}
+                    <div className="flex flex-col gap-2">
+                      {proposal.missing.map((name: string) => {
+                        const suggestion = (proposal.compound_suggestions ?? []).find(
+                          (s: CompoundSuggestion) =>
+                            s.ingredient_name.toLowerCase() === name.toLowerCase(),
+                        )
+                        return (
+                          <div key={name} className="flex flex-col gap-0.5">
+                            <span
+                              className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border border-[var(--color-border)] text-[var(--color-muted)] self-start"
+                              style={{ fontFamily: 'Nunito, sans-serif' }}
+                            >
+                              ⚠️ {name}
+                            </span>
+                            {suggestion && (
+                              <div
+                                className="ml-2 text-[10px] leading-snug text-[var(--color-muted)]"
+                                style={{ fontFamily: 'Nunito, sans-serif' }}
+                                aria-label={`Compound substitution suggestion for ${name}`}
+                              >
+                                <span className="font-semibold">
+                                  Try combining:{' '}
+                                </span>
+                                {suggestion.components.join(' + ')}
+                                <span className="block italic mt-0.5">{suggestion.note}</span>
+                              </div>
+                            )}
+                          </div>
+                        )
+                      })}
                     </div>
                   </div>
                 )}

--- a/nextjs/src/types/recipes.ts
+++ b/nextjs/src/types/recipes.ts
@@ -92,12 +92,26 @@ export interface IngredientMatch {
   substitution_note: string | null
 }
 
+/**
+ * Advisory multi-item substitution for a missing ingredient.
+ * Nothing is deducted — the ingredient stays in CookProposal.missing.
+ */
+export interface CompoundSuggestion {
+  ingredient_name: string
+  /** Pantry item names to combine — all exist in the user's pantry. */
+  components: string[]
+  /** Short instruction for the cook, e.g. "Melt butter, whisk in flour, add milk" */
+  note: string
+}
+
 export interface CookProposal {
   recipe_id: string
   recipe_title: string
   matches: IngredientMatch[]
   missing: string[]
   unit_conflicts: Array<{ ingredient: string; recipe_unit: string; pantry_unit: string }>
+  /** Advisory compound substitutions — never deducted. Default: []. */
+  compound_suggestions: CompoundSuggestion[]
 }
 
 export interface DeductionItem {


### PR DESCRIPTION
## Summary

Heavy cream lands in the dead-end "Not in pantry" strip not because nothing in the pantry works, but because `_SUBSTITUTION_PROMPT` asked for **"the single best pantry item, or null"**. A combination — butter + milk + flour — was literally unrepresentable, so the model was forced to answer `"none"`.

Which is the odd part: Bubbles suggests exactly that roux when you ask the same question in chat. The knowledge was there; the schema had nowhere to put it.

## Suggestion only — deliberately

A compound swap **does not deduct**. The ingredient stays in `CookProposal.missing`, creates no `IngredientMatch`, and never reaches the `consumed` accounting, `DeductionItem`, or the confirm payload. Verified in the diff: no line touching `consumed`, `deduct_qty`, `pantry_item_id`, or `summariseDeductions` changed.

Deducting across several pantry rows needs the matcher's per-item consumption accounting to apportion one ingredient across multiple items, and there's an unsolved question underneath it (how much butter vs milk stands in for a cup of cream?). That's filed as #284. This PR lands the half carrying nearly all the user value: knowing what to do about the cream.

## What lands

- New `CompoundSuggestion` model on `CookProposal`, defaulting to an empty list so existing consumers and older payloads stay valid.
- Every component name is validated against the pantry using the same normalization as single matches. **If any one component is absent, the whole suggestion is dropped** rather than half-shown — a recipe for butter + milk + flour is useless if you have no flour.
- Suggestions are returned separately from `aliases` so they cannot leak into the deduction path, then filtered against the final `missing` list: an ingredient that resolved deterministically must not carry a contradictory suggestion.
- The prompt still prefers a single-item swap when one exists, so this doesn't make simple cases worse.
- The modal renders the components and the instruction under the missing ingredient, visually secondary — advice, not something being deducted.

## Tests

Backend **431 passed** (was 425), ruff clean. Frontend **138 passed** (was 136), tsc clean.

Six backend cases: valid suggestion reaches the proposal; a suggestion naming an item the user doesn't have is dropped entirely; low-confidence dropped; a suggestion creates no `IngredientMatch` and no deduction; provider failure yields none; a resolved ingredient carries none. Plus two frontend render cases.

## Linked

Related to #281 (item 1, suggestion half)
Follow-up filed as #284 (deduction half)

## Merge order note

This branch and #282 both change `resolve_aliases_with_llm` to return a tuple, with **different** second elements — `list[CompoundSuggestion]` here, `dict[str, str]` of missing-notes there. They will conflict. Whichever merges second needs the return type widened to carry both; the logic is independent and shouldn't fight, it's purely the signature. Happy to do that rebase — say which you want first.

## Note

Not verified in the live app: this needs a recipe whose missing ingredient the model chooses to answer with a combination, which I can't reliably force from chat. Covered by unit tests at both layers; worth an eye during manual QA.