### PR TITLE
fix(chat): pantry opt-out that persists, brainstorm card colour, and an eslint CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - name: TypeScript
         run: npx tsc --noEmit
 
+      # Without this gate the error count drifts upward unnoticed — it had reached
+      # 8 before anyone looked (#149). Warnings stay non-fatal; errors fail the build.
+      - name: ESLint
+        run: npx eslint src/ --max-warnings=-1
+
       - name: Jest
         run: npm test -- --ci
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ AIManager.get_provider()  # returns first available: Gemini → Ollama
 **Live at:** https://bubbly-chef.vercel.app
 
 **Done:**
-- Phase 1 + 2: pantry CRUD, receipt scanning, recipe generation, chat intent router, DOM kitchen scene, milestone decorations, 454+ tests
+- Phase 1 + 2: pantry CRUD, receipt scanning, recipe generation, chat intent router, 454+ tests
 - Migration: Next.js + Supabase + FastAPI AI microservice (three-tier)
 - Recipe library UI: save, search, edit, delete, favourite
 - Phase 7: Deployed to Vercel + Railway; Gemini Vision OCR; all core features working in production
@@ -380,6 +380,17 @@ the same credential differently.
 - `mutating` state in RecipeBook — buttons not yet `disabled={mutating}`
 - iOS Safari bottom nav bug — issue #4
 - Recipe generation ignores constraint modifications from chat follow-up — BubblyChef-747
+- The `decorations` table and `GET /api/decorations` exist, but nothing in
+  `nextjs/src` consumes them and there is no kitchen-scene component — the
+  milestone/decoration feature is a backend stub with no UI. The gamification
+  and live-kitchen design that would build on it is held (high risk, medium
+  value, not MVP) — see PR #124
+- Chat can't be told to ignore the pantry, and the instruction is lost on the
+  next turn — issue #287
+- Expiring items are forced into every suggestion regardless of whether they
+  suit the dish — issue #288
+- Chat only ever proposes a single all-in-one dish; there is no notion of a
+  meal with separate components — issue #289
 
 ---
 
@@ -412,7 +423,7 @@ add a new one.
 
 ---
 
-*Last updated: 2026-07-11*
+*Last updated: 2026-08-30*
 
 
 ## Issue Tracking

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,7 +25,7 @@ A Sanrio-inspired pantry + recipe assistant grounded in your actual kitchen.
 | Phase | Description |
 |---|---|
 | Phase 1 | Pantry CRUD, receipt scanning, recipe generation, LangGraph workflows, 454+ tests |
-| Phase 2 | Chat intent router, recipe grounding (constraint extraction + expiry scoring), conversation history, DOM kitchen scene + milestone decorations |
+| Phase 2 | Chat intent router, recipe grounding (constraint extraction + expiry scoring), conversation history |
 | Migration | Next.js + Supabase + FastAPI AI microservice (three-tier rewrite); component migration done; JWT wiring + SSE streaming done |
 | Recipe library | Save, search, edit, delete, favourite recipes; `is_favorite` toggle; search auto-select; ingredients + instructions editing |
 | AI workflows R1+R2 | Sub-graph decomposition (`chat/`, `pantry/`, `recipe/`), parent router, server-side conversation sessions + context-aware routing (`SessionMode`) |
@@ -144,4 +144,4 @@ None outstanding. Both entries previously listed here are closed:
 
 ---
 
-*Last updated: 2026-05-02*
+*Last updated: 2026-08-30*

--- a/ai-service/bubbly_chef/models/recipe.py
+++ b/ai-service/bubbly_chef/models/recipe.py
@@ -95,6 +95,21 @@ class RecipeConstraints(BaseModel):
             "every suggestion must actually use these."
         ),
     )
+    use_pantry: bool | None = Field(
+        default=None,
+        description=(
+            "Whether to ground suggestions in the user's pantry. False when the user "
+            "asks us not to look at it ('don't look at my pantry', 'ignore what I "
+            "have'); True when they ask us to start using it again. None means they "
+            "did not say either way, which is what lets a previous turn's choice "
+            "survive instead of being overwritten by every silent turn."
+        ),
+    )
+
+    @property
+    def pantry_grounded(self) -> bool:
+        """True unless the user explicitly opted out. None (unstated) means grounded."""
+        return self.use_pantry is not False
 
 
 class IngredientAvailability(BaseModel):

