### PR TITLE
feat(expiry): close the loop — resolve actions and a Use Soon triage view

### DIFF
--- a/nextjs/src/__tests__/pantry-resolve.test.tsx
+++ b/nextjs/src/__tests__/pantry-resolve.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Issue #140: resolve actions — "Used it up" / "Tossed it" with recordable outcomes.
+ *
+ * Two surfaces, deliberately different: expiring and expired cards get visible
+ * buttons because urgency earns the real estate, and every other card resolves
+ * by a graduated swipe so normal stock stays visually clean.
+ *
+ * The swipe's safety property is the thing worth pinning — a short drag must
+ * reveal without committing, because that graduation replaces the confirm
+ * dialog the spec deliberately dropped.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react'
+import ResolveActions from '@/components/pantry/ResolveActions'
+import SwipeToResolve, {
+  COMMIT_DISTANCE,
+  REVEAL_DISTANCE,
+  gestureVerdict,
+} from '@/components/pantry/SwipeToResolve'
+
+describe('ResolveActions', () => {
+  it('commits "used" on a single tap — the happy path is not gated', () => {
+    const onResolve = jest.fn()
+    render(<ResolveActions itemName="spinach" onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /used up/i }))
+    expect(onResolve).toHaveBeenCalledWith('used')
+  })
+
+  it('does not toss on first tap — it swaps to a confirm', () => {
+    const onResolve = jest.fn()
+    render(<ResolveActions itemName="spinach" onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /tossed/i }))
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /confirm spinach was tossed/i })).toBeInTheDocument()
+  })
+
+  it('commits "tossed" only after the confirm', () => {
+    const onResolve = jest.fn()
+    render(<ResolveActions itemName="spinach" onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /tossed/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm spinach was tossed/i }))
+    expect(onResolve).toHaveBeenCalledWith('tossed')
+  })
+
+  it('lets the user back out of the toss confirm', () => {
+    const onResolve = jest.fn()
+    render(<ResolveActions itemName="spinach" onResolve={onResolve} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /tossed/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onResolve).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /used up/i })).toBeInTheDocument()
+  })
+
+  it('disables both actions while a resolve is in flight', () => {
+    render(<ResolveActions itemName="spinach" onResolve={jest.fn()} pending />)
+    expect(screen.getByRole('button', { name: /used up/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /tossed/i })).toBeDisabled()
+  })
+
+  it('gives every action a 44px target', () => {
+    // WCAG 2.5.5 — the labels stay text-xs so the 2-column grid doesn't reflow.
+    render(<ResolveActions itemName="spinach" onResolve={jest.fn()} />)
+    expect(screen.getByRole('button', { name: /used up/i }).className).toContain('min-h-[44px]')
+    expect(screen.getByRole('button', { name: /tossed/i }).className).toContain('min-h-[44px]')
+  })
+})
+
+describe('SwipeToResolve — gesture thresholds', () => {
+  /**
+   * The graduation IS the safety mechanism: the spec dropped the confirm dialog
+   * on the grounds that a light swipe cannot commit. framer-motion's drag does
+   * not run under jsdom, so this is tested through the pure decision function
+   * rather than through a simulated pointer sequence that would assert nothing.
+   */
+
+  it('treats a stray touch as a no-op', () => {
+    expect(gestureVerdict(0)).toEqual({ kind: 'reset' })
+    expect(gestureVerdict(12)).toEqual({ kind: 'reset' })
+    expect(gestureVerdict(-12)).toEqual({ kind: 'reset' })
+  })
+
+  it('reveals — but does not commit — at the reveal distance', () => {
+    expect(gestureVerdict(REVEAL_DISTANCE)).toEqual({ kind: 'reveal', outcome: 'used' })
+    expect(gestureVerdict(-REVEAL_DISTANCE)).toEqual({ kind: 'reveal', outcome: 'tossed' })
+  })
+
+  it('still only reveals just below the commit distance', () => {
+    // The gap between the two thresholds is the whole safety margin.
+    expect(gestureVerdict(COMMIT_DISTANCE - 1).kind).toBe('reveal')
+    expect(gestureVerdict(-(COMMIT_DISTANCE - 1)).kind).toBe('reveal')
+  })
+
+  it('commits at and beyond the commit distance', () => {
+    expect(gestureVerdict(COMMIT_DISTANCE)).toEqual({ kind: 'commit', outcome: 'used' })
+    expect(gestureVerdict(400)).toEqual({ kind: 'commit', outcome: 'used' })
+    expect(gestureVerdict(-COMMIT_DISTANCE)).toEqual({ kind: 'commit', outcome: 'tossed' })
+    expect(gestureVerdict(-400)).toEqual({ kind: 'commit', outcome: 'tossed' })
+  })
+
+  it('maps right to used and left to tossed, never the reverse', () => {
+    // Getting this backwards would silently bin food the user meant to keep.
+    expect(gestureVerdict(200)).toEqual({ kind: 'commit', outcome: 'used' })
+    expect(gestureVerdict(-200)).toEqual({ kind: 'commit', outcome: 'tossed' })
+  })
+
+  it('keeps reveal strictly below commit', () => {
+    expect(REVEAL_DISTANCE).toBeLessThan(COMMIT_DISTANCE)
+  })
+})
+
+describe('SwipeToResolve — rendering', () => {
+  it('renders its child', () => {
+    render(
+      <SwipeToResolve itemName="rice" onResolve={jest.fn()}>
+        <div>rice card</div>
+      </SwipeToResolve>
+    )
+    expect(screen.getByText('rice card')).toBeInTheDocument()
+  })
+
+  it('offers both outcomes in the action layer', () => {
+    render(
+      <SwipeToResolve itemName="rice" onResolve={jest.fn()}>
+        <div>rice card</div>
+      </SwipeToResolve>
+    )
+    expect(screen.getByText(/Used it/)).toBeInTheDocument()
+    expect(screen.getByText(/Tossed/)).toBeInTheDocument()
+  })
+
+  it('does not commit on mount', () => {
+    const onResolve = jest.fn()
+    render(
+      <SwipeToResolve itemName="rice" onResolve={onResolve}>
+        <div>rice card</div>
+      </SwipeToResolve>
+    )
+    expect(onResolve).not.toHaveBeenCalled()
+  })
+
+  it('hides the action layer from assistive tech', () => {
+    // A screen-reader user must never be asked to perform a drag; the buttons
+    // on urgent cards, and the reduced-motion fallback, are the accessible path.
+    const { container } = render(
+      <SwipeToResolve itemName="rice" onResolve={jest.fn()}>
+        <div>rice card</div>
+      </SwipeToResolve>
+    )
+    expect(container.querySelector('[aria-hidden]')).toBeInTheDocument()
+  })
+})