--- a/ai-service/bubbly_chef/workflows/recipe/nodes.py
+++ b/ai-service/bubbly_chef/workflows/recipe/nodes.py
@@ -112,7 +112,13 @@ RECIPE_CONSTRAINTS_SYSTEM_PROMPT = (
     "Record only the ingredient name in must_use_ingredients (e.g. 'eggs', not "
     "'my eggs' or 'eggs before they go bad'). Leave it empty if the user names no "
     "specific ingredient (e.g. 'what's for dinner?', 'give me a quick pasta recipe' — "
-    "'pasta' there is a dish, not an ingredient the user is using up)."
+    "'pasta' there is a dish, not an ingredient the user is using up).\n\n"
+    "use_pantry: set to false ONLY when the user asks us not to use their pantry "
+    "-- 'don't look at my pantry', 'ignore what I have', 'forget my pantry', "
+    "'just give me a recipe'. Set it to true ONLY when they ask us to start using "
+    "it again -- 'use my pantry', 'what can I make with what I have'. If they say "
+    "nothing either way, leave it null: null means 'no opinion this turn', and a "
+    "choice they made earlier stays in force."
 )
 
 BRAINSTORM_SYSTEM_PROMPT = """\
@@ -128,6 +134,30 @@ this overrides every other preference
 - ALL suggestions must be for the same meal type — if meal_type is specified, \
 every idea must fit that meal (don't mix breakfast and dinner)
 - Only suggest recipes that can realistically be made with 60%+ of the listed ingredients
+- Format: conversational text with **bold** recipe names in a numbered list
+- End with a prompt like "Which one sounds good?" or "Want me to make any of these?"\
+"""
+
+# Used when the user has asked us not to look at their pantry (#287). The two
+# pantry-dependent rules are dropped rather than softened: "prioritize expiring"
+# and "60%+ of the listed ingredients" both refer to a list that is not in this
+# prompt, and leaving them in is what pulled the pantry back into a conversation
+# the user had explicitly excluded it from.
+BRAINSTORM_SYSTEM_PROMPT_NO_PANTRY = """\
+You are a creative cooking assistant. Suggest 3-4 recipe ideas from the user's \
+request alone.
+
+The user has asked you NOT to use their pantry. Do not mention their pantry, \
+their stock, or anything expiring, and do not steer the suggestions toward \
+ingredients you think they might have. Work only from what they asked for.
+
+Rules:
+- Each idea should be a recipe name (2-5 words), not a full recipe
+- If "Must use" ingredients are listed, EVERY idea must actually use them — \
+this overrides every other preference
+- Match the cuisine/mood if specified
+- ALL suggestions must be for the same meal type — if meal_type is specified, \
+every idea must fit that meal (don't mix breakfast and dinner)
 - Format: conversational text with **bold** recipe names in a numbered list
 - End with a prompt like "Which one sounds good?" or "Want me to make any of these?"\
 """
@@ -407,6 +437,15 @@ def score_and_rank(
 # =============================================================================
 
 
+def is_pantry_grounded(constraints: dict[str, Any] | None) -> bool:
+    """Whether pantry grounding is on for this turn.
+
+    Only an explicit False turns it off. None means the user never said either
+    way, so grounding stays on — the default the app has always had.
+    """
+    return (constraints or {}).get("use_pantry") is not False
+
+
 def _default_meal_type() -> str:
     """Infer meal type from current time of day."""
     hour = datetime.now().hour
@@ -437,6 +476,10 @@ def _merge_constraints(
     - must_use_ingredients: fresh list wins when non-empty; otherwise inherit
       prior. This ensures dietary restrictions AND must-use ingredients both
       survive a follow-up turn that doesn't repeat them.
+    - use_pantry: tri-state. A fresh True or False wins; None means the user said
+      nothing this turn, so the prior choice stands. Without this a user who said
+      "don't look at my pantry" got the pantry back on their very next message
+      (#287).
     """
     merged: dict[str, Any] = dict(prior)
 
@@ -458,6 +501,12 @@ def _merge_constraints(
         if fresh_list:
             merged[key] = fresh_list
         # else: keep prior value (already in merged)
+
+    # Tri-state, so it cannot use the scalar rule above: False is a real choice
+    # the user made, and only None means "no opinion this turn".
+    fresh_use_pantry = fresh.get("use_pantry")
+    if fresh_use_pantry is not None:
+        merged["use_pantry"] = fresh_use_pantry
 
     return merged
 
@@ -506,9 +555,10 @@ async def extract_recipe_constraints(state: WorkflowState) -> WorkflowState:
         constraints = _merge_constraints(prior, constraints)
         logger.info(
             "Merged prior session constraints into fresh extraction "
-            "(dietary=%s, must_use=%s)",
+            "(dietary=%s, must_use=%s, use_pantry=%s)",
             constraints.get("dietary"),
             constraints.get("must_use_ingredients"),
+            constraints.get("use_pantry"),
         )
 
     # Default meal_type from time of day when user didn't specify
@@ -527,6 +577,13 @@ async def score_pantry_ingredients(state: WorkflowState) -> WorkflowState:
     pantry_items: list[dict[str, Any]] = state.get("pantry_snapshot") or []
     constraints: dict[str, Any] = state.get("recipe_constraints") or {}
     logger.info("Scoring pantry ingredients", extra={"constraints": constraints})
+
+    # The user asked us not to use their pantry. Return nothing rather than
+    # scoring and letting a downstream node decide: an empty list means no
+    # prompt-builder can reach for the stock even by accident (#287).
+    if not is_pantry_grounded(constraints):
+        logger.info("Pantry grounding is off for this turn; skipping scoring")
+        return {**state, "scored_pantry_items": []}
 
     # Fetch from DB if no snapshot was passed in
     if not pantry_items:
@@ -569,10 +626,18 @@ _MODE_SYSTEM_PROMPTS: dict[str, str] = {
 }
 
 
-def _get_mode_prefix(state: WorkflowState) -> str:
+# Recipe mode's own instruction to lean on the pantry. Dropped from the prefix
+# when the user has opted out, otherwise it contradicts the rest of the prompt.
+_RECIPE_MODE_PANTRY_LINE = "Prioritize ingredients the user already has in their pantry.\n"
+
+
+def _get_mode_prefix(state: WorkflowState, *, pantry_grounded: bool = True) -> str:
     """Return the system prompt prefix for the current chat mode."""
     mode = state.get("input_mode", "chat")
-    return _MODE_SYSTEM_PROMPTS.get(mode, "")
+    prefix = _MODE_SYSTEM_PROMPTS.get(mode, "")
+    if not pantry_grounded:
+        prefix = prefix.replace(_RECIPE_MODE_PANTRY_LINE, "")
+    return prefix
 
 
 def _format_history_context(state: WorkflowState, max_turns: int = 10) -> str:
@@ -595,6 +660,7 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
     input_text = state.get("input_text", "")
     scored_items: list[dict[str, Any]] = state.get("scored_pantry_items") or []
     constraints: dict[str, Any] = state.get("recipe_constraints") or {}
+    pantry_grounded = is_pantry_grounded(constraints)
 
     # Fall back to the time of day, same as the recipe-generate path does at
     # `extract_recipe_constraints`. Without this the brainstorm prompt says only
@@ -604,7 +670,11 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
         constraints = {**constraints, "meal_type": _default_meal_type()}
 
     # Build ingredient summary for the prompt
-    if scored_items:
+    if not pantry_grounded:
+        # No pantry block at all — not an empty one. "No pantry items available"
+        # would still invite the model to talk about the pantry.
+        pantry_context = ""
+    elif scored_items:
         must_use = [i for i in scored_items if i.get("_must_use")]
         # Expired stock is dropped from the suggestion pool entirely (#239):
         # scoring no longer promotes it, but leaving it under "Other available"
@@ -651,10 +721,13 @@ async def brainstorm_recipe_ideas(state: WorkflowState) -> WorkflowState:
         constraints_str += f"\nExclude: {', '.join(constraints['excluded_ingredients'])}"
 
     history_context = _format_history_context(state)
-    mode_prefix = _get_mode_prefix(state)
+    mode_prefix = _get_mode_prefix(state, pantry_grounded=pantry_grounded)
+    system_prompt = (
+        BRAINSTORM_SYSTEM_PROMPT if pantry_grounded else BRAINSTORM_SYSTEM_PROMPT_NO_PANTRY
+    )
     prompt = (
         mode_prefix
-        + BRAINSTORM_SYSTEM_PROMPT
+        + system_prompt
         + pantry_context
         + constraints_str
         + "\n\n"
@@ -735,9 +808,12 @@ async def generate_grounded_recipe(state: WorkflowState) -> WorkflowState:
     constraints: dict[str, Any] = state.get("recipe_constraints") or {}
     scored_items: list[dict[str, Any]] = state.get("scored_pantry_items") or []
     web_result: dict[str, Any] | None = state.get("web_search_result")
+    pantry_grounded = is_pantry_grounded(constraints)
 
-    # If pantry wasn't scored yet (direct recipe_card path), try to load & score now
-    if not scored_items:
+    # If pantry wasn't scored yet (direct recipe_card path), try to load & score now.
+    # Skipped entirely when the user opted out — this is the path that would
+    # otherwise re-fetch the pantry from the DB after scoring had been skipped.
+    if not scored_items and pantry_grounded:
         pantry_snapshot: list[dict[str, Any]] = state.get("pantry_snapshot") or []
         if not pantry_snapshot:
             try:
@@ -769,7 +845,11 @@ async def generate_grounded_recipe(state: WorkflowState) -> WorkflowState:
     else:
         context = "Use your culinary knowledge to create an authentic recipe."
 
-    constraints_json = _json.dumps({k: v for k, v in constraints.items() if v})
+    # use_pantry is an instruction to us, not a constraint to hand the model; when
+    # it is off the prompt below already omits every pantry field.
+    constraints_json = _json.dumps(
+        {k: v for k, v in constraints.items() if v and k != "use_pantry"}
+    )
     prompt = GROUNDED_RECIPE_SYSTEM_PROMPT.format(
         recipe_name=recipe_name,
         constraints_json=constraints_json,

--- a/ai-service/tests/test_issue_287_pantry_optout.py
+++ b/ai-service/tests/test_issue_287_pantry_optout.py
@@ -1,0 +1,298 @@
+"""Issue #287: "don't look at my pantry" must be representable, and must persist.
+
+The reported failure was a two-turn sequence. Turn 1: "I want a recipe with chicken
+and potatoes. Don't look at my pantry." — honoured. Turn 2: "Like a full meal. It can
+be separate dishes." — the pantry came back, and every suggestion was bent around
+expiring apples and bananas.
+
+Three things had to be true for that bug to exist, and this file pins all three:
+the constraint is extracted, the prompts actually drop the pantry when it is off,
+and the choice survives a follow-up turn that doesn't repeat it.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bubbly_chef.models.recipe import RecipeConstraints
+from bubbly_chef.workflows.recipe.nodes import (
+    _merge_constraints,
+    brainstorm_recipe_ideas,
+    extract_recipe_constraints,
+    generate_grounded_recipe,
+    is_pantry_grounded,
+    score_pantry_ingredients,
+)
+from bubbly_chef.workflows.state import LLMRecipeResult
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_ai(return_value: Any) -> Any:
+    ai = MagicMock()
+    ai.complete = AsyncMock(return_value=return_value)
+    return patch(
+        "bubbly_chef.workflows.recipe.nodes.get_ai_manager",
+        MagicMock(return_value=ai),
+    )
+
+
+def _captured_prompt(ai_patch_target: Any) -> str:
+    """Pull the prompt out of the single ai_manager.complete call."""
+    return str(ai_patch_target.complete.await_args.kwargs["prompt"])
+
+
+def _pantry(*names: str) -> list[dict[str, Any]]:
+    return [
+        {"name": n, "quantity": 1.0, "unit": "piece", "days_until_expiry": 1}
+        for n in names
+    ]
+
+
+def _state(**extra: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "input_text": "",
+        "user_id": "user-1",
+        "input_mode": "chat",
+        "conversation_history": [],
+    }
+    base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# The flag itself
+# ---------------------------------------------------------------------------
+
+
+class TestPantryGroundedPredicate:
+    """None means 'no opinion', not 'off' — the distinction the whole fix rests on."""
+
+    def test_unstated_is_grounded(self) -> None:
+        assert is_pantry_grounded({}) is True
+        assert is_pantry_grounded({"use_pantry": None}) is True
+
+    def test_only_explicit_false_turns_it_off(self) -> None:
+        assert is_pantry_grounded({"use_pantry": False}) is False
+        assert is_pantry_grounded({"use_pantry": True}) is True
+
+    def test_none_constraints_are_grounded(self) -> None:
+        assert is_pantry_grounded(None) is True
+
+    def test_model_property_agrees(self) -> None:
+        assert RecipeConstraints().pantry_grounded is True
+        assert RecipeConstraints(use_pantry=True).pantry_grounded is True
+        assert RecipeConstraints(use_pantry=False).pantry_grounded is False
+
+
+# ---------------------------------------------------------------------------
+# Persistence across turns — the actual reported bug
+# ---------------------------------------------------------------------------
+
+
+class TestOptOutSurvivesFollowUp:
+    def test_merge_keeps_false_when_the_next_turn_says_nothing(self) -> None:
+        merged = _merge_constraints({"use_pantry": False}, {"use_pantry": None})
+        assert merged["use_pantry"] is False
+
+    def test_merge_lets_the_user_turn_it_back_on(self) -> None:
+        merged = _merge_constraints({"use_pantry": False}, {"use_pantry": True})
+        assert merged["use_pantry"] is True
+
+    def test_merge_lets_the_user_turn_it_off_later(self) -> None:
+        merged = _merge_constraints({"use_pantry": True}, {"use_pantry": False})
+        assert merged["use_pantry"] is False
+
+    def test_absent_key_does_not_resurrect_the_pantry(self) -> None:
+        """A fresh extraction with no use_pantry key at all must not override."""
+        merged = _merge_constraints({"use_pantry": False}, {"cuisine": "italian"})
+        assert merged["use_pantry"] is False
+        assert merged["cuisine"] == "italian"
+
+    @pytest.mark.asyncio
+    async def test_second_turn_inherits_the_opt_out_end_to_end(self) -> None:
+        """Turn 2 says nothing about the pantry; the turn-1 opt-out must hold."""
+        state = _state(
+            input_text="Like a full meal. It can be separate dishes",
+            session={"metadata": {"recipe_constraints": {"use_pantry": False}}},
+        )
+        # The model, seeing no pantry mention this turn, returns None for the flag.
+        with _mock_ai(RecipeConstraints(use_pantry=None, meal_type="dinner")):
+            result = await extract_recipe_constraints(state)  # type: ignore[arg-type]
+
+        assert result["recipe_constraints"]["use_pantry"] is False
+        assert is_pantry_grounded(result["recipe_constraints"]) is False
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+
+class TestScoringShortCircuits:
+    @pytest.mark.asyncio
+    async def test_opt_out_skips_scoring_entirely(self) -> None:
+        state = _state(
+            pantry_snapshot=_pantry("banana", "apple"),
+            recipe_constraints={"use_pantry": False},
+        )
+        result = await score_pantry_ingredients(state)  # type: ignore[arg-type]
+        assert result["scored_pantry_items"] == []
+
+    @pytest.mark.asyncio
+    async def test_opt_out_never_touches_the_database(self) -> None:
+        """With no snapshot, the grounded path hits the repo; the opted-out one must not."""
+        state = _state(pantry_snapshot=[], recipe_constraints={"use_pantry": False})
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_repository", new_callable=AsyncMock
+        ) as repo:
+            result = await score_pantry_ingredients(state)  # type: ignore[arg-type]
+        repo.assert_not_awaited()
+        assert result["scored_pantry_items"] == []
+
+    @pytest.mark.asyncio
+    async def test_default_still_scores(self) -> None:
+        state = _state(pantry_snapshot=_pantry("chicken"), recipe_constraints={})
+        result = await score_pantry_ingredients(state)  # type: ignore[arg-type]
+        assert len(result["scored_pantry_items"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Prompts — the part that actually reached the user
+# ---------------------------------------------------------------------------
+
+
+class TestBrainstormPrompt:
+    @pytest.mark.asyncio
+    async def test_opted_out_prompt_carries_no_pantry_and_no_expiry_rule(self) -> None:
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value="**Roast Chicken**\nWhich one sounds good?")
+        state = _state(
+            input_text="I want a recipe with chicken and potatoes. Don't look at my pantry.",
+            scored_pantry_items=[],
+            recipe_constraints={"use_pantry": False, "meal_type": "dinner"},
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ):
+            await brainstorm_recipe_ideas(state)  # type: ignore[arg-type]
+
+        prompt = _captured_prompt(ai)
+        assert "Expiring soon" not in prompt
+        assert "Prioritize ingredients marked as expiring soon" not in prompt
+        assert "Other available" not in prompt
+        # The "no pantry items available" fallback would still invite pantry talk.
+        assert "No pantry items available" not in prompt
+        assert "asked you NOT to use their pantry" in prompt
+
+    @pytest.mark.asyncio
+    async def test_opted_out_prompt_drops_the_60_percent_rule(self) -> None:
+        """That rule refers to a list this prompt no longer contains."""
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value="**Roast Chicken**")
+        state = _state(
+            input_text="chicken, ignore my pantry",
+            scored_pantry_items=[],
+            recipe_constraints={"use_pantry": False},
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ):
+            await brainstorm_recipe_ideas(state)  # type: ignore[arg-type]
+        assert "60%+" not in _captured_prompt(ai)
+
+    @pytest.mark.asyncio
+    async def test_opted_out_recipe_mode_drops_its_own_pantry_line(self) -> None:
+        """Recipe mode's prefix says to prioritise the pantry — it must not contradict."""
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value="**Roast Chicken**")
+        state = _state(
+            input_text="chicken, don't look at my pantry",
+            input_mode="recipe",
+            scored_pantry_items=[],
+            recipe_constraints={"use_pantry": False},
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ):
+            await brainstorm_recipe_ideas(state)  # type: ignore[arg-type]
+        prompt = _captured_prompt(ai)
+        assert "already has in their pantry" not in prompt
+        assert "RECIPE MODE" in prompt  # the rest of the mode prefix survives
+
+    @pytest.mark.asyncio
+    async def test_must_use_still_binds_when_opted_out(self) -> None:
+        """Opting out of the pantry is not opting out of what the user asked for."""
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value="**Chicken Potato Bake**")
+        state = _state(
+            input_text="chicken and potatoes, don't look at my pantry",
+            scored_pantry_items=[],
+            recipe_constraints={
+                "use_pantry": False,
+                "must_use_ingredients": ["chicken", "potatoes"],
+            },
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ):
+            await brainstorm_recipe_ideas(state)  # type: ignore[arg-type]
+        prompt = _captured_prompt(ai)
+        assert "chicken, potatoes" in prompt
+        assert "Must use" in prompt
+
+    @pytest.mark.asyncio
+    async def test_default_prompt_is_unchanged(self) -> None:
+        """The grounded path must behave exactly as before."""
+        ai = MagicMock()
+        ai.complete = AsyncMock(return_value="**Chicken Bake**")
+        state = _state(
+            input_text="what can I make?",
+            scored_pantry_items=[
+                {"name": "spinach", "_score": 12, "_must_use": False, "_expired": False},
+            ],
+            recipe_constraints={},
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ):
+            await brainstorm_recipe_ideas(state)  # type: ignore[arg-type]
+        prompt = _captured_prompt(ai)
+        assert "Expiring soon (prioritize): spinach" in prompt
+        assert "Prioritize ingredients marked as expiring soon" in prompt
+
+
+class TestGroundedRecipePrompt:
+    @pytest.mark.asyncio
+    async def test_opted_out_generation_does_not_reload_the_pantry(self) -> None:
+        """The direct recipe_card path re-fetches when unscored — it must not here."""
+        ai = MagicMock()
+        ai.complete = AsyncMock(
+            return_value=LLMRecipeResult(
+                title="Roast Chicken",
+                description="d",
+                ingredients=[],
+                instructions=["step"],
+            )
+        )
+        state = _state(
+            input_text="Roast Chicken",
+            selected_recipe_name="Roast Chicken",
+            scored_pantry_items=[],
+            pantry_snapshot=[],
+            recipe_constraints={"use_pantry": False},
+        )
+        with patch(
+            "bubbly_chef.workflows.recipe.nodes.get_ai_manager", MagicMock(return_value=ai)
+        ), patch(
+            "bubbly_chef.workflows.recipe.nodes.get_repository", new_callable=AsyncMock
+        ) as repo:
+            await generate_grounded_recipe(state)  # type: ignore[arg-type]
+
+        repo.assert_not_awaited()
+        prompt = _captured_prompt(ai)
+        assert "use_pantry" not in prompt
+        assert "Priority ingredients (expiring soon — use first): none specified" in prompt