--- a/nextjs/src/__tests__/use-soon.test.ts
+++ b/nextjs/src/__tests__/use-soon.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Issue #139: the Use Soon triage view — urgency-sorted, resolvable rows.
+ *
+ * The list logic is what's worth pinning: which items belong on the page and in
+ * what order. Both differ deliberately from `/api/pantry/expiring`, which
+ * excludes already-expired stock (#239) because it answers a different question.
+ */
+
+import { needsAttention, urgencySort, urgencyTier } from '@/app/pantry/use-soon/page'
+import type { PantryItem } from '@/types/pantry'
+
+/** An item expiring `days` from today, as a local date string. */
+function itemExpiringIn(days: number | null, name = 'item'): PantryItem {
+  let expiry: string | null = null
+  if (days !== null) {
+    const d = new Date()
+    d.setDate(d.getDate() + days)
+    expiry = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  }
+  return {
+    id: name,
+    name,
+    category: 'produce',
+    location: 'fridge',
+    quantity: 1,
+    unit: 'piece',
+    expiry_date: expiry,
+  }
+}
+
+describe('needsAttention', () => {
+  it('includes expired items — this page is where they get cleared', () => {
+    // /api/pantry/expiring deliberately excludes these (#239); this view is the
+    // one place they belong, now that #140 gives them a remedy.
+    expect(needsAttention(itemExpiringIn(-10))).toBe(true)
+    expect(needsAttention(itemExpiringIn(-1))).toBe(true)
+  })
+
+  it('includes items expiring today and within the 3-day window', () => {
+    expect(needsAttention(itemExpiringIn(0))).toBe(true)
+    expect(needsAttention(itemExpiringIn(1))).toBe(true)
+    expect(needsAttention(itemExpiringIn(3))).toBe(true)
+  })
+
+  it('excludes items with time left', () => {
+    expect(needsAttention(itemExpiringIn(4))).toBe(false)
+    expect(needsAttention(itemExpiringIn(30))).toBe(false)
+  })
+
+  it('excludes items with no expiry date at all', () => {
+    // Dry goods with no date aren't urgent and would otherwise pin to the top.
+    expect(needsAttention(itemExpiringIn(null))).toBe(false)
+  })
+})
+
+describe('urgencySort', () => {
+  it('puts the most overdue item first', () => {
+    const items = [itemExpiringIn(2, 'b'), itemExpiringIn(-5, 'a'), itemExpiringIn(0, 'c')]
+    expect(items.sort(urgencySort).map((i) => i.name)).toEqual(['a', 'c', 'b'])
+  })
+
+  it('orders strictly by days remaining, not by expired-vs-not', () => {
+    const items = [itemExpiringIn(3, 'd'), itemExpiringIn(-1, 'b'), itemExpiringIn(-9, 'a'), itemExpiringIn(1, 'c')]
+    expect(items.sort(urgencySort).map((i) => i.name)).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('sinks undated items rather than sorting them as urgent', () => {
+    const items = [itemExpiringIn(null, 'z'), itemExpiringIn(1, 'a')]
+    expect(items.sort(urgencySort).map((i) => i.name)).toEqual(['a', 'z'])
+  })
+})
+
+describe('urgencyTier', () => {
+  it('names the overdue case in days, not as a bare "Expired"', () => {
+    expect(urgencyTier(-1)?.label).toBe('Expired yesterday')
+    expect(urgencyTier(-4)?.label).toBe('Expired 4d ago')
+  })
+
+  it('uses words for the two most urgent live cases', () => {
+    expect(urgencyTier(0)?.label).toBe('Today')
+    expect(urgencyTier(1)?.label).toBe('Tomorrow')
+  })
+
+  it('counts days beyond that', () => {
+    expect(urgencyTier(3)?.label).toBe('3 days left')
+  })
+
+  it('gives expired and same-day items the strongest colour', () => {
+    expect(urgencyTier(-1)?.color).toContain('--color-expired')
+    expect(urgencyTier(0)?.color).toContain('--color-expired')
+    expect(urgencyTier(3)?.color).toContain('--color-expiring')
+  })
+
+  it('returns nothing for an undated item', () => {
+    expect(urgencyTier(null)).toBeNull()
+  })
+})

--- a/nextjs/src/app/api/pantry/[id]/resolve/route.ts
+++ b/nextjs/src/app/api/pantry/[id]/resolve/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from 'next/server'
+import { requireAuth, errorResponse, notFound } from '@/lib/response-helpers'
+import { daysUntilExpiry } from '@/lib/pantry-helpers'
+import type { PantryItemRow } from '@/lib/pantry-helpers'
+
+/** Outcomes the client may record. Must match the CHECK constraint on pantry_events. */
+const OUTCOMES = ['used', 'tossed', 'cooked'] as const
+type Outcome = (typeof OUTCOMES)[number]
+
+function isOutcome(value: unknown): value is Outcome {
+  return typeof value === 'string' && (OUTCOMES as readonly string[]).includes(value)
+}
+
+/**
+ * POST /api/pantry/[id]/resolve — record what happened to an item and clear it.
+ *
+ * Body: `{ outcome: 'used' | 'tossed' | 'cooked' }`
+ *
+ * The event is written BEFORE the item is deleted, and a failed write aborts the
+ * whole thing. There is no transaction across these two statements from here, so
+ * the order is the safety property: writing the event second would mean a
+ * mid-request failure silently deletes stock and records nothing, which is the
+ * one outcome that makes the future "you saved N items" screen lie. Losing the
+ * delete instead leaves the item visible and the user simply resolves it again.
+ *
+ * The event captures item_name, quantity, unit and days_until_expiry at the
+ * moment of resolution, because the pantry_items row is about to disappear and
+ * the event has to stay meaningful without it (#140).
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const result = await requireAuth()
+  if (result instanceof NextResponse) return result
+  const [supabase, user] = result
+  const { id } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return errorResponse('Request body must be JSON', 400)
+  }
+
+  const outcome = (body as { outcome?: unknown } | null)?.outcome
+  if (!isOutcome(outcome)) {
+    return errorResponse(
+      `outcome must be one of: ${OUTCOMES.join(', ')}`,
+      400
+    )
+  }
+
+  // Read the item first — both to confirm ownership and to snapshot the fields
+  // the event needs before the row goes away.
+  const { data: item, error: fetchError } = await supabase
+    .from('pantry_items')
+    .select('*')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .single()
+
+  if (fetchError || !item) return notFound('Pantry item')
+
+  const row = item as PantryItemRow
+
+  const { error: eventError } = await supabase.from('pantry_events').insert({
+    user_id: user.id,
+    pantry_item_id: row.id,
+    item_name: row.name,
+    outcome,
+    quantity: row.quantity,
+    unit: row.unit,
+    days_until_expiry: daysUntilExpiry(row.expiry_date),
+  })
+
+  // Abort rather than delete: an unrecorded deletion is worse than no-op.
+  if (eventError) return errorResponse(eventError.message)
+
+  const { error: deleteError } = await supabase
+    .from('pantry_items')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+
+  if (deleteError) return errorResponse(deleteError.message)
+
+  return NextResponse.json({
+    id: row.id,
+    name: row.name,
+    outcome,
+    resolved: true,
+  })
+}

--- a/nextjs/src/app/pantry/page.tsx
+++ b/nextjs/src/app/pantry/page.tsx
@@ -3,8 +3,8 @@
 import { useState, useEffect, Suspense } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
-import { motion } from 'framer-motion'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { motion, useReducedMotion } from 'framer-motion'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import SpringButton from '@/components/ui/SpringButton'
 import FadeInView from '@/components/ui/FadeInView'
 import BubblesHeader from '@/components/layout/BubblesHeader'
@@ -12,21 +12,15 @@ import BubblesMascot from '@/components/ui/BubblesMascot'
 import AddItemModal from '@/components/pantry/AddItemModal'
 import ThemePicker from '@/components/ui/ThemePicker'
 import PantryAddSheet, { type PantryAddTab } from '@/components/pantry/PantryAddSheet'
+import ResolveActions from '@/components/pantry/ResolveActions'
+import SwipeToResolve from '@/components/pantry/SwipeToResolve'
+import { resolvePantryItem, type ResolveOutcome } from '@/lib/api/pantry'
+import type { PantryItem } from '@/types/pantry'
 import { getFoodEmoji } from '@/lib/food-emoji'
 import { titleCase } from '@/lib/format'
 import { cookThisHref } from '@/lib/chat-seed'
 import { daysUntilExpiry } from '@/lib/pantry-helpers'
 import Chip from '@/components/ui/Chip'
-
-interface PantryItem {
-  id: string
-  name: string
-  category: string
-  location: string
-  quantity: number
-  unit: string
-  expiry_date: string | null
-}
 
 // Category card tints — dedicated --color-cat-* tokens (globals.css). These must
 // never reference expiry/status tokens (fresh/expiring/expired): status signals
@@ -113,6 +107,9 @@ function PantryPageInner() {
   const queryClient = useQueryClient()
   const searchParams = useSearchParams()
   const router = useRouter()
+  // A gesture whose only feedback is movement isn't usable without motion, so
+  // reduced-motion users get the button affordance on every card (#140).
+  const prefersReduced = useReducedMotion()
 
   const { data, isLoading } = useQuery({
     queryKey: ['pantry', {}],
@@ -182,6 +179,21 @@ function PantryPageInner() {
   const handleItemsAdded = () => {
     queryClient.invalidateQueries({ queryKey: ['pantry'] })
   }
+
+  // Resolving deletes the pantry row and writes an append-only event, so the
+  // list is refetched rather than patched: the server is the authority on what
+  // is left, and an optimistic removal would have to be un-removed on failure.
+  const resolveMutation = useMutation({
+    mutationFn: ({ id, outcome }: { id: string; outcome: ResolveOutcome }) =>
+      resolvePantryItem(id, outcome),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['pantry'] })
+    },
+  })
+
+  const resolvingId = resolveMutation.isPending
+    ? resolveMutation.variables?.id
+    : undefined
 
   return (
     <div className="min-h-screen pb-24">
@@ -258,7 +270,12 @@ function PantryPageInner() {
                   {grouped[cat].map((item, i) => {
                     const days = daysUntilExpiry(item.expiry_date)
                     const badge = expiryBadge(days)
-                    return (
+                    // Expired or expiring gets the visible buttons; everything
+                    // else resolves by swipe, so normal cards stay clean (#140).
+                    const urgent = isUrgent(days) || (days !== null && days < 0)
+                    const showButtons = urgent || prefersReduced
+                    const pending = resolvingId === item.id
+                    const card = (
                       // Wrapper is a div, not a button: an urgent item nests a
                       // "Cook this" link, and a link inside a button is invalid.
                       <motion.div
@@ -309,7 +326,32 @@ function PantryPageInner() {
                             🍳 Cook this
                           </Link>
                         )}
+
+                        {showButtons && (
+                          <ResolveActions
+                            itemName={item.name}
+                            pending={pending}
+                            onResolve={(outcome) =>
+                              resolveMutation.mutate({ id: item.id, outcome })
+                            }
+                          />
+                        )}
                       </motion.div>
+                    )
+
+                    if (showButtons) return card
+
+                    return (
+                      <SwipeToResolve
+                        key={item.id}
+                        itemName={item.name}
+                        pending={pending}
+                        onResolve={(outcome) =>
+                          resolveMutation.mutate({ id: item.id, outcome })
+                        }
+                      >
+                        {card}
+                      </SwipeToResolve>
                     )
                   })}
                 </div>

--- a/nextjs/src/app/pantry/use-soon/page.tsx
+++ b/nextjs/src/app/pantry/use-soon/page.tsx
@@ -1,0 +1,191 @@
+'use client'
+
+import Link from 'next/link'
+import { motion, useReducedMotion } from 'framer-motion'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import BubblesHeader from '@/components/layout/BubblesHeader'
+import FadeInView from '@/components/ui/FadeInView'
+import EmptyState from '@/components/ui/EmptyState'
+import ThemePicker from '@/components/ui/ThemePicker'
+import ResolveActions from '@/components/pantry/ResolveActions'
+import { getFoodEmoji } from '@/lib/food-emoji'
+import { titleCase } from '@/lib/format'
+import { cookThisHref } from '@/lib/chat-seed'
+import { daysUntilExpiry } from '@/lib/pantry-helpers'
+import { resolvePantryItem, type ResolveOutcome } from '@/lib/api/pantry'
+import type { PantryItem } from '@/types/pantry'
+
+/**
+ * Everything that needs attention, most urgent first (#139).
+ *
+ * Deliberately built on the `['pantry']` query rather than `/api/pantry/expiring`.
+ * That endpoint excludes already-expired stock on purpose (#239) — it existed to
+ * answer "what should I cook soon", and expired food was noise there. This view
+ * is the opposite case: expired items are exactly what needs clearing, and now
+ * that #140 gives them a remedy they belong at the top of the list. Filtering
+ * here keeps that endpoint's contract intact for its other callers and reuses a
+ * cache the pantry page has usually already warmed.
+ */
+
+/** Expired first (most negative), then soonest to expire. */
+export function urgencySort(a: PantryItem, b: PantryItem): number {
+  const da = daysUntilExpiry(a.expiry_date)
+  const db = daysUntilExpiry(b.expiry_date)
+  if (da === null) return 1
+  if (db === null) return -1
+  return da - db
+}
+
+export function needsAttention(item: PantryItem): boolean {
+  const days = daysUntilExpiry(item.expiry_date)
+  return days !== null && days <= 3
+}
+
+export function urgencyTier(days: number | null) {
+  if (days === null) return null
+  if (days < 0) {
+    const ago = Math.abs(days)
+    return {
+      label: ago === 1 ? 'Expired yesterday' : `Expired ${ago}d ago`,
+      color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]',
+    }
+  }
+  if (days === 0)
+    return {
+      label: 'Today',
+      color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]',
+    }
+  if (days === 1)
+    return {
+      label: 'Tomorrow',
+      color: 'bg-[var(--color-expired)] text-[var(--color-expired-text)]',
+    }
+  return {
+    label: `${days} days left`,
+    color: 'bg-[var(--color-expiring)] text-[var(--color-expiring-text)]',
+  }
+}
+
+export default function UseSoonPage() {
+  const queryClient = useQueryClient()
+  const prefersReduced = useReducedMotion()
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['pantry', {}],
+    queryFn: () => fetch('/api/pantry').then((r) => r.json()),
+  })
+
+  const items: PantryItem[] = (data?.items ?? []).filter(needsAttention).sort(urgencySort)
+
+  const resolveMutation = useMutation({
+    mutationFn: ({ id, outcome }: { id: string; outcome: ResolveOutcome }) =>
+      resolvePantryItem(id, outcome),
+    onSuccess: () => {
+      // The row disappears from this list because the server no longer returns
+      // it — the list is derived from the refetch, never patched locally.
+      queryClient.invalidateQueries({ queryKey: ['pantry'] })
+    },
+  })
+
+  const resolvingId = resolveMutation.isPending ? resolveMutation.variables?.id : undefined
+
+  return (
+    <div className="min-h-screen pb-24">
+      <BubblesHeader
+        rightSlot={
+          <div className="flex items-center gap-2">
+            {items.length > 0 && (
+              <span className="bg-[var(--color-primary)] text-white text-xs font-semibold px-3 py-1 rounded-full">
+                {items.length} to clear
+              </span>
+            )}
+            <ThemePicker />
+          </div>
+        }
+      />
+
+      <div className="px-6 pt-2 pb-4">
+        <h1 className="text-xl font-bold text-[var(--color-text)]">Use Soon</h1>
+        <p className="text-sm text-[var(--color-muted)]">
+          Most urgent first — cook it, or tell me what happened to it.
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="px-6 space-y-2" aria-busy>
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="h-20 rounded-2xl bg-[var(--color-surface)] border border-[var(--color-border)] animate-pulse"
+            />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <EmptyState
+          className="mx-6"
+          mascotState="happy"
+          headerLabel="All clear"
+          headline="Nothing's about to expire — nice! ✨"
+          subline="Everything in your pantry has time left. Check back in a few days."
+        />
+      ) : (
+        <div className="px-6 space-y-2">
+          {items.map((item, i) => {
+            const days = daysUntilExpiry(item.expiry_date)
+            const tier = urgencyTier(days)
+            const pending = resolvingId === item.id
+
+            return (
+              <FadeInView key={item.id}>
+                <motion.div
+                  className="rounded-2xl bg-[var(--color-surface)] border border-[var(--color-border)] overflow-hidden"
+                  initial={prefersReduced ? undefined : { opacity: 0, y: 8 }}
+                  animate={prefersReduced ? undefined : { opacity: 1, y: 0 }}
+                  transition={{ delay: i * 0.04, duration: 0.25 }}
+                >
+                  <div className="p-3 flex items-center gap-3">
+                    <span className="text-2xl" aria-hidden>
+                      {getFoodEmoji(item.name, item.category)}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-semibold text-sm text-[var(--color-text)] truncate">
+                        {titleCase(item.name)}
+                      </p>
+                      <p className="text-xs text-[var(--color-muted)]">
+                        {item.quantity} {item.unit}
+                      </p>
+                    </div>
+                    {tier && (
+                      <span
+                        className={`text-xs font-semibold px-2 py-0.5 rounded-full whitespace-nowrap ${tier.color}`}
+                      >
+                        {tier.label}
+                      </span>
+                    )}
+                  </div>
+
+                  <Link
+                    href={cookThisHref(item.name, item.expiry_date)}
+                    aria-label={`Find a recipe using ${item.name}`}
+                    className="border-t border-[var(--color-border)] px-3 min-h-[44px] flex items-center justify-center text-xs font-semibold text-[var(--color-primary-dark)] hover:bg-[var(--color-border)] transition-colors focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+                  >
+                    🍳 Find a recipe
+                  </Link>
+
+                  {/* Always the button affordance here, never the swipe: every
+                      row on this page is urgent by construction, which is the
+                      case #140 says earns a visible control. */}
+                  <ResolveActions
+                    itemName={item.name}
+                    pending={pending}
+                    onResolve={(outcome) => resolveMutation.mutate({ id: item.id, outcome })}
+                  />
+                </motion.div>
+              </FadeInView>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/nextjs/src/components/dashboard/BubblesFeed.tsx
+++ b/nextjs/src/components/dashboard/BubblesFeed.tsx
@@ -199,6 +199,12 @@ export default function BubblesFeed({ displayName }: BubblesFeedProps) {
         <BubbleMessage
           delay={delays[hasUrgent ? 2 : 1]}
           bubbleState="happy"
+          // The count was a dead end until #139 gave it somewhere to go.
+          actions={
+            expiringWeekCount > 0
+              ? [{ label: 'Use them soon ⏰', href: '/pantry/use-soon' }]
+              : undefined
+          }
         >
           You have{' '}
           <strong className="font-semibold">{totalCount} items</strong> in your pantry and{' '}

--- a/nextjs/src/components/pantry/ResolveActions.tsx
+++ b/nextjs/src/components/pantry/ResolveActions.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import { useState } from 'react'
+import { motion } from 'framer-motion'
+import { springs } from '@/lib/motion'
+import type { ResolveOutcome } from '@/lib/api/pantry'
+
+export interface ResolveActionsProps {
+  /** Item being resolved — used for accessible labels only. */
+  itemName: string
+  /** Fires with the chosen outcome. The parent owns the mutation. */
+  onResolve: (outcome: ResolveOutcome) => void
+  /** True while the parent's mutation is in flight. */
+  pending?: boolean
+}
+
+/**
+ * Visible "Used it up" / "Tossed it" buttons for expired and expiring-soon
+ * cards (#140).
+ *
+ * Urgency buys the card real estate: these items are the whole point of the
+ * expiry feature, so their resolve action is a present affordance rather than
+ * something the user has to discover by dragging. Everything else in the pantry
+ * gets `SwipeToResolve` instead, which keeps normal cards visually clean.
+ *
+ * "Tossed it" is destructive and irreversible (the pantry row is deleted and an
+ * append-only event is written), so it swaps to an inline confirm rather than
+ * firing on first tap. "Used it up" is the happy path and commits directly —
+ * the item is gone either way, and only the recorded outcome differs.
+ */
+export default function ResolveActions({
+  itemName,
+  onResolve,
+  pending = false,
+}: ResolveActionsProps) {
+  const [confirmingToss, setConfirmingToss] = useState(false)
+
+  if (confirmingToss) {
+    return (
+      <div className="border-t border-[var(--color-border)] flex">
+        <button
+          type="button"
+          disabled={pending}
+          onClick={() => onResolve('tossed')}
+          aria-label={`Confirm ${itemName} was tossed`}
+          className="flex-1 min-h-[44px] text-xs font-semibold text-[var(--color-expired-text)] bg-[var(--color-expired)] hover:brightness-95 disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+        >
+          {pending ? 'Tossing…' : 'Really toss?'}
+        </button>
+        <button
+          type="button"
+          disabled={pending}
+          onClick={() => setConfirmingToss(false)}
+          aria-label="Cancel"
+          className="px-3 min-h-[44px] text-xs font-semibold text-[var(--color-muted)] border-l border-[var(--color-border)] hover:bg-[var(--color-border)] disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+        >
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="border-t border-[var(--color-border)] flex">
+      {/* Both targets are a full 44px tall (WCAG 2.5.5) while the labels stay
+          text-xs, so the two-column card grid doesn't reflow. */}
+      <motion.button
+        type="button"
+        disabled={pending}
+        whileTap={pending ? undefined : { scale: 0.97 }}
+        transition={springs.snappy}
+        onClick={() => onResolve('used')}
+        aria-label={`Mark ${itemName} as used up`}
+        className="flex-1 min-h-[44px] text-xs font-semibold text-[var(--color-fresh-text)] bg-[var(--color-fresh)] hover:brightness-95 disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+      >
+        {pending ? 'Saving…' : '✓ Used it'}
+      </motion.button>
+      <motion.button
+        type="button"
+        disabled={pending}
+        whileTap={pending ? undefined : { scale: 0.97 }}
+        transition={springs.snappy}
+        onClick={() => setConfirmingToss(true)}
+        aria-label={`Mark ${itemName} as tossed`}
+        className="flex-1 min-h-[44px] text-xs font-semibold text-[var(--color-muted)] border-l border-[var(--color-border)] hover:bg-[var(--color-border)] disabled:opacity-60 focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]"
+      >
+        🗑 Tossed
+      </motion.button>
+    </div>
+  )
+}

--- a/nextjs/src/components/pantry/SwipeToResolve.tsx
+++ b/nextjs/src/components/pantry/SwipeToResolve.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import { motion, useReducedMotion, type PanInfo } from 'framer-motion'
+import { springs } from '@/lib/motion'
+import type { ResolveOutcome } from '@/lib/api/pantry'
+
+/** Drag distance (px) at which the action icon is fully revealed. */
+export const REVEAL_DISTANCE = 64
+/** Drag distance (px) past which releasing commits the action outright. */
+export const COMMIT_DISTANCE = 132
+
+/**
+ * A swipe can only ever mean "used" or "tossed". `ResolveOutcome` also allows
+ * "cooked", which is recorded by the cook flow rather than by a gesture, so the
+ * gesture is typed to the narrower set — otherwise the reveal state has to
+ * pretend it can hold a value this component can never produce.
+ */
+export type SwipeOutcome = Extract<ResolveOutcome, 'used' | 'tossed'>
+
+export type GestureVerdict =
+  | { kind: 'commit'; outcome: SwipeOutcome }
+  | { kind: 'reveal'; outcome: SwipeOutcome }
+  | { kind: 'reset' }
+
+/**
+ * What a released drag of `dx` pixels means. Pure, and exported, because this
+ * is the safety mechanism: the spec dropped the confirm dialog on the grounds
+ * that a light swipe cannot commit, so "how far is far enough" is the rule that
+ * has to be right. framer-motion's drag does not run under jsdom, so testing it
+ * through the component would assert nothing.
+ *
+ * Right is "used up", left is "tossed".
+ */
+export function gestureVerdict(dx: number): GestureVerdict {
+  const outcome: SwipeOutcome = dx > 0 ? 'used' : 'tossed'
+  if (Math.abs(dx) >= COMMIT_DISTANCE) return { kind: 'commit', outcome }
+  if (Math.abs(dx) >= REVEAL_DISTANCE) return { kind: 'reveal', outcome }
+  return { kind: 'reset' }
+}
+
+export interface SwipeToResolveProps {
+  itemName: string
+  onResolve: (outcome: ResolveOutcome) => void
+  pending?: boolean
+  children: React.ReactNode
+}
+
+type Revealed = SwipeOutcome | null
+
+/**
+ * Graduated swipe-to-resolve for ordinary pantry cards (#140).
+ *
+ * Swipe right = "Used it up", swipe left = "Tossed it" — one continuous drag,
+ * not two discrete gestures:
+ *
+ * 1. A short drag reveals the action icon and stops there. Releasing at this
+ *    stage does nothing and the card springs back.
+ * 2. From the revealed state, tapping the icon commits.
+ * 3. Continuing the same drag past COMMIT_DISTANCE commits on release.
+ *
+ * The graduation *is* the safety mechanism, which is why there's no confirm
+ * dialog or undo toast on top of it: a light swipe cannot commit, and only a
+ * deliberate tap or a decisive drag does. Layering a confirm on top would make
+ * the fast path slower than the buttons it exists to avoid.
+ *
+ * Expiring and expired cards use `ResolveActions` instead — urgency earns a
+ * visible affordance, and this component is what keeps every *other* card clean.
+ *
+ * Reduced motion: the drag is disabled entirely rather than merely shortened,
+ * and the parent is expected to fall back to `ResolveActions`. A gesture whose
+ * whole feedback channel is movement is not usable without it.
+ */
+export default function SwipeToResolve({
+  itemName,
+  onResolve,
+  pending = false,
+  children,
+}: SwipeToResolveProps) {
+  const [revealed, setRevealed] = useState<Revealed>(null)
+  const prefersReduced = useReducedMotion()
+
+  function handleDragEnd(_e: unknown, info: PanInfo) {
+    const verdict = gestureVerdict(info.offset.x)
+
+    if (verdict.kind === 'commit') {
+      // Past the threshold: the drag itself is the confirmation.
+      onResolve(verdict.outcome)
+      setRevealed(null)
+      return
+    }
+
+    if (verdict.kind === 'reveal') {
+      // Hold the icon open, awaiting a tap.
+      setRevealed(verdict.outcome)
+      return
+    }
+
+    // A stray touch — reset with no side effect.
+    setRevealed(null)
+  }
+
+  const dragEnabled = !pending && !prefersReduced
+
+  return (
+    <div className="relative overflow-hidden rounded-2xl">
+      {/* Action layer, revealed as the card slides off it. aria-hidden because
+          the buttons below are the accessible path; a screen-reader user should
+          never be asked to perform a drag. */}
+      <div className="absolute inset-0 flex items-stretch" aria-hidden>
+        <div className="flex-1 flex items-center justify-start px-4 bg-[var(--color-fresh)] text-[var(--color-fresh-text)] text-xs font-semibold">
+          ✓ Used it
+        </div>
+        <div className="flex-1 flex items-center justify-end px-4 bg-[var(--color-expired)] text-[var(--color-expired-text)] text-xs font-semibold">
+          🗑 Tossed
+        </div>
+      </div>
+
+      <motion.div
+        drag={dragEnabled ? 'x' : false}
+        dragDirectionLock
+        dragConstraints={{ left: 0, right: 0 }}
+        dragElastic={0.7}
+        onDragEnd={handleDragEnd}
+        animate={{
+          x:
+            revealed === 'used'
+              ? REVEAL_DISTANCE
+              : revealed === 'tossed'
+                ? -REVEAL_DISTANCE
+                : 0,
+        }}
+        transition={springs.snappy}
+        className="relative bg-[var(--color-surface)] touch-pan-y"
+      >
+        {children}
+      </motion.div>
+
+      {/* The commit control for stage 2. Rendered only while revealed, and
+          always as a real button so the action is reachable by keyboard and
+          assistive tech even though the reveal itself is a gesture. */}
+      {revealed && (
+        <motion.button
+          type="button"
+          autoFocus
+          disabled={pending}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={springs.snappy}
+          onClick={() => {
+            onResolve(revealed)
+            setRevealed(null)
+          }}
+          onBlur={() => setRevealed(null)}
+          aria-label={
+            revealed === 'used'
+              ? `Confirm ${itemName} was used up`
+              : `Confirm ${itemName} was tossed`
+          }
+          className={[
+            'absolute inset-y-0 w-16 flex items-center justify-center text-lg',
+            'focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-[var(--color-primary-dark)]',
+            revealed === 'used'
+              ? 'left-0 text-[var(--color-fresh-text)]'
+              : 'right-0 text-[var(--color-expired-text)]',
+          ].join(' ')}
+        >
+          {revealed === 'used' ? '✓' : '🗑'}
+        </motion.button>
+      )}
+    </div>
+  )
+}

--- a/nextjs/src/lib/api/pantry.ts
+++ b/nextjs/src/lib/api/pantry.ts
@@ -1,0 +1,40 @@
+/**
+ * Pantry API client.
+ *
+ * CRUD goes through the Next.js routes (same-origin), never the AI service —
+ * see the "two API surfaces" rule in CLAUDE.md.
+ */
+
+/** Must match the CHECK constraint on pantry_events and the resolve route. */
+export type ResolveOutcome = 'used' | 'tossed' | 'cooked'
+
+export interface ResolveResult {
+  id: string
+  name: string
+  outcome: ResolveOutcome
+  resolved: boolean
+}
+
+/**
+ * Record what happened to a pantry item and remove it from the pantry.
+ *
+ * The server writes the event before deleting the row, so a failure here means
+ * the item is still there — the caller can simply let the user try again.
+ */
+export async function resolvePantryItem(
+  itemId: string,
+  outcome: ResolveOutcome
+): Promise<ResolveResult> {
+  const res = await fetch(`/api/pantry/${itemId}/resolve`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ outcome }),
+  })
+
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null)
+    throw new Error(detail?.error ?? `Could not resolve item (${res.status})`)
+  }
+
+  return res.json()
+}

--- a/nextjs/src/types/pantry.ts
+++ b/nextjs/src/types/pantry.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared pantry types.
+ *
+ * `PantryItem` is the shape the `/api/pantry` list route returns to the client.
+ * It lived as a private interface inside `app/pantry/page.tsx` until the Use
+ * Soon view (#139) needed the same shape; two copies of a row type that the API
+ * defines is how they drift apart.
+ *
+ * This is deliberately narrower than `EnrichedPantryItem` in `lib/pantry-helpers`:
+ * that one is the server-side row plus computed fields, while pages compute
+ * expiry from `expiry_date` themselves via `daysUntilExpiry` so the badge can
+ * never disagree with the server flags (#244).
+ */
+export interface PantryItem {
+  id: string
+  name: string
+  category: string
+  location: string
+  quantity: number
+  unit: string
+  expiry_date: string | null
+}

--- a/supabase/migrations/00007_add_pantry_events.sql
+++ b/supabase/migrations/00007_add_pantry_events.sql
@@ -1,0 +1,45 @@
+-- Migration: Add pantry_events table
+-- Records what actually happened to a pantry item when the user resolved it
+-- (used it up, tossed it, or cooked it) so the app can eventually report
+-- "you saved N items this week" instead of just watching items expire silently.
+--
+-- pantry_item_id is nullable on purpose and carries NO foreign key: resolving an
+-- item deletes its pantry_items row, so by the time anyone reads this table the
+-- target may already be gone. item_name is denormalised alongside it so the
+-- event stays meaningful on its own after the pantry_items row disappears.
+--
+-- Append-only: no updated_at column, and no UPDATE or DELETE policy below --
+-- rows are written once and never changed. A miscount is better than a
+-- rewritable history when the whole point is to measure what happened.
+
+CREATE TABLE pantry_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  pantry_item_id UUID,
+  item_name TEXT NOT NULL,
+  outcome TEXT NOT NULL CHECK (outcome IN ('used', 'tossed', 'cooked')),
+  quantity NUMERIC,
+  unit TEXT,
+  days_until_expiry INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Serves "this user's events, most recent first"; the future weekly-stats
+-- screen filters this same table on created_at.
+CREATE INDEX idx_pantry_events_user_created ON pantry_events(user_id, created_at DESC);
+
+-- ============================================================================
+-- RLS
+-- ============================================================================
+ALTER TABLE pantry_events ENABLE ROW LEVEL SECURITY;
+
+-- Deliberately not FOR ALL, unlike the other tables in 00002. The table is
+-- append-only, so granting UPDATE and DELETE would hand away the one property
+-- it exists to guarantee.
+CREATE POLICY "Users read own pantry events"
+  ON pantry_events FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users insert own pantry events"
+  ON pantry_events FOR INSERT
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

The pantry could tell you something was about to go bad but never learn what happened to it. Items lingered forever, inflating counts and eroding trust in the feature, and there was no data to ever build the "you saved N items this week" payoff on.

Closes #140
Closes #139

## #140 — resolve actions

**`pantry_events` is append-only by construction.** No `updated_at`, and RLS grants `SELECT` and `INSERT` only rather than the `FOR ALL` every other table in `00002` uses. Granting UPDATE/DELETE would hand away the one property a record of what happened actually needs.

`pantry_item_id` is nullable and carries **no foreign key** — resolving deletes the `pantry_items` row, so the target is already gone by the time anyone reads the event. `item_name` is denormalised alongside it so the row still means something afterwards.

**Write order is the safety property.** The route writes the event *before* deleting the item, and aborts if that write fails. There's no transaction across the two statements, so writing the event second would let a mid-request failure delete stock and record nothing — the one outcome that makes the future stats screen lie. Losing the delete instead just leaves the item visible and the user resolves it again.

Two surfaces, per this issue's 2026-08-12 spec:

- **Expired and expiring cards** → visible buttons. Urgency earns the card real estate.
- **Everything else** → graduated swipe. A short drag reveals and stops; a tap on the revealed icon commits; continuing past the commit threshold commits on release.

The graduation **is** the safety mechanism, which is why there's no confirm dialog or undo toast layered on top — that's what the spec replaced. "Tossed it" *does* still swap to an inline confirm on the button surface, where there's no drag distance to make the intent deliberate.

Reduced-motion users get the buttons on every card. A gesture whose only feedback channel is movement isn't usable without it.

### One thing worth calling out

The threshold decision is a pure exported function (`gestureVerdict`) rather than logic inside the drag handler. framer-motion's drag doesn't run under jsdom, so testing it through the component asserts nothing — **the first version of these tests passed trivially** and covered none of the graduation. The rewrite tests the thresholds directly, including that reveal stays strictly below commit, and that right→used / left→tossed is never reversed (getting that backwards would silently bin food the user meant to keep).

`tsc` also caught a real type bug the tests didn't: `gestureVerdict` returned `ResolveOutcome`, which includes `'cooked'` — an outcome a swipe can never produce. Narrowed to a `SwipeOutcome` subtype.

## #139 — Use Soon

Built on the `['pantry']` query rather than `/api/pantry/expiring`. That endpoint excludes already-expired stock **on purpose** (#239) because it answers "what should I cook soon", where expired food was noise. This view is the opposite case: expired items are exactly what needs clearing, and now that #140 gives them a remedy they belong at the top. Filtering here leaves that endpoint's contract intact for its other callers.

Rows sort strictly by days remaining — most overdue first — and each offers "Find a recipe" (into the existing seeded cook flow) alongside the resolve buttons. The dashboard's "N expiring this week" line was a dead end and now links here.

`PantryItem` moves to `types/pantry.ts`; it was a private interface in `pantry/page.tsx`, and a second copy is how row types drift apart.

## Migration

`00007_add_pantry_events.sql` — **needs applying before deploy.** The schema is carried over from the closed PR #150, whose design was sound; the number is bumped and RLS narrowed to append-only.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint src/` — clean (0 errors)
- `npm test` — **179 passed** (28 new)

Not covered: the drag gesture end-to-end, which needs a real browser. The threshold logic it delegates to is fully covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfLKvfYudmMLSoC1bqpFrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfLKvfYudmMLSoC1bqpFrZ)_