--- a/nextjs/src/__tests__/brainstorm-options.test.tsx
+++ b/nextjs/src/__tests__/brainstorm-options.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Issue #286: brainstorm option cards must not wear the user's colour.
+ *
+ * The reported failure was purely visual — three assistant suggestions rendered
+ * as solid `--color-primary` blocks, the same token MessageBubble gives the
+ * user's own messages, so the transcript read as if the user had sent them.
+ *
+ * A snapshot would not catch a regression here in any useful way, so these
+ * assert the one property that actually matters: primary belongs to the user,
+ * and nothing in this component may claim it.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import BrainstormOptions from '@/components/chat/BrainstormOptions'
+
+const IDEAS = ['Loaded Chicken Potato Skins', 'Spicy Chicken Potato Bites']
+
+function markup(container: HTMLElement): string {
+  return container.innerHTML
+}
+
+describe('BrainstormOptions', () => {
+  it('renders one card per idea', () => {
+    render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    IDEAS.forEach((idea) => expect(screen.getByText(idea)).toBeInTheDocument())
+  })
+
+  it('renders nothing when there are no ideas', () => {
+    const { container } = render(<BrainstormOptions ideas={[]} onSelect={jest.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // ── The actual bug ────────────────────────────────────────────────────────
+
+  it('never uses --color-primary, which is the user-message colour', () => {
+    const { container } = render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    expect(markup(container)).not.toContain('--color-primary')
+  })
+
+  it('uses the accent family so the cards read as assistant content', () => {
+    const { container } = render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    expect(markup(container)).toContain('--color-accent')
+  })
+
+  it('does not put white text on the accent strip', () => {
+    // White on accent measures 1.28–1.67:1 across the six themes.
+    const { container } = render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    expect(markup(container)).not.toContain('text-white')
+  })
+
+  it('renders the affordance at full opacity, not a faded variant', () => {
+    // At /80 the affordance fell to 3.87:1 in the mint theme.
+    render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    const affordances = screen.getAllByText(/Tap to make/)
+    affordances.forEach((el) => {
+      expect(el.className).toContain('text-[var(--color-text)]')
+      expect(el.className).not.toMatch(/text-\[var\(--color-text\)\]\/\d+/)
+    })
+  })
+
+  // ── Behaviour that had to survive the re-treatment ────────────────────────
+
+  it('fires onSelect with the idea that was tapped', () => {
+    const onSelect = jest.fn()
+    render(<BrainstormOptions ideas={IDEAS} onSelect={onSelect} />)
+
+    fireEvent.click(screen.getByRole('listitem', { name: `Pick ${IDEAS[1]}` }))
+    expect(onSelect).toHaveBeenCalledWith(IDEAS[1])
+  })
+
+  it('shows the tap affordance only on interactive cards', () => {
+    const { rerender } = render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} />)
+    expect(screen.getAllByText(/Tap to make/)).toHaveLength(IDEAS.length)
+
+    rerender(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} disabled />)
+    expect(screen.queryByText(/Tap to make/)).not.toBeInTheDocument()
+  })
+
+  it('does not fire onSelect when disabled', () => {
+    const onSelect = jest.fn()
+    render(<BrainstormOptions ideas={IDEAS} onSelect={onSelect} disabled />)
+
+    fireEvent.click(screen.getByRole('listitem', { name: `Pick ${IDEAS[0]}` }))
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('keeps the idea titles legible when disabled', () => {
+    // Older brainstorm messages stay readable rather than fading out entirely.
+    render(<BrainstormOptions ideas={IDEAS} onSelect={jest.fn()} disabled />)
+    IDEAS.forEach((idea) => expect(screen.getByText(idea)).toBeInTheDocument())
+  })
+})

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -136,6 +136,11 @@ function PantryPageInner() {
   useEffect(() => {
     const addParam = searchParams.get('add')
     if (addParam === 'scan' || addParam === 'type') {
+      /* The URL is an external system being synced into React, which is exactly
+         what an effect is for. This cannot be derived state: the user must be able
+         to close the sheet again, so once opened its visibility belongs to the
+         component, not the param. */
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setAddSheetTab(addParam)
       setAddSheetOpen(true)
     }

--- a/nextjs/src/components/ThemeProvider.tsx
+++ b/nextjs/src/components/ThemeProvider.tsx
@@ -43,6 +43,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY)
     const resolved = stored !== null && isValidTheme(stored) ? stored : DEFAULT_THEME
+    /* The extra render pass is the point: rendering DEFAULT_THEME first is what
+       keeps the server and client passes identical, and localStorage cannot be
+       read before hydration without reintroducing the mismatch this component
+       exists to avoid. Moving this into a lazy useState initialiser brings the
+       hydration bug straight back. */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setThemeState(resolved)
     document.documentElement.setAttribute('data-theme', resolved)
   }, [])

--- a/nextjs/src/components/chat/BrainstormOptions.tsx
+++ b/nextjs/src/components/chat/BrainstormOptions.tsx
@@ -16,10 +16,19 @@ export interface BrainstormOptionsProps {
 }
 
 /**
- * Renders a vertical stack of tappable mini recipe cards modelled on
- * ChatRecipeCard's pink header strip — same `bg-[var(--color-primary)]`,
- * `rounded-2xl`, white bold title, shadow-sm treatment — so tapping one
- * feels like it "expands" into the full recipe card the backend returns.
+ * Renders a vertical stack of tappable mini recipe cards, shaped exactly like
+ * ChatRecipeCard (same `rounded-2xl` white shell, header strip, shadow-sm) so
+ * tapping one still feels like it "expands" into the full recipe card the
+ * backend returns.
+ *
+ * The strip is `--color-accent`, NOT `--color-primary` (#286). Primary is the
+ * user's own message colour in MessageBubble, so a primary strip made three
+ * assistant suggestions read as three messages the user had just sent —
+ * indistinguishable at a glance on a 480px viewport. Accent is the assistant
+ * family (the assistant bubble is `--color-accent`/30 with an accent border),
+ * and every theme defines accent and primary as a contrasting pair, so this
+ * holds across all of them. The strip going accent → primary when the real
+ * recipe card arrives now reads as a state change rather than a coincidence.
  *
  * Each card fires `onSelect(ideaName)`, which is sent as the next chat
  * message. The backend fuzzy-matches the exact name → returns a recipe_card.
@@ -53,23 +62,31 @@ export default function BrainstormOptions({
           transition={{ ...springs.snappy, delay: i * 0.07 }}
           whileTap={disabled ? undefined : { scale: 0.97 }}
           className={[
-            // Outer card shell — matches ChatRecipeCard wrapper exactly
-            'rounded-2xl bg-white border border-[var(--color-border)] shadow-sm overflow-hidden',
+            // Outer card shell — ChatRecipeCard's geometry, with an accent border
+            // instead of its neutral one so the whole card sits in the assistant
+            // family rather than borrowing the user's colour.
+            'rounded-2xl bg-[var(--color-surface)] border border-[var(--color-accent)] shadow-sm overflow-hidden',
             'w-full text-left',
             disabled
               ? 'cursor-default opacity-70'
               : 'cursor-pointer hover:brightness-97 active:brightness-90',
           ].join(' ')}
         >
-          {/* Header strip — identical to ChatRecipeCard's title strip */}
-          <div className="bg-[var(--color-primary)] px-4 py-2.5 flex items-center justify-between gap-3">
-            <h4 className="text-white font-bold text-sm leading-snug flex-1">
+          {/* Header strip — ChatRecipeCard's shape in the assistant's colour.
+              Measured, not eyeballed. White on accent is 1.28–1.67:1 across the
+              six themes, so the title and the affordance both use --color-text.
+              Accent at /55 over --color-surface gives 5.59:1 (mint) to 8.74:1
+              (lavender); solid accent would drop mint to 4.47:1, just under AA.
+              The affordance is full-opacity for the same reason — at /80 it fell
+              to 3.87:1 in mint — and separates by size and weight instead. */}
+          <div className="bg-[var(--color-accent)]/55 px-4 py-2.5 flex items-center justify-between gap-3">
+            <h4 className="text-[var(--color-text)] font-bold text-sm leading-snug flex-1">
               {idea}
             </h4>
             {!disabled && (
               <span
                 aria-hidden
-                className="text-white/70 text-xs font-semibold flex-shrink-0"
+                className="text-[var(--color-text)] text-xs font-semibold flex-shrink-0"
               >
                 Tap to make →
               </span>


### PR DESCRIPTION
## Summary

Three independent fixes, two of them from a real chat session that went wrong.

Closes #286
Closes #287
Closes #149

## #287 — "don't look at my pantry" now sticks

The reported sequence: turn 1 asked for chicken and potatoes with *"Don't look at my pantry"* and was honoured; turn 2 said *"Like a full meal"* and the pantry came back, bending every suggestion around expiring apples and bananas.

The instruction had nowhere to live. `RecipeConstraints` modelled must-use, preferred and excluded ingredients but nothing that meant *don't ground on the pantry*, so it was discarded at the structured-output boundary. Turn 1 only appeared to work because the raw text was in the prompt; by turn 2 it was competing with an explicit `Expiring soon (prioritize)` block.

**The flag is tri-state, not a bool.** A `bool` defaulting to `True` cannot express *"the user said nothing this turn"*, so every silent follow-up would overwrite the choice — which is precisely the bug. `None` means no opinion and `_merge_constraints` inherits the prior value; only an explicit `True`/`False` changes it. `is_pantry_grounded()` reads `None` as grounded, so the existing default is untouched.

When grounding is off:

- `score_pantry_ingredients` returns `[]` **without querying the repo**, so no downstream node can reach for the stock by accident.
- Brainstorm uses a prompt with no pantry block and no expiry rule, rather than a softened one. The "No pantry items available" fallback goes too — it still invites the model to discuss the pantry.
- The `60%+ of the listed ingredients` rule goes with it, since it refers to a list the prompt no longer contains.
- Recipe mode's own *"prioritize ingredients the user already has"* line is stripped from the mode prefix, which would otherwise contradict everything else.
- `generate_grounded_recipe` skips the re-fetch it does on the direct `recipe_card` path.

Must-use ingredients still bind when grounding is off — opting out of the pantry is not opting out of what the user asked for.

## #286 — brainstorm cards no longer wear the user's colour

`BrainstormOptions` painted its header strip `bg-[var(--color-primary)]` with white bold text — the same token `MessageBubble` gives user messages — so three assistant suggestions read as three messages the user had just sent.

The cards keep `ChatRecipeCard`'s geometry and move to the accent family, which is already the assistant's. The strip going accent → primary when the real recipe card arrives now reads as a state change rather than a coincidence.

**Contrast was measured across all six themes, and both numbers changed the design:**

| | ratio | outcome |
|---|---|---|
| White on accent | 1.28–1.67:1 | title and affordance use `--color-text` |
| Solid accent | 4.47:1 in mint | strip is `accent/55` instead → 5.59–8.74:1 |
| Affordance at `/80` | 3.87:1 in mint | full opacity; separates by size and weight |

## #149 — two eslint errors, and the gate that stops them returning

The issue reported 8 errors across 5 files; **2 remained.** The four `react/no-unescaped-entities` errors were fixed by #166 (which used no closing keyword, so the issue stayed open), and two of the four `set-state-in-effect` sites have since been resolved independently.

Both survivors are the deliberate patterns the issue itself anticipated, so each gets a documented disable rather than a "fix" that reintroduces a bug — `ThemeProvider` renders `DEFAULT_THEME` first so the SSR passes agree, and `pantry/page.tsx` syncs the `?add=` param into state that the user must then be able to close.

The CI gate is the part that matters: without it the count drifts unnoticed, which is how it reached 8. Errors now fail the `nextjs` job; warnings stay non-fatal.

## Also included

`CLAUDE.md` and `ROADMAP.md` claimed "DOM kitchen scene + milestone decorations" shipped in Phase 1+2. Verified against the tree: the `decorations` table and `GET /api/decorations` exist, but **nothing in `nextjs/src` consumes them** and there is no kitchen-scene component. Corrected to describe a backend stub with no UI, and the newly-filed #287/#288/#289 added to Known Limitations.

## Testing

- `pytest` — **468 passed, 13 skipped** (18 new for #287)
- `ruff check bubbly_chef/` — clean
- `npx tsc --noEmit` — clean
- `npx eslint src/` — **0 errors** (exit 0)
- `npm test` — **151 passed** (10 new for #286)

#286's tests assert the property rather than a snapshot: this component may not reference `--color-primary` at all, and the affordance may not carry an opacity suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfLKvfYudmMLSoC1bqpFrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfLKvfYudmMLSoC1bqpFrZ)_